### PR TITLE
Fix grammar, unnecessary escape in closed circle description

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is the right option if you want to do recurrent sharing with the same list 
 Anyone can see the circle, can join the circle and access the items shared to the circle.
  
 - Joining a **Closed Circle** requires an invitation or a confirmation by a moderator.  
-Anyone can find the circle and request an invitation; but only members will see who's in it and get access to shared items.
+Anyone can find and request an invitation to the circle; but only members can see its membership and get access to its shared items.
 
 - A **Secret Circle** is an hidden group that can only be seen by its members or by people knowing the exact name of the circle.  
 Non-members won't be able to find your secret circle using the search bar.

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -230,7 +230,7 @@ OC.L10N.register(
     "A secret circle is an hidden group that can only be seen by its members or by people knowing the exact name of the circle." : "A secret circle is an hidden group that can only be seen by its members or by people knowing the exact name of the circle.",
     "Non-members won't be able to find your secret circle using the search bar." : "Non-members won't be able to find your secret circle using the search bar.",
     "Joining a closed circle requires an invitation or confirmation by a moderator." : "Joining a closed circle requires an invitation or confirmation by a moderator.",
-    "Anyone can find and request an invitation to the circle; but only members will see who\\'s in it and get access to it\\'s shared items." : "Anyone can find and request an invitation to the circle; but only members will see who\\'s in it and get access to it\\'s shared items.",
+    "Anyone can find and request an invitation to the circle; but only members can see its membership and get access to its shared items." : "Anyone can find and request an invitation to the circle; but only members can see its membership and get access to its shared items.",
     "A public circle is an open group visible to anyone willing to join." : "A public circle is an open group visible to anyone willing to join.",
     "Anyone can see, join, and access the items shared within the circle." : "Anyone can see, join, and access the items shared within the circle.",
     "Personal circles" : "Personal circles",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -228,7 +228,7 @@
     "A secret circle is an hidden group that can only be seen by its members or by people knowing the exact name of the circle." : "A secret circle is an hidden group that can only be seen by its members or by people knowing the exact name of the circle.",
     "Non-members won't be able to find your secret circle using the search bar." : "Non-members won't be able to find your secret circle using the search bar.",
     "Joining a closed circle requires an invitation or confirmation by a moderator." : "Joining a closed circle requires an invitation or confirmation by a moderator.",
-    "Anyone can find and request an invitation to the circle; but only members will see who\\'s in it and get access to it\\'s shared items." : "Anyone can find and request an invitation to the circle; but only members will see who\\'s in it and get access to it\\'s shared items.",
+    "Anyone can find and request an invitation to the circle; but only members can see its membership and get access to its shared items." : "Anyone can find and request an invitation to the circle; but only members can see its membership and get access to its shared items.",
     "A public circle is an open group visible to anyone willing to join." : "A public circle is an open group visible to anyone willing to join.",
     "Anyone can see, join, and access the items shared within the circle." : "Anyone can see, join, and access the items shared within the circle.",
     "Personal circles" : "Personal circles",

--- a/templates/navigate.php
+++ b/templates/navigate.php
@@ -135,7 +135,7 @@ style(Application::APP_NAME, 'navigation');
 					); ?>
 				</b><br/><?php p(
 					$l->t(
-						"Anyone can find and request an invitation to the circle; but only members will see who\'s in it and get access to it\'s shared items."
+						"Anyone can find and request an invitation to the circle; but only members can see its membership and get access to its shared items."
 					)
 				); ?>
 			</div>


### PR DESCRIPTION
Change incorrect use of "it's", and remove unnecessary escaped apostrophe by changing "who\\'s in it" to "its membership".

Note that this change likely needs bulk edits (find-and-replace) across localization files. **Only en_GB was edited to demonstrate** the likely needed change.