### PR TITLE
members cannot directly join a Secret Circle

### DIFF
--- a/lib/Model/Member.php
+++ b/lib/Model/Member.php
@@ -63,10 +63,10 @@ class Member extends BaseMember {
 	public function joinCircle($circleType) {
 
 		switch ($circleType) {
-			case Circle::CIRCLES_SECRET:
 			case Circle::CIRCLES_PUBLIC:
 				return $this->addMemberToCircle();
 
+			case Circle::CIRCLES_SECRET:
 			case Circle::CIRCLES_CLOSED:
 				return $this->joinClosedCircle();
 		}


### PR DESCRIPTION
Because the name of a secret circle might be discovered, a new member cannot directly join it (working like a closed circle)