### PR TITLE
rework on some new members' events

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -44,9 +44,10 @@ use OCA\Circles\Events\MembershipsRemovedEvent;
 use OCA\Circles\Events\RequestingCircleMemberEvent;
 use OCA\Circles\Handlers\WebfingerHandler;
 use OCA\Circles\Listeners\DeprecatedListener;
-use OCA\Circles\Listeners\Examples\AddingExampleCircleMember;
+use OCA\Circles\Listeners\Examples\ExampleAddingCircleMember;
 use OCA\Circles\Listeners\Examples\ExampleMembershipsCreated;
 use OCA\Circles\Listeners\Examples\ExampleMembershipsRemoved;
+use OCA\Circles\Listeners\Examples\ExampleRequestingCircleMember;
 use OCA\Circles\Listeners\Files\AddingMember as ListenerFilesAddingMember;
 use OCA\Circles\Listeners\Files\MemberAdded as ListenerFilesMemberAdded;
 use OCA\Circles\Listeners\Files\MembershipsRemoved as ListenerFilesMembershipsRemoved;
@@ -226,7 +227,10 @@ class Application extends App implements IBootstrap {
 	 * @param IRegistrationContext $context
 	 */
 	private function loadExampleEvents(IRegistrationContext $context): void {
-		$context->registerEventListener(AddingCircleMemberEvent::class, AddingExampleCircleMember::class);
+		$context->registerEventListener(AddingCircleMemberEvent::class, ExampleAddingCircleMember::class);
+		$context->registerEventListener(
+			RequestingCircleMemberEvent::class, ExampleRequestingCircleMember::class
+		);
 		$context->registerEventListener(MembershipsCreatedEvent::class, ExampleMembershipsCreated::class);
 		$context->registerEventListener(MembershipsRemovedEvent::class, ExampleMembershipsRemoved::class);
 	}
@@ -261,11 +265,11 @@ class Application extends App implements IBootstrap {
 				$l = OC::$server->getL10N('circles');
 
 				return [
-					'id'      => 'circlesfilter',
+					'id' => 'circlesfilter',
 					'appname' => 'circles',
-					'script'  => 'files/list.php',
-					'order'   => 25,
-					'name'    => $l->t('Shared to Circles'),
+					'script' => 'files/list.php',
+					'order' => 25,
+					'name' => $l->t('Shared to Circles'),
 				];
 			}
 		);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -41,6 +41,7 @@ use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleMemberAddedEvent;
 use OCA\Circles\Events\MembershipsCreatedEvent;
 use OCA\Circles\Events\MembershipsRemovedEvent;
+use OCA\Circles\Events\RequestingCircleMemberEvent;
 use OCA\Circles\Handlers\WebfingerHandler;
 use OCA\Circles\Listeners\DeprecatedListener;
 use OCA\Circles\Listeners\Examples\AddingExampleCircleMember;
@@ -53,6 +54,7 @@ use OCA\Circles\Listeners\GroupCreated;
 use OCA\Circles\Listeners\GroupDeleted;
 use OCA\Circles\Listeners\GroupMemberAdded;
 use OCA\Circles\Listeners\GroupMemberRemoved;
+use OCA\Circles\Listeners\Notifications\RequestingMember as ListenerNotificationsRequestingMember;
 use OCA\Circles\Listeners\UserCreated;
 use OCA\Circles\Listeners\UserDeleted;
 use OCA\Circles\MountManager\CircleMountProvider;
@@ -134,11 +136,14 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserAddedEvent::class, GroupMemberAdded::class);
 		$context->registerEventListener(UserRemovedEvent::class, GroupMemberRemoved::class);
 
-		// Local Events (for Files/Shares management)
+		// Local Events (for Files/Shares/Notifications management)
 		$context->registerEventListener(AddingCircleMemberEvent::class, ListenerFilesAddingMember::class);
 		$context->registerEventListener(CircleMemberAddedEvent::class, ListenerFilesMemberAdded::class);
 		$context->registerEventListener(
 			MembershipsRemovedEvent::class, ListenerFilesMembershipsRemoved::class
+		);
+		$context->registerEventListener(
+			RequestingCircleMemberEvent::class, ListenerNotificationsRequestingMember::class
 		);
 
 		// It seems that AccountManager use deprecated dispatcher, let's use a deprecated listener

--- a/lib/Events/CircleEditedEvent.php
+++ b/lib/Events/CircleEditedEvent.php
@@ -36,54 +36,29 @@ use OCA\Circles\Model\Federated\FederatedEvent;
 
 
 /**
- * Class RemovingCircleMemberEvent
+ * Class CircleEditedEvent
  *
- * This event is called when a member is removed from a Circle.
- * This event is called on every instance of Nextcloud related to the Circle.
+ * This Event is called when it has been confirmed that the Circle have been edited on all targeted
+ * instances.
  *
- * The entry is already removed from the members table.
- * The memberships of the member are already removed from the memberships table.
+ * Meaning that the event won't be triggered until each instances have been once available during the
+ * retry-on-fail initiated in a background job
  *
- * This is a good place if anything needs to be executed when a member have been removed from a Circle.
- *
- * If anything needs to be managed on the master instance of the Circle (ie. CircleMemberRemovedEvent), please use:
- *    $event->getFederatedEvent()->addResult(string $key, array $data);
+ * WARNING: Unlike EditingCircleEvent, this Event is only called on the master instance of the Circle.
  *
  * @package OCA\Circles\Events
  */
-class RemovingCircleMemberEvent extends CircleMemberGenericEvent {
-
-
-	/** @var int */
-	private $type = 0;
+class CircleEditedEvent extends CircleResultGenericEvent {
 
 
 	/**
-	 * RemovingCircleMemberEvent constructor.
+	 * CircleEditedEvent constructor.
 	 *
 	 * @param FederatedEvent $federatedEvent
+	 * @param array $results
 	 */
-	public function __construct(FederatedEvent $federatedEvent) {
-		parent::__construct($federatedEvent);
-	}
-
-
-	/**
-	 * @param int $type
-	 *
-	 * @return $this
-	 */
-	public function setType(int $type): self {
-		$this->type = $type;
-
-		return $this;
-	}
-
-	/**
-	 * @return int
-	 */
-	public function getType(): int {
-		return $this->type;
+	public function __construct(FederatedEvent $federatedEvent, array $results) {
+		parent::__construct($federatedEvent, $results);
 	}
 
 }

--- a/lib/Events/CircleGenericEvent.php
+++ b/lib/Events/CircleGenericEvent.php
@@ -47,10 +47,13 @@ class CircleGenericEvent extends Event {
 
 	const INVITED = 1;
 	const JOINED = 2;
+	/** @deprecated */
 	const MULTIPLE = 3;
 	const REMOVED = 4;
 	const LEFT = 5;
 	const LEVEL = 6;
+	const NAME = 7;
+	const REQUESTED = 8;
 
 
 	/** @var FederatedEvent */

--- a/lib/Events/CircleMemberEditedEvent.php
+++ b/lib/Events/CircleMemberEditedEvent.php
@@ -38,6 +38,13 @@ use OCA\Circles\Model\Federated\FederatedEvent;
 /**
  * Class CircleMemberEditedEvent
  *
+ * This Event is called when it has been confirmed that a Member have been edited on all instances used
+ * by the Circle.
+ * Meaning that the event won't be triggered until each instances have been once available during the
+ * retry-on-fail initiated in a background job
+ *
+ * WARNING: Unlike EditingCircleMemberEvent, this Event is only called on the master instance of the Circle.
+ *
  * @package OCA\Circles\Events
  */
 class CircleMemberEditedEvent extends CircleResultGenericEvent {
@@ -45,6 +52,12 @@ class CircleMemberEditedEvent extends CircleResultGenericEvent {
 
 	/** @var int */
 	private $type = 0;
+
+	/** @var int */
+	private $newLevel = 0;
+
+	/** @var string */
+	private $newDisplayName = '';
 
 
 	/**
@@ -73,6 +86,44 @@ class CircleMemberEditedEvent extends CircleResultGenericEvent {
 	 */
 	public function getType(): int {
 		return $this->type;
+	}
+
+
+	/**
+	 * @param int $newLevel
+	 *
+	 * @return CircleMemberEditedEvent
+	 */
+	public function setNewLevel(int $newLevel): self {
+		$this->newLevel = $newLevel;
+
+		return $this;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getNewLevel(): int {
+		return $this->newLevel;
+	}
+
+
+	/**
+	 * @param string $newDisplayName
+	 *
+	 * @return CircleMemberEditedEvent
+	 */
+	public function setNewDisplayName(string $newDisplayName): self {
+		$this->newDisplayName = $newDisplayName;
+
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getNewDisplayName(): string {
+		return $this->newDisplayName;
 	}
 
 }

--- a/lib/Events/CircleMemberGenericEvent.php
+++ b/lib/Events/CircleMemberGenericEvent.php
@@ -47,9 +47,6 @@ class CircleMemberGenericEvent extends CircleGenericEvent {
 	/** @var Member */
 	private $member;
 
-	/** @var Member[] */
-	private $members;
-
 
 	/**
 	 * CircleMemberAddedEvent constructor.
@@ -59,34 +56,15 @@ class CircleMemberGenericEvent extends CircleGenericEvent {
 	public function __construct(FederatedEvent $federatedEvent) {
 		parent::__construct($federatedEvent);
 
-		if ($federatedEvent->hasMember()) {
-			$this->member = $federatedEvent->getMember();
-		}
-
-		$this->members = $federatedEvent->getMembers();
+		$this->member = $federatedEvent->getMember();
 	}
 
-
-	/**
-	 * @return bool
-	 */
-	public function hasMember(): bool {
-		return (!is_null($this->member));
-	}
 
 	/**
 	 * @return Member
 	 */
 	public function getMember(): Member {
 		return $this->member;
-	}
-
-	
-	/**
-	 * @return Member[]
-	 */
-	public function getMembers(): array {
-		return $this->members;
 	}
 
 }

--- a/lib/Events/CircleMemberRequestedEvent.php
+++ b/lib/Events/CircleMemberRequestedEvent.php
@@ -36,22 +36,18 @@ use OCA\Circles\Model\Federated\FederatedEvent;
 
 
 /**
- * Class RemovingCircleMemberEvent
+ * Class CircleMemberRequestedEvent
  *
- * This event is called when a member is removed from a Circle.
- * This event is called on every instance of Nextcloud related to the Circle.
+ * This Event is called when it has been confirmed that a Member's request/invitation is done on all instances
+ * used by the Circle.
+ * Meaning that the event won't be triggered until each instances have been once available during the
+ * retry-on-fail initiated in a background job
  *
- * The entry is already removed from the members table.
- * The memberships of the member are already removed from the memberships table.
- *
- * This is a good place if anything needs to be executed when a member have been removed from a Circle.
- *
- * If anything needs to be managed on the master instance of the Circle (ie. CircleMemberRemovedEvent), please use:
- *    $event->getFederatedEvent()->addResult(string $key, array $data);
+ * WARNING: Unlike RequestingCircleMemberEvent, this Event is only called on the master instance of the Circle.
  *
  * @package OCA\Circles\Events
  */
-class RemovingCircleMemberEvent extends CircleMemberGenericEvent {
+class CircleMemberRequestedEvent extends CircleResultGenericEvent {
 
 
 	/** @var int */
@@ -59,12 +55,13 @@ class RemovingCircleMemberEvent extends CircleMemberGenericEvent {
 
 
 	/**
-	 * RemovingCircleMemberEvent constructor.
+	 * CircleMemberRequestedEvent constructor.
 	 *
 	 * @param FederatedEvent $federatedEvent
+	 * @param array $results
 	 */
-	public function __construct(FederatedEvent $federatedEvent) {
-		parent::__construct($federatedEvent);
+	public function __construct(FederatedEvent $federatedEvent, array $results) {
+		parent::__construct($federatedEvent, $results);
 	}
 
 

--- a/lib/Events/CircleResultGenericEvent.php
+++ b/lib/Events/CircleResultGenericEvent.php
@@ -59,9 +59,6 @@ class CircleResultGenericEvent extends Event {
 	/** @var Member */
 	private $member;
 
-	/** @var Member[] */
-	private $members;
-
 
 	/**
 	 * CircleResultGenericEvent constructor.
@@ -79,8 +76,6 @@ class CircleResultGenericEvent extends Event {
 		if ($federatedEvent->hasMember()) {
 			$this->member = $federatedEvent->getMember();
 		}
-
-		$this->members = $federatedEvent->getMembers();
 	}
 
 
@@ -120,14 +115,6 @@ class CircleResultGenericEvent extends Event {
 	 */
 	public function getMember(): ?Member {
 		return $this->member;
-	}
-
-
-	/**
-	 * @return Member[]
-	 */
-	public function getMembers(): array {
-		return $this->members;
 	}
 
 }

--- a/lib/Events/EditingCircleEvent.php
+++ b/lib/Events/EditingCircleEvent.php
@@ -36,54 +36,31 @@ use OCA\Circles\Model\Federated\FederatedEvent;
 
 
 /**
- * Class RemovingCircleMemberEvent
+ * Class EditingCircleEvent
  *
- * This event is called when a member is removed from a Circle.
+ * This event is called when a circle is edited.
  * This event is called on every instance of Nextcloud related to the Circle.
  *
- * The entry is already removed from the members table.
- * The memberships of the member are already removed from the memberships table.
+ * The entry is already edited in the circles table.
+ * If needed, the entries in the memberships table are already edited.
  *
- * This is a good place if anything needs to be executed when a member have been removed from a Circle.
+ * This is a good place if anything needs to be executed when a circle is edited.
  *
- * If anything needs to be managed on the master instance of the Circle (ie. CircleMemberRemovedEvent), please use:
+ * If anything needs to be managed on the master instance of the Circle (ie. CircleEditedEvent), please use:
  *    $event->getFederatedEvent()->addResult(string $key, array $data);
  *
  * @package OCA\Circles\Events
  */
-class RemovingCircleMemberEvent extends CircleMemberGenericEvent {
-
-
-	/** @var int */
-	private $type = 0;
+class EditingCircleEvent extends CircleMemberGenericEvent {
 
 
 	/**
-	 * RemovingCircleMemberEvent constructor.
+	 * EditingCircleEvent constructor.
 	 *
 	 * @param FederatedEvent $federatedEvent
 	 */
 	public function __construct(FederatedEvent $federatedEvent) {
 		parent::__construct($federatedEvent);
-	}
-
-
-	/**
-	 * @param int $type
-	 *
-	 * @return $this
-	 */
-	public function setType(int $type): self {
-		$this->type = $type;
-
-		return $this;
-	}
-
-	/**
-	 * @return int
-	 */
-	public function getType(): int {
-		return $this->type;
 	}
 
 }

--- a/lib/Events/EditingCircleMemberEvent.php
+++ b/lib/Events/EditingCircleMemberEvent.php
@@ -38,6 +38,18 @@ use OCA\Circles\Model\Federated\FederatedEvent;
 /**
  * Class EditingCircleMemberEvent
  *
+ * This event is called when a member is edited.
+ * This event is called on every instance of Nextcloud related to the Circle.
+ *
+ * The entry is already edited in the members table.
+ * If needed, the entries in the memberships table are already edited.
+ *
+ * This is a good place if anything needs to be executed when a member is edited.
+ *
+ * If anything needs to be managed on the master instance of the Circle (ie. CircleMemberEditedEvent), please
+ * use:
+ *    $event->getFederatedEvent()->addResult(string $key, array $data);
+ *
  * @package OCA\Circles\Events
  */
 class EditingCircleMemberEvent extends CircleMemberGenericEvent {
@@ -45,6 +57,12 @@ class EditingCircleMemberEvent extends CircleMemberGenericEvent {
 
 	/** @var int */
 	private $type = 0;
+
+	/** @var int */
+	private $level = 0;
+
+	/** @var string */
+	private $displayName = '';
 
 
 	/**
@@ -74,6 +92,45 @@ class EditingCircleMemberEvent extends CircleMemberGenericEvent {
 	public function getType(): int {
 		return $this->type;
 	}
+
+
+	/**
+	 * @param int $level
+	 *
+	 * @return EditingCircleMemberEvent
+	 */
+	public function setLevel(int $level): self {
+		$this->level = $level;
+
+		return $this;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLevel(): int {
+		return $this->level;
+	}
+
+
+	/**
+	 * @param string $displayName
+	 *
+	 * @return EditingCircleMemberEvent
+	 */
+	public function setDisplayName(string $displayName): self {
+		$this->displayName = $displayName;
+
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDisplayName(): string {
+		return $this->displayName;
+	}
+
 
 }
 

--- a/lib/Events/MembershipsEditedEvent.php
+++ b/lib/Events/MembershipsEditedEvent.php
@@ -32,55 +32,39 @@ declare(strict_types=1);
 namespace OCA\Circles\Events;
 
 
-use OCA\Circles\Model\Federated\FederatedEvent;
+use OCA\Circles\Model\Membership;
+use OCP\EventDispatcher\Event;
 
 
 /**
- * Class CircleMemberRemovedEvent
- *
- * This Event is called when it has been confirmed that a Member have been removed on all instances used
- * by the Circle.
- * Meaning that the event won't be triggered until each instances have been once available during the
- * retry-on-fail initiated in a background job
- *
- * WARNING: Unlike RemovingCircleMemberEvent, this Event is only called on the master instance of the Circle.
+ * Class MembershipsEditedEvent
  *
  * @package OCA\Circles\Events
  */
-class CircleMemberRemovedEvent extends CircleResultGenericEvent {
+class MembershipsEditedEvent extends Event {
 
 
-	/** @var int */
-	private $type = 0;
+	/** @var Membership[] */
+	private $memberships;
 
 
 	/**
-	 * CircleMemberRemovedEvent constructor.
+	 * MembershipsEditedEvent constructor.
 	 *
-	 * @param FederatedEvent $federatedEvent
-	 * @param array $results
+	 * @param Membership[] $memberships
 	 */
-	public function __construct(FederatedEvent $federatedEvent, array $results) {
-		parent::__construct($federatedEvent, $results);
+	public function __construct(array $memberships) {
+		parent::__construct();
+
+		$this->memberships = $memberships;
 	}
 
 
 	/**
-	 * @param int $type
-	 *
-	 * @return $this
+	 * @return Membership[]
 	 */
-	public function setType(int $type): self {
-		$this->type = $type;
-
-		return $this;
-	}
-
-	/**
-	 * @return int
-	 */
-	public function getType(): int {
-		return $this->type;
+	public function getMemberships(): array {
+		return $this->memberships;
 	}
 
 }

--- a/lib/Events/RequestingCircleMemberEvent.php
+++ b/lib/Events/RequestingCircleMemberEvent.php
@@ -36,22 +36,21 @@ use OCA\Circles\Model\Federated\FederatedEvent;
 
 
 /**
- * Class RemovingCircleMemberEvent
+ * Class RequestingCircleMemberEvent
  *
- * This event is called when a member is removed from a Circle.
+ * This event is called when one or multiple members are requesting/invited to a Circle.
  * This event is called on every instance of Nextcloud related to the Circle.
  *
- * The entry is already removed from the members table.
- * The memberships of the member are already removed from the memberships table.
+ * The entry is already generated in the members table.
  *
- * This is a good place if anything needs to be executed when a member have been removed from a Circle.
+ * This is a good place if anything needs to be executed when a member requests or is invited to a Circle.
  *
- * If anything needs to be managed on the master instance of the Circle (ie. CircleMemberRemovedEvent), please use:
+ * If anything needs to be managed on the master instance of the Circle (ie. CircleMemberRequestedEvent), please use:
  *    $event->getFederatedEvent()->addResult(string $key, array $data);
  *
  * @package OCA\Circles\Events
  */
-class RemovingCircleMemberEvent extends CircleMemberGenericEvent {
+class RequestingCircleMemberEvent extends CircleMemberGenericEvent {
 
 
 	/** @var int */
@@ -59,7 +58,7 @@ class RemovingCircleMemberEvent extends CircleMemberGenericEvent {
 
 
 	/**
-	 * RemovingCircleMemberEvent constructor.
+	 * RequestingCircleMemberEvent constructor.
 	 *
 	 * @param FederatedEvent $federatedEvent
 	 */

--- a/lib/FederatedItems/CircleEdit.php
+++ b/lib/FederatedItems/CircleEdit.php
@@ -39,6 +39,7 @@ use OCA\Circles\IFederatedItem;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Model\Helpers\MemberHelper;
 use OCA\Circles\Service\CircleService;
+use OCA\Circles\Service\EventService;
 
 
 /**
@@ -58,15 +59,25 @@ class CircleEdit implements IFederatedItem {
 	/** @var CircleService */
 	private $circleService;
 
+	/** @var EventService */
+	private $eventService;
+
+
 	/**
 	 * CircleEdit constructor.
 	 *
 	 * @param CircleRequest $circleRequest
 	 * @param CircleService $circleService
+	 * @param EventService $eventService
 	 */
-	public function __construct(CircleRequest $circleRequest, CircleService $circleService) {
+	public function __construct(
+		CircleRequest $circleRequest,
+		CircleService $circleService,
+		EventService $eventService
+	) {
 		$this->circleRequest = $circleRequest;
 		$this->circleService = $circleService;
+		$this->eventService = $eventService;
 	}
 
 
@@ -120,6 +131,7 @@ class CircleEdit implements IFederatedItem {
 		}
 
 		$this->circleRequest->edit($circle);
+		$this->eventService->circleEditing($event);
 	}
 
 
@@ -128,6 +140,7 @@ class CircleEdit implements IFederatedItem {
 	 * @param array $results
 	 */
 	public function result(FederatedEvent $event, array $results): void {
+		$this->eventService->circleEdited($event, $results);
 	}
 
 }

--- a/lib/FederatedItems/CircleJoin.php
+++ b/lib/FederatedItems/CircleJoin.php
@@ -257,7 +257,12 @@ class CircleJoin implements
 
 		$this->memberRequest->save($member);
 		$this->membershipService->onUpdate($member->getSingleId());
+
+		if ($member->getStatus() === Member::STATUS_REQUEST) {
+			$this->eventService->memberRequesting($event);
+		} else {
 		$this->eventService->memberJoining($event);
+		}
 	}
 
 
@@ -266,7 +271,12 @@ class CircleJoin implements
 	 * @param array $results
 	 */
 	public function result(FederatedEvent $event, array $results): void {
-		$this->eventService->memberJoined($event, $results);
+		$member = $event->getMember();
+		if ($member->getStatus() === Member::STATUS_REQUEST) {
+			$this->eventService->memberRequested($event, $results);
+		} else {
+			$this->eventService->memberJoined($event, $results);
+		}
 	}
 
 

--- a/lib/FederatedItems/MemberDisplayName.php
+++ b/lib/FederatedItems/MemberDisplayName.php
@@ -38,9 +38,11 @@ use OCA\Circles\Exceptions\FederatedItemBadRequestException;
 use OCA\Circles\Exceptions\FederatedItemException;
 use OCA\Circles\Exceptions\MemberLevelException;
 use OCA\Circles\IFederatedItem;
+use OCA\Circles\IFederatedItemHighSeverity;
 use OCA\Circles\IFederatedItemMemberEmpty;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\EventService;
 use OCA\Circles\Service\MembershipService;
 use OCA\Circles\StatusCode;
 
@@ -52,6 +54,7 @@ use OCA\Circles\StatusCode;
  */
 class MemberDisplayName implements
 	IFederatedItem,
+	IFederatedItemHighSeverity,
 	IFederatedItemMemberEmpty {
 
 
@@ -64,6 +67,9 @@ class MemberDisplayName implements
 	/** @var MembershipService */
 	private $membershipService;
 
+	/** @var EventService */
+	private $eventService;
+
 	/** @var ConfigService */
 	private $configService;
 
@@ -73,15 +79,18 @@ class MemberDisplayName implements
 	 *
 	 * @param MemberRequest $memberRequest
 	 * @param MembershipService $membershipService
+	 * @param EventService $eventService
 	 * @param ConfigService $configService
 	 */
 	public function __construct(
 		MemberRequest $memberRequest,
 		MembershipService $membershipService,
+		EventService $eventService,
 		ConfigService $configService
 	) {
 		$this->memberRequest = $memberRequest;
 		$this->membershipService = $membershipService;
+		$this->eventService = $eventService;
 		$this->configService = $configService;
 	}
 
@@ -121,6 +130,8 @@ class MemberDisplayName implements
 
 		$member->setDisplayName($displayName);
 		$this->memberRequest->updateDisplayName($member->getSingleId(), $displayName, $circle->getSingleId());
+
+		$this->eventService->memberNameEditing($event);
 	}
 
 
@@ -129,6 +140,7 @@ class MemberDisplayName implements
 	 * @param array $results
 	 */
 	public function result(FederatedEvent $event, array $results): void {
+		$this->eventService->memberNameEdited($event, $results);
 	}
 
 }

--- a/lib/FederatedItems/MemberLevel.php
+++ b/lib/FederatedItems/MemberLevel.php
@@ -39,12 +39,14 @@ use OCA\Circles\Exceptions\FederatedItemException;
 use OCA\Circles\Exceptions\MemberLevelException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\IFederatedItem;
+use OCA\Circles\IFederatedItemHighSeverity;
 use OCA\Circles\IFederatedItemMemberRequired;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Model\Helpers\MemberHelper;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\EventService;
 use OCA\Circles\Service\MembershipService;
 
 
@@ -55,6 +57,7 @@ use OCA\Circles\Service\MembershipService;
  */
 class MemberLevel implements
 	IFederatedItem,
+	IFederatedItemHighSeverity,
 	IFederatedItemMemberRequired {
 
 
@@ -67,6 +70,9 @@ class MemberLevel implements
 	/** @var MembershipService */
 	private $membershipService;
 
+	/** @var EventService */
+	private $eventService;
+
 	/** @var ConfigService */
 	private $configService;
 
@@ -76,15 +82,18 @@ class MemberLevel implements
 	 *
 	 * @param MemberRequest $memberRequest
 	 * @param MembershipService $membershipService
+	 * @param EventService $eventService
 	 * @param ConfigService $configService
 	 */
 	public function __construct(
 		MemberRequest $memberRequest,
 		MembershipService $membershipService,
+		EventService $eventService,
 		ConfigService $configService
 	) {
 		$this->memberRequest = $memberRequest;
 		$this->membershipService = $membershipService;
+		$this->eventService = $eventService;
 		$this->configService = $configService;
 	}
 
@@ -149,6 +158,8 @@ class MemberLevel implements
 		}
 
 		$this->membershipService->onUpdate($member->getSingleId());
+
+		$this->eventService->memberLevelEditing($event);
 	}
 
 
@@ -157,6 +168,7 @@ class MemberLevel implements
 	 * @param array $results
 	 */
 	public function result(FederatedEvent $event, array $results): void {
+		$this->eventService->memberLevelEdited($event, $results);
 	}
 
 

--- a/lib/FederatedItems/SingleMemberAdd.php
+++ b/lib/FederatedItems/SingleMemberAdd.php
@@ -447,7 +447,9 @@ class SingleMemberAdd implements
 	 *
 	 * @throws FederatedItemBadRequestException
 	 * @throws FederatedUserException
+	 * @throws RemoteNotFoundException
 	 * @throws RequestBuilderException
+	 * @throws UnknownRemoteException
 	 */
 	private function confirmPatron(FederatedEvent $event, Member $member): void {
 		if (!$member->hasInvitedBy()) {
@@ -459,7 +461,7 @@ class SingleMemberAdd implements
 			throw new FederatedItemBadRequestException(StatusCode::$MEMBER_ADD[130], 130);
 		}
 
-//		$this->federatedUserService->confirmLocalSingleId($patron);
+		$this->federatedUserService->confirmSingleIdUniqueness($patron);
 	}
 
 
@@ -468,7 +470,9 @@ class SingleMemberAdd implements
 	 *
 	 * @return bool
 	 * @throws InvalidIdException
+	 * @throws RemoteNotFoundException
 	 * @throws RequestBuilderException
+	 * @throws UnknownRemoteException
 	 */
 	protected function insertOrUpdate(Member $member): bool {
 		try {

--- a/lib/FederatedItems/SingleMemberAdd.php
+++ b/lib/FederatedItems/SingleMemberAdd.php
@@ -225,15 +225,16 @@ class SingleMemberAdd implements
 	 */
 	public function manage(FederatedEvent $event): void {
 		$member = $event->getMember();
-//		$member->setNoteObj('invitedBy', $member->getInvitedBy());
 
-
-//		$this->federatedUserService->confirmSingleIdUniqueness($member);
 		if (!$this->insertOrUpdate($member)) {
 			return;
 		}
 
-		$this->eventService->singleMemberAdding($event);
+		if ($member->getStatus() === Member::STATUS_INVITED) {
+			$this->eventService->memberInviting($event);
+		} else {
+			$this->eventService->memberAdding($event);
+		}
 
 //
 //		//
@@ -264,7 +265,12 @@ class SingleMemberAdd implements
 	 * @param array $results
 	 */
 	public function result(FederatedEvent $event, array $results): void {
-		$this->eventService->singleMemberAdded($event, $results);
+		$member = $event->getMember();
+		if ($member->getStatus() === Member::STATUS_INVITED) {
+			$this->eventService->memberInvited($event, $results);
+		} else {
+			$this->eventService->memberAdded($event, $results);
+		}
 
 //		$password = $cachedName = '';
 //		$circle = $member = null;

--- a/lib/Listeners/Examples/ExampleRequestingCircleMember.php
+++ b/lib/Listeners/Examples/ExampleRequestingCircleMember.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2021
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\Listeners\Examples;
+
+
+use daita\MySmallPhpTools\Traits\Nextcloud\nc22\TNC22Logger;
+use OCA\Circles\AppInfo\Application;
+use OCA\Circles\Events\CircleGenericEvent;
+use OCA\Circles\Events\RequestingCircleMemberEvent;
+use OCA\Circles\Model\Member;
+use OCA\Circles\Service\ConfigService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+
+/**
+ * Class ExampleRequestingCircleMember
+ *
+ * @package OCA\Circles\Listeners\Examples
+ */
+class ExampleRequestingCircleMember implements IEventListener {
+
+
+	use TNC22Logger;
+
+
+	/** @var ConfigService */
+	private $configService;
+
+
+	/**
+	 * ExampleRequestingCircleMember constructor.
+	 *
+	 * @param ConfigService $configService
+	 */
+	public function __construct(ConfigService $configService) {
+		$this->configService = $configService;
+
+		$this->setup('app', Application::APP_ID);
+	}
+
+
+	/**
+	 * @param Event $event
+	 */
+	public function handle(Event $event): void {
+		if (!$event instanceof RequestingCircleMemberEvent) {
+			return;
+		}
+
+		if ($this->configService->getAppValue(ConfigService::EVENT_EXAMPLES) !== '1') {
+			return;
+		}
+
+		$prefix = '[Example Event] (ExampleRequestingCircleMember) ';
+
+		if ($event->getType() === CircleGenericEvent::INVITED) {
+			$info = 'A new member have been invited to a Circle. ';
+		} else {
+			$info = 'A new member is requesting to join a Circle. ';
+		}
+
+		$circle = $event->getCircle();
+		$member = $event->getMember();
+		$info .= 'circleId: ' . $circle->getSingleId() . '; userId: ' . $member->getUserId() . '; userType: '
+				 . Member::$TYPE[$member->getUserType()] . '; singleId: ' . $member->getSingleId()
+				 . '; memberId: ' . $member->getId() . '; isLocal: ' . json_encode($member->isLocal()) . '; ';
+
+		$this->log(3, $prefix . $info);
+	}
+
+}
+

--- a/lib/Listeners/Files/AddingMember.php
+++ b/lib/Listeners/Files/AddingMember.php
@@ -32,7 +32,6 @@ declare(strict_types=1);
 namespace OCA\Circles\Listeners\Files;
 
 
-use daita\MySmallPhpTools\Model\SimpleDataStore;
 use daita\MySmallPhpTools\Traits\TStringTools;
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Exceptions\RequestBuilderException;
@@ -78,10 +77,9 @@ class AddingMember implements IEventListener {
 		}
 
 		$bypass = true;
-		foreach ($event->getMembers() as $member) {
-			if ($member->getUserType() === Member::TYPE_MAIL) {
-				$bypass = false;
-			}
+		$member = $event->getMember();
+		if ($member->getUserType() === Member::TYPE_MAIL) {
+			$bypass = false;
 		}
 
 		if ($bypass) {

--- a/lib/Listeners/Files/MemberAdded.php
+++ b/lib/Listeners/Files/MemberAdded.php
@@ -59,10 +59,9 @@ class MemberAdded implements IEventListener {
 		}
 
 		$federatedUsers = [];
-		foreach ($event->getMembers() as $member) {
-			if ($member->getUserType() === Member::TYPE_MAIL) {
-				$federatedUsers[] = $member;
-			}
+		$member = $event->getMember();
+		if ($member->getUserType() === Member::TYPE_MAIL) {
+			$federatedUsers[] = $member;
 		}
 
 		if (empty($federatedUsers)) {

--- a/lib/Listeners/Notifications/RequestingMember.php
+++ b/lib/Listeners/Notifications/RequestingMember.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2021
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\Listeners\Notifications;
+
+
+use OCA\Circles\Events\RequestingCircleMemberEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+
+/**
+ * Class RequestingMember
+ *
+ * @package OCA\Circles\Listeners\Notifications
+ */
+class RequestingMember implements IEventListener {
+
+
+	/**
+	 * RequestingMember constructor.
+	 */
+	public function __construct() {
+	}
+
+
+	/**
+	 * @param Event $event
+	 */
+	public function handle(Event $event): void {
+		if (!$event instanceof RequestingCircleMemberEvent) {
+			return;
+		}
+
+	}
+
+}
+

--- a/lib/Model/Federated/FederatedEvent.php
+++ b/lib/Model/Federated/FederatedEvent.php
@@ -480,6 +480,15 @@ class FederatedEvent implements JsonSerializable {
 	}
 
 	/**
+	 * @return $this
+	 */
+	public function resetResult(): self {
+		$this->result = new SimpleDataStore();
+
+		return $this;
+	}
+
+	/**
 	 * @param string $key
 	 * @param array $result
 	 *

--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -364,7 +364,6 @@ class CircleService {
 			$this->federatedUserService->setMemberPatron($circle->getInitiator());
 		}
 
-		echo json_encode($circle, JSON_PRETTY_PRINT);
 		$event = new FederatedEvent(CircleJoin::class);
 		$event->setCircle($circle);
 

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -36,6 +36,8 @@ namespace OCA\Circles\Service;
 
 
 use daita\MySmallPhpTools\Model\SimpleDataStore;
+use daita\MySmallPhpTools\Traits\Nextcloud\nc22\TNC22Logger;
+use OCA\Circles\AppInfo\Application;
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleCreatedEvent;
 use OCA\Circles\Events\CircleDestroyedEvent;
@@ -68,6 +70,9 @@ use OCP\EventDispatcher\IEventDispatcher;
 class EventService {
 
 
+	use TNC22Logger;
+
+
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
@@ -79,6 +84,8 @@ class EventService {
 	 */
 	public function __construct(IEventDispatcher $eventDispatcher) {
 		$this->eventDispatcher = $eventDispatcher;
+
+		$this->setup('app', Application::APP_ID);
 	}
 
 
@@ -152,28 +159,6 @@ class EventService {
 	public function memberAdded(FederatedEvent $federatedEvent, array $results): void {
 		$event = new CircleMemberAddedEvent($federatedEvent, $results);
 		$event->setType(CircleGenericEvent::INVITED);
-		$this->eventDispatcher->dispatchTyped($event);
-	}
-
-
-	/**
-	 * @deprecated
-	 * @param FederatedEvent $federatedEvent
-	 */
-	public function multipleMemberAdding(FederatedEvent $federatedEvent): void {
-		$event = new AddingCircleMemberEvent($federatedEvent);
-		$event->setType(CircleGenericEvent::MULTIPLE);
-		$this->eventDispatcher->dispatchTyped($event);
-	}
-
-	/**
-	 * @deprecated
-	 * @param FederatedEvent $federatedEvent
-	 * @param array $results
-	 */
-	public function multipleMemberAdded(FederatedEvent $federatedEvent, array $results): void {
-		$event = new CircleMemberAddedEvent($federatedEvent, $results);
-		$event->setType(CircleGenericEvent::MULTIPLE);
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
@@ -348,6 +333,7 @@ class EventService {
 
 	/**
 	 * @param ShareWrapper $wrappedShare
+	 * @param Mount $mount
 	 */
 	public function federatedShareCreated(ShareWrapper $wrappedShare, Mount $mount): void {
 //		Circles::shareToCircle(

--- a/lib/Service/RemoteDownstreamService.php
+++ b/lib/Service/RemoteDownstreamService.php
@@ -155,7 +155,8 @@ class RemoteDownstreamService {
 		}
 
 		$event->setOrigin($event->getSender());
-		$event->resetData();
+		$event->resetData()
+			  ->resetResult();
 
 		$this->federatedEventService->confirmInitiator($event, false);
 		$this->confirmContent($event, true);


### PR DESCRIPTION
- more events regarding edit on members
- the idea is to remove the 'massive members add' event as it will be unmanageable in some use-case. 
- WIP: need to check what would happens on duplicate single on a remote instance if we keep the faulty members in the event