### PR TITLE
For some reason the querybuilder messes up with aliases on update on sqlite

### DIFF
--- a/lib/Db/CircleProviderRequestBuilder.php
+++ b/lib/Db/CircleProviderRequestBuilder.php
@@ -356,7 +356,7 @@ class CircleProviderRequestBuilder {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$expr = $qb->expr();
 
-		$qb->update('share', 's')
+		$qb->update('share')
 		   ->where($expr->eq('share_type', $qb->createNamedParameter(Share::SHARE_TYPE_CIRCLE)));
 
 		return $qb;


### PR DESCRIPTION
As far as I could tell it was also never used.