### PR TITLE
Add `allow_listed_circles` option

### DIFF
--- a/lib/Api/Sharees.php
+++ b/lib/Api/Sharees.php
@@ -30,6 +30,7 @@ use OCA\Circles\AppInfo\Application;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Service\CirclesService;
+use OCA\Circles\Service\ConfigService;
 use OCA\Circles\Service\MiscService;
 use OCP\Share;
 
@@ -61,12 +62,20 @@ class Sharees {
 //	public static function search($search, $limit, $offset) {
 	public static function search($search) {
 		$c = self::getContainer();
+
+		$type = Circle::CIRCLES_ALL;
+		$circlesAreVisible = $c->query(ConfigService::class)
+						 		->isListedCirclesAllowed();
+		if (!$circlesAreVisible) {
+			$type = $type - Circle::CIRCLES_CLOSED - Circle::CIRCLES_PUBLIC;
+		}
+
 		$userId = \OC::$server->getUserSession()
 							  ->getUser()
 							  ->getUID();
 
 		$data = $c->query(CirclesService::class)
-				  ->listCircles($userId, Circle::CIRCLES_ALL, $search, Member::LEVEL_MEMBER);
+				  ->listCircles($userId, $type, $search, Member::LEVEL_MEMBER);
 		$result = array(
 			'exact'   => ['circles'],
 			'circles' => []

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -41,6 +41,7 @@ class ConfigService {
 	const CIRCLES_ALLOW_FEDERATED_CIRCLES = 'allow_federated';
 	const CIRCLES_MEMBERS_LIMIT = 'members_limit';
 	const CIRCLES_ACCOUNTS_ONLY = 'accounts_only';
+	const CIRCLES_ALLOW_LISTED_CIRCLES = 'allow_listed_circles';
 	const CIRCLES_ALLOW_LINKED_GROUPS = 'allow_linked_groups';
 	const CIRCLES_ALLOW_NON_SSL_LINKS = 'allow_non_ssl_links';
 	const CIRCLES_NON_SSL_LOCAL = 'local_is_non_ssl';
@@ -66,6 +67,7 @@ class ConfigService {
 		self::CIRCLES_NON_SSL_LOCAL           => '0',
 		self::CIRCLES_ACTIVITY_ON_CREATION    => '1',
 		self::CIRCLES_SKIP_INVITATION_STEP    => '0'
+		self::CIRCLES_ALLOW_LISTED_CIRCLES       => '1',
 	];
 
 	/** @var string */
@@ -85,6 +87,9 @@ class ConfigService {
 
 	/** @var int */
 	private $allowedCircle = -1;
+
+	/** @var int */
+	private $allowedListedCircles = -1;
 
 	/** @var int */
 	private $allowedLinkedGroups = -1;
@@ -137,6 +142,20 @@ class ConfigService {
 		}
 
 		return ((int)$type & (int)$this->allowedCircle);
+	}
+
+	/**
+	 * returns if the circles are allowed to be listed outside the Circles application.
+	 *
+	 * @return bool
+	 */
+	public function isListedCirclesAllowed() {
+		if ($this->allowedListedCircles === -1) {
+			$this->allowedListedCircles =
+				(int)$this->getAppValue(self::CIRCLES_ALLOW_LISTED_CIRCLES);
+		}
+
+		return ($this->allowedListedCircles === 1);
 	}
 
 


### PR DESCRIPTION
To list or not circles outside the Circles app.

Default value is `1`, to show circles in shared list.
Set it to `0` to hide them.