### PR TITLE
Include circle short ID in formatted "shared with" field

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -372,8 +372,8 @@ class ShareByCircleProvider extends CircleProviderRequest implements IShareProvi
 	private function editShareEntry($data) {
 		$data['share_with'] =
 			sprintf(
-				'%s (%s, %s)', $data['circle_name'], Circle::TypeLongString($data['circle_type']),
-				$this->miscService->getDisplayName($data['circle_owner'])
+				'%s (%s, %s) [%s]', $data['circle_name'], Circle::TypeLongString($data['circle_type']),
+				$this->miscService->getDisplayName($data['circle_owner']), $data['share_with']
 			);
 
 		return $data;


### PR DESCRIPTION
When a share was shared with a circle the formatted _shared with_ field included the name, type and owner of the circle to provide a user friendly information about the circle to the Sharing UI. However, the ID of the circle was missing; this pull request adds it to make possible to identify the circle that a share was shared with.

This is needed, for example, to properly filter known shares with a circle in the _Sharing_ tab of the details view of the Files app. When a file is already shared with a sharee the sharee is filtered from the suggestions; this is done [by comparing the `share_with` field from the suggested sharee with the `share_with` field of all the shares of the file](https://github.com/nextcloud/server/blob/5f06380a4f4c8e49d8367825be119feba360b380/core/js/sharedialogview.js#L272). However, although the _share_with_ field of the suggested sharee [is set to the ID of the circle](https://github.com/nextcloud/circles/blob/748993ed70fcaa60ecf8d6e4c23d2c70e0b0d31e/lib/Collaboration/v1/CollaboratorSearchPlugin.php#L73) the _share_with_ field of the shares [is set to the name of the circle](https://github.com/nextcloud/server/blob/ebb15283a60d1c2ee5fb731feca1c68275d58264/apps/files_sharing/lib/Controller/ShareAPIController.php#L211).

Besides adding the circle ID in the formatted _share_with_ field the server also needs to make use of that extra value. This is done in nextcloud/server#8843

If the ID was prepended to the _share_with_ field then nothing would need to be changed in the server to filter the share as expected from the suggestions (as the _share_with_ field is set to whatever appears before the first space in the _shared with_ field of the share). However, the server would need to be patched anyway to remove the ID from the displayed name of the share, and prepending the ID would make very difficult to differentiate between a _shared with_ field that includes the ID and one that does not (for example, to handle the situation where the server is updated but the Circles app is not).

Instead, the ID was appended enclosed in brackets for easier parsing; this makes easier to handle an outdated Circles app in the server, and also does not pose any problem if the Circles app is updated but the server is not.
