### PR TITLE
fix: do not rely on `api` global

### DIFF
--- a/js/circles.v1.circles.js
+++ b/js/circles.v1.circles.js
@@ -29,26 +29,19 @@
 var circles = {
 
 	createCircle: function (type, name, callback) {
-
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'PUT',
 			url: OC.generateUrl('/apps/circles/v1/circles'),
 			data: {
 				type: type,
 				name: name
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	listCircles: function (type, name, level, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'GET',
 			url: OC.generateUrl('/apps/circles/v1/circles'),
 			data: {
@@ -56,80 +49,51 @@ var circles = {
 				name: name,
 				level: level
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	detailsCircle: function (circleId, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'GET',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId)
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	joinCircle: function (circleId, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'GET',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/join'),
 			data: {}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	settingsCircle: function (circleId, settings, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'POST',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/settings'),
 			data: {settings: settings}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	leaveCircle: function (circleId, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'GET',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/leave'),
 			data: {}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	destroyCircle: function (circleId, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'DELETE',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId),
 			data: {}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	}
 
 };

--- a/js/circles.v1.circles.js
+++ b/js/circles.v1.circles.js
@@ -39,9 +39,9 @@ var circles = {
 				name: name
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -57,9 +57,9 @@ var circles = {
 				level: level
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -70,9 +70,9 @@ var circles = {
 			method: 'GET',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId)
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -84,9 +84,9 @@ var circles = {
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/join'),
 			data: {}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -98,9 +98,9 @@ var circles = {
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/settings'),
 			data: {settings: settings}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -112,9 +112,9 @@ var circles = {
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/leave'),
 			data: {}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -126,9 +126,9 @@ var circles = {
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId),
 			data: {}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	}
 

--- a/js/circles.v1.js
+++ b/js/circles.v1.js
@@ -50,8 +50,7 @@
 
 
 			this.shareToCircle = function (circleId, source, type, item, callback) {
-				var result = {status: -1};
-				$.ajax({
+				self.request({
 					method: 'PUT',
 					url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/share'),
 					data: {
@@ -59,11 +58,14 @@
 						type: type,
 						item: item
 					}
-				}).done(function (res) {
-					self.onCallback(callback, res);
-				}).fail(function () {
-					self.onCallback(callback, result);
-				});
+				}, callback)
+			};
+
+			this.request = function (options, callback) {
+				var result = {status: -1};
+				$.ajax(options)
+					.done(function (res) { self.onCallback(callback, res); })
+					.fail(function () { self.onCallback(callback, result); });
 			};
 
 			this.onCallback = function (callback, result) {

--- a/js/circles.v1.links.js
+++ b/js/circles.v1.links.js
@@ -30,83 +30,58 @@
 var links = {
 
 	linkCircle: function (circleId, remote, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'POST',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/link'),
 			data: {
 				remote: remote
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	linkStatus: function (linkId, status, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'POST',
 			url: OC.generateUrl('/apps/circles/v1/link/' + linkId + '/status'),
 			data: {
 				status: status
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	linkGroup: function (circleId, groupId, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'PUT',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/groups'),
 			data: {
 				name: groupId
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	unlinkGroup: function (circleId, groupId, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'DELETE',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/groups'),
 			data: {
 				group: groupId
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	levelGroup: function (circleId, group, level, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'POST',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/group/level'),
 			data: {
 				group: group,
 				level: level
 			}
-		}).done(function (res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function () {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	}
 
 };

--- a/js/circles.v1.links.js
+++ b/js/circles.v1.links.js
@@ -29,7 +29,6 @@
 
 var links = {
 
-
 	linkCircle: function (circleId, remote, callback) {
 		var result = {status: -1};
 		$.ajax({
@@ -39,9 +38,9 @@ var links = {
 				remote: remote
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -55,9 +54,9 @@ var links = {
 				status: status
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -71,9 +70,9 @@ var links = {
 				name: groupId
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -87,9 +86,9 @@ var links = {
 				group: groupId
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -104,9 +103,9 @@ var links = {
 				level: level
 			}
 		}).done(function (res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function () {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	}
 

--- a/js/circles.v1.members.js
+++ b/js/circles.v1.members.js
@@ -29,25 +29,18 @@
 var members = {
 
 	searchUsers: function(search, callback) {
-
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'GET',
 			url: OC.generateUrl('/apps/circles/v1/globalsearch'),
 			data: {
 				search: search
 			}
-		}).done(function(res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function() {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	addMember: function(circleId, ident, type, instance, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'PUT',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/member'),
 			data: {
@@ -55,17 +48,12 @@ var members = {
 				type: type,
 				instance: instance
 			}
-		}).done(function(res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function() {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	removeMember: function(circleId, userId, userType, instance, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'DELETE',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/member'),
 			data: {
@@ -73,17 +61,12 @@ var members = {
 				type: Number(userType),
 				instance: instance
 			}
-		}).done(function(res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function() {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	},
 
 
 	levelMember: function(circleId, userId, userType, instance, level, callback) {
-		var result = {status: -1};
-		$.ajax({
+		OCA.Circles.api.request({
 			method: 'POST',
 			url: OC.generateUrl('/apps/circles/v1/circles/' + circleId + '/level'),
 			data: {
@@ -92,11 +75,7 @@ var members = {
 				instance: instance,
 				level: level
 			}
-		}).done(function(res) {
-			OCA.Circles.api.onCallback(callback, res);
-		}).fail(function() {
-			OCA.Circles.api.onCallback(callback, result);
-		});
+		}, callback);
 	}
 
 

--- a/js/circles.v1.members.js
+++ b/js/circles.v1.members.js
@@ -28,7 +28,6 @@
 
 var members = {
 
-
 	searchUsers: function(search, callback) {
 
 		var result = {status: -1};
@@ -39,9 +38,9 @@ var members = {
 				search: search
 			}
 		}).done(function(res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function() {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -57,9 +56,9 @@ var members = {
 				instance: instance
 			}
 		}).done(function(res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function() {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -75,9 +74,9 @@ var members = {
 				instance: instance
 			}
 		}).done(function(res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function() {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	},
 
@@ -94,9 +93,9 @@ var members = {
 				level: level
 			}
 		}).done(function(res) {
-			api.onCallback(callback, res);
+			OCA.Circles.api.onCallback(callback, res);
 		}).fail(function() {
-			api.onCallback(callback, result);
+			OCA.Circles.api.onCallback(callback, result);
 		});
 	}
 

--- a/js/files/circles.files.app.js
+++ b/js/files/circles.files.app.js
@@ -11,8 +11,6 @@
  *
  */
 
-var api = OCA.Circles.api;
-
 (function() {
 	if (!OCA.Circles) {
 		/**


### PR DESCRIPTION
The api files relied on an api global to handle responses:

```javascript
$.ajax({ ...
}).done(function (res) {
	api.onCallback(callback, res);
}).fail(function () {
	api.onCallback(callback, result);
});
```

In the files app this only worked
because circles.files.app.js added api as a global.

Remove that global and replace it with
```javascript
OCA.Circles.api
```
wherever it was used.

Signed-off-by: Azul <azul@riseup.net>