### PR TITLE
honor user enumeration prevention of the share api

### DIFF
--- a/lib/Controller/MembersController.php
+++ b/lib/Controller/MembersController.php
@@ -27,6 +27,7 @@
 namespace OCA\Circles\Controller;
 
 use OCA\Circles\Model\Member;
+use OCA\Circles\Model\SearchResult;
 use OCA\Circles\Service\MiscService;
 use OCP\AppFramework\Http\DataResponse;
 
@@ -173,11 +174,15 @@ class MembersController extends BaseController {
 				);
 		}
 
-		if ($this->configService->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes')
-			$result = array_filter($result,
-			                       function($data, $k) use ($search) {
-			                           return $data->getIdent() == $search;
-			                       }, ARRAY_FILTER_USE_BOTH);
+		if ($this->configService->getAppValue('shareapi_allow_share_dialog_user_enumeration') !== 'yes') {
+			$result = array_filter(
+				$result,
+				function($data, $k) use ($search) {
+					/** @var SearchResult $data */
+					return $data->getIdent() === $search;
+				}, ARRAY_FILTER_USE_BOTH
+			);
+		}
 
 		return $this->success(['search' => $search, 'result' => $result]);
 	}

--- a/lib/Controller/MembersController.php
+++ b/lib/Controller/MembersController.php
@@ -173,6 +173,12 @@ class MembersController extends BaseController {
 				);
 		}
 
+		if ($this->configService->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') !== 'yes')
+			$result = array_filter($result,
+			                       function($data, $k) use ($search) {
+			                           return $data->getIdent() == $search;
+			                       }, ARRAY_FILTER_USE_BOTH);
+
 		return $this->success(['search' => $search, 'result' => $result]);
 	}
 


### PR DESCRIPTION
If user enumeration is disabled in nextcloud core, then circle can
be used to circumvent this measure. For example the adduser button
in the user facing circle UI allows enumeration of all registered
users.

This patch honors the choice made in
 'shareapi_allow_share_dialog_user_enumeration'
for deciding if auto completion should present partial results.
This is in line with other apps, such as webdav, which reuse this
configuration choice to disable user enumeration.

In case this preference is set, all partial results are removed
from the results.

Fixes #152