### PR TITLE
Enable audit by configuration #163

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -32,5 +32,5 @@ $app->registerSettingsAdmin();
 $app->registerNavigation();
 $app->registerFilesNavigation();
 $app->registerFilesPlugin();
-
+$app->registerHooks();
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -44,6 +44,7 @@ $(document).ready(function () {
 	elements.test_async_result = $('#test_async_result');
 	elements.allow_linked_groups = $('#allow_linked_groups');
 	elements.allow_federated_circles = $('#allow_federated_circles');
+	elements.enable_audit = $('#enable_audit');	
 
 	elements.test_async_wait.hide().on('click', function () {
 		self.refreshResult();
@@ -74,6 +75,10 @@ $(document).ready(function () {
 	elements.allow_federated_circles.on('change', function () {
 		saveChange();
 	});
+	
+	elements.enable_audit.on('change', function () {
+	    saveChange();
+	});
 
 	saveChange = function () {
 		$.ajax({
@@ -83,11 +88,14 @@ $(document).ready(function () {
 				allow_linked_groups: (elements.allow_linked_groups.is(
 					':checked')) ? '1' : '0',
 				allow_federated_circles: (elements.allow_federated_circles.is(
-					':checked')) ? '1' : '0'
+					':checked')) ? '1' : '0',
+			    enable_audit: (elements.enable_audit.is(
+		            ':checked')) ? '1' : '0'
 			}
 		}).done(function (res) {
 			elements.allow_linked_groups.prop('checked', (res.allowLinkedGroups === '1'));
 			elements.allow_federated_circles.prop('checked', (res.allowFederatedCircles === '1'));
+			elements.enable_audit.prop('checked', (res.enableAudit === '1'));
 		});
 	};
 
@@ -170,6 +178,7 @@ $(document).ready(function () {
 	}).done(function (res) {
 		elements.allow_linked_groups.prop('checked', (res.allowLinkedGroups === '1'));
 		elements.allow_federated_circles.prop('checked', (res.allowFederatedCircles === '1'));
+		elements.enable_audit.prop('checked', (res.enableAudit === '1'));		
 	});
 
 	var timerTestAsync = setInterval(function () {

--- a/js/circles.app.actions.js
+++ b/js/circles.app.actions.js
@@ -128,7 +128,8 @@ var actions = {
 			circle_desc: elements.settingsDesc.val(),
 			allow_links: (elements.settingsLink.is(":checked")),
 			allow_links_auto: (elements.settingsLinkAuto.is(":checked")),
-			allow_links_files: (elements.settingsLinkFiles.is(":checked"))
+			allow_links_files: (elements.settingsLinkFiles.is(":checked")),
+			enable_audit: (elements.settingsEnableAudit.is(":checked"))
 		};
 
 		api.settingsCircle(curr.circle, data, settings.saveSettingsResult);

--- a/js/circles.app.elements.js
+++ b/js/circles.app.elements.js
@@ -75,6 +75,7 @@ var elements = {
 	settingsEntryLink: null,
 	settingsEntryLinkAuto: null,
 	settingsEntryLinkFiles: null,
+	settingsEnableAudit: null,
 	settingsSave: null,
 
 	addMember: null,
@@ -131,6 +132,7 @@ var elements = {
 		elements.settingsEntryLink = $('#settings-entry-link');
 		elements.settingsEntryLinkAuto = $('#settings-entry-link-auto');
 		elements.settingsEntryLinkFiles = $('#settings-entry-link-files');
+        elements.settingsEnableAudit = $('#settings-enable-audit');		
 		elements.settingsSave = $('#settings-submit');
 
 		elements.addMember = $('#addmember');

--- a/js/circles.app.js
+++ b/js/circles.app.js
@@ -60,6 +60,7 @@ var curr = {
 	allowed_linked_groups: 0,
 	allowed_federated_circles: 0,
 	allowed_circles: 0,
+	enabled_audit: 0,
 
 	defineCircle: function (data) {
 		curr.circle = data.circle_id;
@@ -192,6 +193,7 @@ $(document).ready(function () {
 			curr.allowed_circles = result.allowed_circles;
 			curr.allowed_linked_groups = result.allowed_linked_groups;
 			curr.allowed_federated_circles = result.allowed_federated_circles;
+			curr.enabled_audit = result.enabled_audit;
 
 			var circleId = window.location.hash.substr(1);
 			if (circleId) {

--- a/js/circles.app.settings.js
+++ b/js/circles.app.settings.js
@@ -54,6 +54,8 @@ var settings = {
 			(curr.circleSettings['allow_links_auto'] === 'true'));
 		elements.settingsLinkFiles.prop('checked',
 			(curr.circleSettings['allow_links_files'] === 'true'));
+		elements.settingsEnableAudit.prop('checked',
+		    (curr.circleSettings['enable_audit'] === 'true'));
 
 		elements.settingsLink.on('change', function () {
 			settings.interactUISettings();
@@ -79,6 +81,9 @@ var settings = {
 			(elements.settingsLink.is(":checked")));
 		settings.enableSetting(elements.settingsEntryLinkFiles, elements.settingsLinkFiles,
 			(elements.settingsLink.is(":checked")));
+		settings.enableSetting(elements.settingsEntryEnableAudit, elements.settingsEnableAudit,
+		    (elements.settingsEnableAudit.is(":checked")));
+		
 	},
 
 	enableSetting: function (entry, input, enable) {
@@ -101,6 +106,3 @@ var settings = {
 		OCA.notification.onSuccess(t('circles', "Settings saved."));
 	}
 };
-
-
-

--- a/l10n/pt_BR.js
+++ b/l10n/pt_BR.js
@@ -275,6 +275,8 @@ OC.L10N.register(
     "Allow linking of groups:" : "Permitir links dos  grupos:",
     "Groups can be linked to circles." : "Grupos podem ser linkados a círculos.",
     "Allow federated circles:" : "Permitir círculos federados:",
-    "Circles from different Nextclouds can be linked together." : "Círculos de diferentes Nextclouds podem ser linkados juntos."
+    "Circles from different Nextclouds can be linked together." : "Círculos de diferentes Nextclouds podem ser linkados juntos.",
+    "Enable audit:" : "Habilitar auditoria:",
+    "Actions of circles, members and sharing can be audited." : "Ações de círculos, membros e compartilhamentos podem ser auditadas."
 },
 "nplurals=2; plural=(n > 1);");

--- a/l10n/pt_BR.json
+++ b/l10n/pt_BR.json
@@ -273,6 +273,8 @@
     "Allow linking of groups:" : "Permitir links dos  grupos:",
     "Groups can be linked to circles." : "Grupos podem ser linkados a círculos.",
     "Allow federated circles:" : "Permitir círculos federados:",
-    "Circles from different Nextclouds can be linked together." : "Círculos de diferentes Nextclouds podem ser linkados juntos."
+    "Circles from different Nextclouds can be linked together." : "Círculos de diferentes Nextclouds podem ser linkados juntos.",
+    "Enable audit:" : "Habilitar auditoria:",
+    "Actions of circles, members and sharing can be audited." : "Ações de círculos, membros e compartilhamentos podem ser auditadas."
 },"pluralForm" :"nplurals=2; plural=(n > 1);"
 }

--- a/lib/Api/v1/Circles.php
+++ b/lib/Api/v1/Circles.php
@@ -381,8 +381,10 @@ class Circles {
 		$frame = new SharingFrame((string)$source, (string)$type);
 		$frame->setPayload($payload);
 
-		return $c->query(SharingFrameService::class)
+		$result = $c->query(SharingFrameService::class)
 				 ->createFrame($circleUniqueId, $frame, (string)$broadcaster);
+
+		return $result;
 	}
 
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -70,6 +70,36 @@ class Application extends App {
 		Util::connectHook(
 			'OC_User', 'post_deleteGroup', '\OCA\Circles\Hooks\UserHooks', 'onGroupDeleted'
 		);
+		Util::connectHook(
+			'OCA\Circles', 'post_createCircle', '\OCA\Circles\Hooks\UserHooks', 'onCircleCreated'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_destroyCircle', '\OCA\Circles\Hooks\UserHooks', 'onCircleDestroyed'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_updateCircle', '\OCA\Circles\Hooks\UserHooks', 'onCircleUpdated'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_addMember', '\OCA\Circles\Hooks\UserHooks', 'onMemberAdded'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_removeMember', '\OCA\Circles\Hooks\UserHooks', 'onMemberRemoved'
+		);
+		Util::connectHook(
+			'OCP\Share', 'post_share', '\OCA\Circles\Hooks\UserHooks', 'onItemShared'
+		);
+		Util::connectHook(
+			'OCP\Share', 'post_unshare', '\OCA\Circles\Hooks\UserHooks', 'onItemUnshared'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_joinMember', '\OCA\Circles\Hooks\UserHooks', 'onMemberJoined'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_leftMember', '\OCA\Circles\Hooks\UserHooks', 'onMemberLeft'
+		);
+		Util::connectHook(
+			'OCA\Circles', 'post_changeLevelMember', '\OCA\Circles\Hooks\UserHooks', 'onMemberLevelChanged'
+		);
 	}
 
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -46,6 +46,9 @@ class SettingsController extends Controller {
 			),
 			'allowFederatedCircles' => $this->configService->getAppValue(
 				ConfigService::CIRCLES_ALLOW_FEDERATED_CIRCLES
+			),
+			'enableAudit' => $this->configService->getAppValue(
+				ConfigService::CIRCLES_ENABLE_AUDIT
 			)
 		];
 
@@ -53,12 +56,15 @@ class SettingsController extends Controller {
 	}
 
 
-	public function setSettings($allow_linked_groups, $allow_federated_circles) {
+	public function setSettings($allow_linked_groups, $allow_federated_circles, $enable_audit) {
 		$this->configService->setAppValue(
 			ConfigService::CIRCLES_ALLOW_LINKED_GROUPS, $allow_linked_groups
 		);
 		$this->configService->setAppValue(
 			ConfigService::CIRCLES_ALLOW_FEDERATED_CIRCLES, $allow_federated_circles
+		);
+		$this->configService->setAppValue(
+			ConfigService::CIRCLES_ENABLE_AUDIT, $enable_audit
 		);
 
 		return $this->getSettings();

--- a/lib/Events/UserEvents.php
+++ b/lib/Events/UserEvents.php
@@ -8,8 +8,17 @@ use OCA\Circles\Service\CirclesService;
 use OCA\Circles\Service\GroupsService;
 use OCA\Circles\Service\MembersService;
 use OCA\Circles\Service\MiscService;
+use OCP\Util;
+use OC\User\User;
+use OC\Log;
+use OCA\Circles\AppInfo\Application;
+use OCA\Circles\Model\Member;
+use OCA\Circles\Model\Circle;
 
 class UserEvents {
+	
+	/** Default for warning log level **/
+	const logLevel = 2;
 
 	/** @var CirclesService */
 	private $circlesService;
@@ -22,6 +31,9 @@ class UserEvents {
 
 	/** @var MiscService */
 	private $miscService;
+	
+	/** @var User */
+	private static $user = null;
 
 	/**
 	 * UserEvents constructor.
@@ -59,6 +71,142 @@ class UserEvents {
 		$groupId = $params['gid'];
 		$this->groupsService->onGroupRemoved($groupId);
 	}
+	
+	/**
+	 * @param array $params
+	 */
+	public function onCircleCreated(array $params) {
+		$circle = $params['circle'];
+		$user = $this->getUser()->getDisplayName();
+		$this->miscService->log("user $user created circle $circle", self::logLevel);
+	}
 
+	/**
+	 * @param array $params
+	 */
+	public function onCircleDestroyed(array $params) {
+		$circle = $params['circle'];
+		$user = $this->getUser()->getDisplayName();
+		$this->miscService->log("user $user destroyed circle $circle", self::logLevel);
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onCircleUpdated(array $params) {
+		$formerCircle = $params['former_name'];
+		$circle = $params['circle_name'];
+		if ($formerCircle != $circle){
+			$user = $this->getUser()->getDisplayName();
+			$this->miscService->log("user $user updated circle $formerCircle to $circle", self::logLevel);
+		}
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onMemberAdded(array $params) {
+		$circle = $params['circle'];
+		$member = $params['member'];
+		$type = $params['type'];
+		$user = $this->getUser()->getDisplayName();
+		$action = ($type == Circle::CIRCLES_CLOSED ? 'invited' : 'added');
+		$this->miscService->log("user $user $action member $member to circle $circle", self::logLevel);
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onMemberRemoved(array $params) {
+		$circle = $params['circle'];
+		$member = $params['member'];
+		$user = $this->getUser()->getDisplayName();
+		$this->miscService->log("user $user removed member $member from circle $circle", self::logLevel);
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onItemShared(array $params) {
+		$shareWith = $params['shareWith'];
+		$fileTarget = $params['fileTarget'];
+		$user = $this->getUser()->getDisplayName();
+		$this->miscService->log("user $user shared $fileTarget with $shareWith", self::logLevel);
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onItemUnshared(array $params) {
+		$shareWith = $params['shareWith'];
+		$fileTarget = $params['fileTarget'];
+		$user = $this->getUser()->getDisplayName();
+		if (!empty($shareWith)){
+			if (ctype_alnum($shareWith)){
+				try {
+					$shareWith = $this->circlesService->detailsCircle($shareWith)->getName();
+				} catch (\Exception $e) {
+				}
+			}
+			$this->miscService->log("user $user unshared $fileTarget with $shareWith", self::logLevel);
+		}
+	}
+	
+	/**
+	 * @param array $params
+	 */
+	public function onMemberJoined(array $params) {
+		$member = $params['member'];
+		$circle = $params['circle'];
+		$formerStatus = $params['formerStatus'];
+		$type = $params['type'];
+		if ($formerStatus == Member::STATUS_INVITED){
+			$this->miscService->log("member $member accepted invitation to circle $circle", self::logLevel);
+		} else if ($type == Circle::CIRCLES_CLOSED){
+			$this->miscService->log("member $member requested to join circle $circle", self::logLevel);
+		} else {
+			$this->miscService->log("member $member joined circle $circle", self::logLevel);
+		}
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onMemberLeft(array $params) {
+		$member = $params['member'];
+		$circle = $params['circle'];
+		$formerStatus = $params['formerStatus'];
+		$type = $params['type'];
+		if ($formerStatus == Member::STATUS_INVITED){
+			$this->miscService->log("member $member refused invitation to circle $circle", self::logLevel);
+		} else if ($type == Circle::CIRCLES_CLOSED){ 
+			$this->miscService->log("member $member cancelled invitation from circle $circle", self::logLevel);
+		} else {
+			$this->miscService->log("member $member left circle $circle", self::logLevel);
+		}
+	}
+
+	/**
+	 * @param array $params
+	 */
+	public function onMemberLevelChanged(array $params) {
+		$member = $params['member'];
+		$circle = $params['circle'];
+		$level = $params['level'];
+		$levelString = Member::getLevelStringFromCode($level);
+		$user = $this->getUser()->getDisplayName();
+		$this->miscService->log("$user changed level of $member from circle $circle to $levelString", self::logLevel);
+	}
+
+	/**
+	 * @return User
+	 */
+	private function getUser()
+	{
+		if (self::$user == null){
+			$app = new Application();
+			self::$user = $app->getContainer()->query('UserSession')->getUser();
+		}
+		return self::$user;
+	}
 }
-

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -28,5 +28,53 @@ class UserHooks {
 			->onGroupDeleted($params);
 	}
 
-}
+	public static function onCircleCreated($params) {
+		self::getController()
+		->onCircleCreated($params);
+	}
 
+	public static function onCircleDestroyed($params) {
+		self::getController()
+		->onCircleDestroyed($params);
+	}
+
+	public static function onCircleUpdated($params) {
+		self::getController()
+		->onCircleUpdated($params);
+	}
+
+	public static function onMemberAdded($params) {
+		self::getController()
+		->onMemberAdded($params);
+	}
+
+	public static function onMemberRemoved($params) {
+		self::getController()
+		->onMemberRemoved($params);
+	}
+	
+	public static function onItemShared($params) {
+		self::getController()
+		->onItemShared($params);
+	}
+	
+	public static function onItemUnshared($params) {
+		self::getController()
+		->onItemUnshared($params);
+	}
+	
+	public static function onMemberJoined($params) {
+		self::getController()
+		->onMemberJoined($params);
+	}
+
+	public static function onMemberLeft($params) {
+		self::getController()
+		->onMemberLeft($params);
+	}
+
+	public static function onMemberLevelChanged($params) {
+		self::getController()
+		->onMemberLevelChanged($params);
+	}
+}

--- a/lib/Model/BaseMember.php
+++ b/lib/Model/BaseMember.php
@@ -277,20 +277,7 @@ class BaseMember implements \JsonSerializable {
 	}
 
 	public function getLevelString() {
-		switch ($this->getLevel()) {
-			case self::LEVEL_NONE:
-				return 'Not a member';
-			case self::LEVEL_MEMBER:
-				return 'Member';
-			case self::LEVEL_MODERATOR:
-				return 'Moderator';
-			case self::LEVEL_ADMIN:
-				return 'Admin';
-			case self::LEVEL_OWNER:
-				return 'Owner';
-		}
-
-		return 'none';
+		return self::getLevelStringFromCode($this->getLevel());
 	}
 
 
@@ -304,6 +291,27 @@ class BaseMember implements \JsonSerializable {
 				return 'Mail address';
 			case self::TYPE_CONTACT:
 				return 'Contact';
+		}
+
+		return 'none';
+	}
+
+	/** 
+	 * @param integer $code
+	 * @return string
+	 */
+	public static function getLevelStringFromCode($code) {
+		switch ($code) {
+			case self::LEVEL_NONE:
+				return 'Not a member';
+			case self::LEVEL_MEMBER:
+				return 'Member';
+			case self::LEVEL_MODERATOR:
+				return 'Moderator';
+			case self::LEVEL_ADMIN:
+				return 'Admin';
+			case self::LEVEL_OWNER:
+				return 'Owner';
 		}
 
 		return 'none';

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -44,6 +44,8 @@ class ConfigService {
 	const CIRCLES_TEST_ASYNC_INIT = 'test_async_init';
 	const CIRCLES_TEST_ASYNC_HAND = 'test_async_hand';
 	const CIRCLES_TEST_ASYNC_COUNT = 'test_async_count';
+	
+	const CIRCLES_ENABLE_AUDIT = 'circles_enable_audit';
 
 	private $defaults = [
 		self::CIRCLES_ALLOW_CIRCLES           => Circle::CIRCLES_ALL,
@@ -52,7 +54,8 @@ class ConfigService {
 		self::CIRCLES_ALLOW_LINKED_GROUPS     => '0',
 		self::CIRCLES_ALLOW_FEDERATED_CIRCLES => '0',
 		self::CIRCLES_ALLOW_NON_SSL_LINKS     => '0',
-		self::CIRCLES_NON_SSL_LOCAL           => '0'
+		self::CIRCLES_NON_SSL_LOCAL           => '0',
+		self::CIRCLES_ENABLE_AUDIT            => '0'
 	];
 
 	/** @var string */
@@ -84,6 +87,9 @@ class ConfigService {
 
 	/** @var int */
 	private $localNonSSL = -1;
+	
+	/** $var int */
+	private $enableAudit = -1;
 
 	/**
 	 * ConfigService constructor.
@@ -299,5 +305,17 @@ class ConfigService {
 		}
 
 		return $ver[0];
+	}
+	
+	/**
+	 * returns if audit is enabled by the current configuration.
+	 *
+	 * @return int
+	 */
+	public function isAuditEnabled() {
+		if ($this->enableAudit === -1) {
+			$this->enableAudit = (int)$this->getAppValue(self::CIRCLES_ENABLE_AUDIT);
+		}
+		return ((int)$this->enableAudit);
 	}
 }

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -36,5 +36,13 @@ style(Application::APP_NAME, 'admin');
 				<input type="checkbox" value="1" id="allow_federated_circles"/>
 			</td>
 		</tr>
+		<tr class="lane">
+			<td colspan="2" class="left"><?php p($l->t('Enable audit:')); ?><br/>
+				<em><?php p($l->t('Actions of circles, members and sharing can be audited.')); ?></em>
+			</td>
+			<td class="right">
+				<input type="checkbox" value="1" id="enable_audit"/>
+			</td>
+		</tr>
 	</table>
 </div>


### PR DESCRIPTION
- audit of following actions:
- user X created circle Z;
- user X removed circle Z;
- user X change name of circle Z for circle W;
- user X was added to circle U by user Z;
- user X shared file/folder with circle Y;
- user X, that created circle, unshared file/folder with circle Y
- member X accepted invitation to circle Y by user Z;
- member X left circle Y;
- user X change role of member Y in circle Z for W.
- user X was invited to circle U by user Z

- configuration by circles_enable_audit in config.php