### PR TITLE
Bypass initiator from 'membership' using direct 'member'

### DIFF
--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -174,8 +174,9 @@ class CircleRequest extends CircleRequestBuilder {
 		$qb->setOptions(
 			[CoreQueryBuilder::CIRCLE],
 			[
-				'getData'      => true,
-				'mustBeMember' => $params->gBool('mustBeMember')
+				'getData'               => true,
+				'mustBeMember'          => $params->gBool('mustBeMember'),
+				'initiatorDirectMember' => true
 			]
 		);
 
@@ -239,7 +240,14 @@ class CircleRequest extends CircleRequestBuilder {
 		int $filter = Circle::CFG_BACKEND | Circle::CFG_SINGLE | Circle::CFG_HIDDEN
 	): Circle {
 		$qb = $this->getCircleSelectSql();
-		$qb->setOptions([CoreQueryBuilder::CIRCLE], ['getData' => true, 'canBeVisitor' => true]);
+		$qb->setOptions(
+			[CoreQueryBuilder::CIRCLE],
+			[
+				'getData'               => true,
+				'canBeVisitor'          => true,
+				'initiatorDirectMember' => true
+			]
+		);
 
 		$qb->limitToUniqueId($id);
 		$qb->filterCircles(CoreQueryBuilder::CIRCLE, $filter);

--- a/lib/Model/Circle.php
+++ b/lib/Model/Circle.php
@@ -189,6 +189,9 @@ class Circle extends ManagedModel implements IMemberships, IDeserializable, INC2
 	/** @var Member */
 	private $initiator;
 
+	/** @var Member */
+	private $directInitiator;
+
 	/** @var array */
 	private $settings = [];
 
@@ -516,6 +519,13 @@ class Circle extends ManagedModel implements IMemberships, IDeserializable, INC2
 	 * @return Member
 	 */
 	public function getInitiator(): Member {
+		if (is_null($this->initiator)
+			|| ($this->initiator->getId() === ''
+				&& !is_null($this->directInitiator)
+				&& $this->directInitiator->getId() !== '')) {
+			return $this->directInitiator;
+		}
+
 		return $this->initiator;
 	}
 
@@ -523,8 +533,20 @@ class Circle extends ManagedModel implements IMemberships, IDeserializable, INC2
 	 * @return bool
 	 */
 	public function hasInitiator(): bool {
-		return ($this->initiator !== null);
+		return (!is_null($this->initiator) || !is_null($this->directInitiator));
 	}
+
+	/**
+	 * @param Member|null $directInitiator
+	 *
+	 * @return $this
+	 */
+	public function setDirectInitiator(?Member $directInitiator): self {
+		$this->directInitiator = $directInitiator;
+
+		return $this;
+	}
+
 
 	/**
 	 * @param string $instance

--- a/lib/Model/ModelManager.php
+++ b/lib/Model/ModelManager.php
@@ -237,6 +237,15 @@ class ModelManager {
 				} catch (MemberNotFoundException $e) {
 				}
 				break;
+
+			case CoreQueryBuilder::DIRECT_INITIATOR;
+				try {
+					$directInitiator = new Member();
+					$directInitiator->importFromDatabase($data, $prefix);
+					$circle->setDirectInitiator($directInitiator);
+				} catch (MemberNotFoundException $e) {
+				}
+				break;
 		}
 	}
 


### PR DESCRIPTION
The idea is to keep the basic request (getCircles & getMembers) working even if the table 'membership' is emptied, using direct link between initiator and the table 'member', instead of only using the table 'membership' to manage complete inheritance