### PR TITLE
Enable audit by configuration #163

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,36 @@ Anyone can find the circle and request an invitation; but only members will see 
 - A **Secret Circle** is an hidden group that can only be seen by its members or by people knowing the exact name of the circle.  
 Non-members won't be able to find your secret circle using the search bar.
 
+## Settings
+
+Circles settings is available in Nextcloud interface in **Settings / Additional Settings**.
+
+### Async Testing
+
+This option allows to initiate an async test in Circles.
+
+### Allow linking of groups
+
+This option allows that groups be linked to circles.
+
+### Allow federated circles
+
+This option allows that circles from different Nextclouds can be linked together. 
+
+### Enable audit
+
+This options allows that actions of circles, members and sharing can be audit with records into log. Following actions are audited:
+
+* User X created circle Z;
+* User X removed circle Z;
+* User X change name of circle Z for circle W;
+* User X was added to circle U by user Z;
+* User X shared file/folder with circle Y;
+* User X, that created circle, unshared file/folder with circle Y
+* Member X accepted invitation to circle Y by user Z;
+* Member X left circle Y;
+* User X change role of member Y in circle Z for W.
+* User X was invited to circle U by user Z
 
 ***
 # API (PHP & Javascript)

--- a/lib/Model/BaseMember.php
+++ b/lib/Model/BaseMember.php
@@ -277,20 +277,7 @@ class BaseMember implements \JsonSerializable {
 	}
 
 	public function getLevelString() {
-		switch ($this->getLevel()) {
-			case self::LEVEL_NONE:
-				return 'Not a member';
-			case self::LEVEL_MEMBER:
-				return 'Member';
-			case self::LEVEL_MODERATOR:
-				return 'Moderator';
-			case self::LEVEL_ADMIN:
-				return 'Admin';
-			case self::LEVEL_OWNER:
-				return 'Owner';
-		}
-
-		return 'none';
+		return self::getLevelStringFromCode($this->getLevel());
 	}
 
 
@@ -304,6 +291,27 @@ class BaseMember implements \JsonSerializable {
 				return 'Mail address';
 			case self::TYPE_CONTACT:
 				return 'Contact';
+		}
+
+		return 'none';
+	}
+
+	/** 
+	 * @param integer $code
+	 * @return string
+	 */
+	public static function getLevelStringFromCode($code) {
+		switch ($code) {
+			case self::LEVEL_NONE:
+				return 'Not a member';
+			case self::LEVEL_MEMBER:
+				return 'Member';
+			case self::LEVEL_MODERATOR:
+				return 'Moderator';
+			case self::LEVEL_ADMIN:
+				return 'Admin';
+			case self::LEVEL_OWNER:
+				return 'Owner';
 		}
 
 		return 'none';

--- a/lib/Service/BaseService.php
+++ b/lib/Service/BaseService.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Flávio Gomes da Silva Lisboa <flavio.lisboa@fgsl.eti.br>
+ *
+ * @copyright 2018
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Service;
+
+use OCA\Circles\AppInfo\Application;
+use OC\User\User;
+
+abstract class BaseService {
+	protected static $user = null;
+
+	/**
+	 * @return User
+	 */
+	protected function getUser()
+	{
+		if (self::$user == null){
+			$app = new Application();
+			self::$user = $app->getContainer()->query('UserSession')->getUser();
+		}
+		return self::$user;
+	}
+}

--- a/lib/Service/MembersService.php
+++ b/lib/Service/MembersService.php
@@ -40,8 +40,9 @@ use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
 use OCP\IL10N;
 use OCP\IUserManager;
+use OCP\Util;
 
-class MembersService {
+class MembersService extends BaseService {
 
 	/** @var string */
 	private $userId;
@@ -118,10 +119,15 @@ class MembersService {
 			$circle = $this->circlesRequest->getCircle($circleUniqueId, $this->userId);
 			$circle->getHigherViewer()
 				   ->hasToBeModerator();
-
+			
 			if (!$this->addMassiveMembers($circle, $ident, $type)) {
 				$this->addSingleMember($circle, $ident, $type);
 			}
+
+			$action = ($type == Circle::CIRCLES_CLOSED ? 'invited' : 'added');
+			$circleName = $circle->getName();
+			$user = $this->getUser()->getDisplayName();
+			$this->miscService->log("user $user $action member $ident to circle $circleName");
 		} catch (\Exception $e) {
 			throw $e;
 		}
@@ -402,7 +408,12 @@ class MembersService {
 			$member = $this->membersRequest->forceGetMember($circle->getUniqueId(), $name, $type);
 			$member->levelHasToBeEditable();
 			$this->updateMemberLevel($circle, $member, $level);
-
+			
+			$circleName = $circle->getName();
+			$levelString = Member::getLevelStringFromCode($level);
+			$memberName = $member->getDisplayName();
+			$user = $this->getUser()->getDisplayName();
+			$this->miscService->log("$user changed level of $memberName from circle $circleName to $levelString");
 			return $this->membersRequest->getMembers(
 				$circle->getUniqueId(), $circle->getHigherViewer()
 			);
@@ -507,6 +518,11 @@ class MembersService {
 
 			$circle->getHigherViewer()
 				   ->hasToBeHigherLevel($member->getLevel());
+
+			$user = $this->getUser()->getDisplayName();
+			$memberName = $member->getDisplayName();
+			$circleName = $circle->getName();
+			$this->miscService->log("user $user removed member $memberName from circle $circleName");
 		} catch (\Exception $e) {
 			throw $e;
 		}


### PR DESCRIPTION
- audit of following actions:
- user X created circle Z;
- user X removed circle Z;
- user X change name of circle Z for circle W;
- user X was added to circle U by user Z;
- user X shared file/folder with circle Y;
- user X, that created circle, unshared file/folder with circle Y
- member X accepted invitation to circle Y by user Z;
- member X left circle Y;
- user X change role of member Y in circle Z for W.
- user X was invited to circle U by user Z

- configuration by circles_enable_audit in config.php

Signed-off-by: Flávio Gomes da Silva Lisboa <flavio.lisboa@serpro.gov.br>