### PR TITLE
When a node is provided we should use it

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -406,6 +406,10 @@ class ShareByCircleProvider extends CircleProviderRequestBuilder implements ISha
 		$this->linkToFileCache($qb, $userId);
 		$this->limitToPage($qb, $limit, $offset);
 
+		if ($node !== null) {
+			$this->limitToFiles($qb, [$node->getId()]);
+		}
+
 		$cursor = $qb->execute();
 
 		$shares = [];


### PR DESCRIPTION
This lead to the error that if there was an incomming circle share any
other share would have been shared by that user.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>