### PR TITLE
Set properties `name` and `sanitizedName` when changing a circles name

### DIFF
--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -83,7 +83,9 @@ class CircleRequest extends CircleRequestBuilder {
 	 */
 	public function edit(Circle $circle): void {
 		$qb = $this->getCircleUpdateSql();
-		$qb->set('display_name', $qb->createNamedParameter($circle->getDisplayName()))
+		$qb->set('name', $qb->createNamedParameter($circle->getName()))
+		   ->set('display_name', $qb->createNamedParameter($circle->getDisplayName()))
+		   ->set('sanitized_name', $qb->createNamedParameter($circle->getSanitizedName()))
 		   ->set('description', $qb->createNamedParameter($circle->getDescription()));
 
 		$qb->limitToUniqueId($circle->getSingleId());


### PR DESCRIPTION
Until now, only `displayName` was changed.