### PR TITLE
fix definition on single circles

### DIFF
--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -618,7 +618,8 @@ class CircleService {
 	 */
 	public function getDefinition(Circle $circle): string {
 		$source = Circle::$DEF_SOURCE[$circle->getSource()];
-		if ($circle->isConfig(Circle::CFG_NO_OWNER)) {
+		if ($circle->isConfig(Circle::CFG_NO_OWNER)
+			|| $circle->isConfig(Circle::CFG_SINGLE)) {
 			return $this->l10n->t('%s', [$source]);
 		}
 


### PR DESCRIPTION
The current definition returns 'Nextcloud User owned by userId'.
This will only returns 'Nextcloud User'
