### PR TITLE
Allow to get circle details with forceAll

### DIFF
--- a/lib/Service/CirclesService.php
+++ b/lib/Service/CirclesService.php
@@ -267,9 +267,13 @@ class CirclesService {
 	public function detailsCircle($circleUniqueId, $forceAll = false) {
 
 		try {
-			$circle = $this->circlesRequest->getCircle(
-				$circleUniqueId, $this->userId, Member::TYPE_USER, '', $forceAll
-			);
+			if (!$forceAll) {
+				$circle = $this->circlesRequest->getCircle(
+					$circleUniqueId, $this->userId, Member::TYPE_USER, '', $forceAll
+				);
+			} else {
+				$circle = $this->circlesRequest->getCircleFromUniqueId($circleUniqueId);
+			}
 			if ($this->viewerIsAdmin()
 				|| $circle->getHigherViewer()
 						  ->isLevel(Member::LEVEL_MEMBER)


### PR DESCRIPTION
This allows to get a circle details with the member list even if no current user is available (in a background job) in case the API consumer needs a full list of members, e.g. to issue notifications to them.

Should fix #563 