### PR TITLE
Add `allow_adding_any_group_members` option

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -41,6 +41,7 @@ class ConfigService {
 	const CIRCLES_ALLOW_FEDERATED_CIRCLES = 'allow_federated';
 	const CIRCLES_MEMBERS_LIMIT = 'members_limit';
 	const CIRCLES_ACCOUNTS_ONLY = 'accounts_only';
+	const CIRCLES_ALLOW_ANY_GROUP_MEMBERS = 'allow_adding_any_group_members';
 	const CIRCLES_ALLOW_LINKED_GROUPS = 'allow_linked_groups';
 	const CIRCLES_ALLOW_NON_SSL_LINKS = 'allow_non_ssl_links';
 	const CIRCLES_NON_SSL_LOCAL = 'local_is_non_ssl';
@@ -66,6 +67,7 @@ class ConfigService {
 		self::CIRCLES_NON_SSL_LOCAL           => '0',
 		self::CIRCLES_ACTIVITY_ON_CREATION    => '1',
 		self::CIRCLES_SKIP_INVITATION_STEP    => '0'
+		self::CIRCLES_ALLOW_ANY_GROUP_MEMBERS    => '1',
 	];
 
 	/** @var string */
@@ -85,6 +87,9 @@ class ConfigService {
 
 	/** @var int */
 	private $allowedCircle = -1;
+
+	/** @var int */
+	private $allowAddingAnyGroupMembers = -1;
 
 	/** @var int */
 	private $allowedLinkedGroups = -1;
@@ -139,6 +144,20 @@ class ConfigService {
 		return ((int)$type & (int)$this->allowedCircle);
 	}
 
+	/**
+	 * returns if the current user is allowed to add any group members.
+	 * even if he isn't a member of these groups
+	 *
+	 * @return bool
+	 */
+	public function isAddingAnyGroupMembersAllowed() {
+		if ($this->allowAddingAnyGroupMembers === -1) {
+			$this->allowAddingAnyGroupMembers =
+				(int)$this->getAppValue(self::CIRCLES_ALLOW_ANY_GROUP_MEMBERS);
+		}
+
+		return ($this->allowAddingAnyGroupMembers === 1);
+	}
 
 	/**
 	 * @return bool


### PR DESCRIPTION
To allow or not adding group members from any users, default to `1`.

When value is set to `0`, it's only possible to add groups where the current user is a member or for global administrators.

Fix https://github.com/nextcloud/circles/issues/128