### PR TITLE
Fixing missing FR translation

### DIFF
--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -3,6 +3,7 @@ OC.L10N.register(
     {
     "Are you sure you want to transfer your ownership?" : "Êtes-vous sûr de vouloir transférer votre propriété ?",
     "This action is irreversible" : "Cette action est irréversible",
+    "Name of the Circle" : "Nom du Cercle",
     "Personal circle" : "Cercle personnel",
     "Secret circle" : "Cercle caché",
     "Closed circle" : "Cercle privé",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -1,6 +1,7 @@
 { "translations": {
     "Are you sure you want to transfer your ownership?" : "Êtes-vous sûr de vouloir transférer votre propriété ?",
     "This action is irreversible" : "Cette action est irréversible",
+    "Name of the Circle" : "Nom du Cercle",
     "Personal circle" : "Cercle personnel",
     "Secret circle" : "Cercle caché",
     "Closed circle" : "Cercle privé",


### PR DESCRIPTION
An entry was missing in the french translation : "Name of the Circle" which translates to "Nom du Cercle".
I added it in the french locale file.