### PR TITLE
Throw instead of doing nothing

### DIFF
--- a/lib/Api/v1/Circles.php
+++ b/lib/Api/v1/Circles.php
@@ -212,10 +212,7 @@ class Circles {
 	 *
 	 */
 	public static function getMember($circleUniqueId, $ident, $type, $forceAll = false) {
-//		$c = self::getContainer();
-//
-//		return $c->query(MembersService::class)
-//				 ->getMember($circleUniqueId, $ident, $type, $forceAll);
+		throw new \BadMethodCallException('Method is deprecated and not longer works');
 	}
 
 
@@ -232,9 +229,6 @@ class Circles {
 	 *
 	 */
 	public static function getFilesForCircles($circleUniqueIds) {
-//		$c = self::getContainer();
-//
-//		return $c->query(CirclesService::class)
-//				 ->getFilesForCircles($circleUniqueIds);
+		throw new \BadMethodCallException('Method is deprecated and not longer works');
 	}
 }


### PR DESCRIPTION
getMember used to throw an exception in case the circle didn't exist or user was not a member, so in order to avoid misbehaviour we should at least throw something instead of just a noop and return.