### PR TITLE
[stable18] Fix collaborator search and include email matches

### DIFF
--- a/lib/Search/LocalUsers.php
+++ b/lib/Search/LocalUsers.php
@@ -97,7 +97,6 @@ class LocalUsers implements ISearch {
 				new SearchResult(
 					$this->get('value.shareWith', $entry),
 					Member::TYPE_USER,
-					'',
 					['display' => $this->get('label', $entry)]
 				);
 		}

--- a/lib/Search/LocalUsers.php
+++ b/lib/Search/LocalUsers.php
@@ -88,7 +88,7 @@ class LocalUsers implements ISearch {
 	 * @return array
 	 */
 	private function searchFromCollaborator($search): array {
-		list($temp, $hasMore) = $this->search->search($search, [IShare::TYPE_USER], false, 50, 0);
+		list($temp, $hasMore) = $this->search->search($search, [IShare::TYPE_USER, IShare::TYPE_EMAIL], false, 50, 0);
 
 		$result = array_merge($temp['exact']['users'], $temp['users']);
 		$parsed = [];


### PR DESCRIPTION
Backport of https://github.com/nextcloud/circles/pull/462 and fix an issue where the displayname of search results doesn't get passed properly to the SearchResult instance