### PR TITLE
fix: add fail function to SharesController

### DIFF
--- a/lib/Controller/SharesController.php
+++ b/lib/Controller/SharesController.php
@@ -28,6 +28,7 @@ namespace OCA\Circles\Controller;
 
 use daita\MySmallPhpTools\Traits\TStringTools;
 use Exception;
+use OC\AppFramework\Http;
 use OCA\Circles\Db\SharesRequest;
 use OCA\Circles\Db\TokensRequest;
 use OCA\Circles\Exceptions\MemberDoesNotExistException;
@@ -234,5 +235,32 @@ class SharesController extends Controller {
 
 		throw new MemberDoesNotExistException();
 	}
+
+	/**
+	 * @param $data
+	 *
+	 * @return DataResponse
+	 */
+	private function fail($data) {
+		$this->miscService->log(json_encode($data));
+
+		return new DataResponse(
+			array_merge($data, array('status' => 0)),
+			Http::STATUS_NON_AUTHORATIVE_INFORMATION
+		);
+	}
+
+	/**
+	 * @param $data
+	 *
+	 * @return DataResponse
+	 */
+	private function success($data) {
+		return new DataResponse(
+			array_merge($data, array('status' => 1)),
+			Http::STATUS_CREATED
+		);
+	}
+
 }
 


### PR DESCRIPTION
`SharesController` extends `Controller` - not `BaseController`
and thus does not inherit `this->fail`.

Not sure if it should extend `BaseController` instead.

This is the fix with the least changes
that make error reporting in the logs work for me again.