### PR TITLE
Check if `$knownPath` is set before invoking `rtrim()`

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -694,7 +694,7 @@ class ConfigService {
 			$knownPath = OC::$WEBROOT;
 		}
 
-		$knownPath = rtrim($knownPath, '/');
+		$knownPath = $knownPath ? rtrim($knownPath, '/') : '';
 		if ($knownPath === '') {
 			return $path;
 		}


### PR DESCRIPTION
`$knownPath` may by `null` in `ConfigService->linkToRoute()`. `rtrim()`
requires a string as first argument.

Fixes: #774
Signed-off-by: Jonas Meurer <jonas@freesources.org>