### PR TITLE
owner of NO_OWNER should not have memberships cached

### DIFF
--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -355,7 +355,12 @@ class CircleRequest extends CircleRequestBuilder {
 		}
 
 		if (!is_null($initiator)) {
-			$qb->setOptions([CoreQueryBuilder::CIRCLE], ['getData' => true]);
+			$qb->setOptions(
+				[CoreQueryBuilder::CIRCLE], [
+					'getData' => true,
+					'initiatorDirectMember' => true
+				]
+			);
 			$qb->limitToInitiator(CoreQueryBuilder::CIRCLE, $initiator);
 		}
 

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -126,6 +126,7 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 				self::MEMBERSHIPS => [
 					self::CONFIG
 				],
+				self::DIRECT_INITIATOR,
 				self::INITIATOR => [
 					self::OPTIONS => [
 						'minimumLevel' => Member::LEVEL_MEMBER
@@ -1156,13 +1157,36 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 			)
 		);
 
+
+		$listMembershipCircleAlias = [$aliasMembership];
+		if ($this->getBool('initiatorDirectMember', $options, false)) {
+			try {
+				$aliasDirectInitiator = $this->generateAlias($alias, self::DIRECT_INITIATOR, $options);
+				$listMembershipCircleAlias[] = $aliasDirectInitiator;
+			} catch (RequestBuilderException $e) {
+			}
+		}
+
 		try {
 			$aliasMembershipCircle = $this->generateAlias($aliasMembership, self::CONFIG, $options);
+			$orXMembershipCircle = $expr->orX();
+			array_map(
+				function (string $alias) use ($orXMembershipCircle, $aliasMembershipCircle) {
+					$orXMembershipCircle->add(
+						$this->expr()->eq(
+							$alias . '.circle_id',
+							$aliasMembershipCircle . '.unique_id'
+						)
+					);
+				},
+				$listMembershipCircleAlias
+			);
+
 			$this->leftJoin(
 				$aliasMembership,
 				CoreRequestBuilder::TABLE_CIRCLE,
 				$aliasMembershipCircle,
-				$expr->eq($aliasMembership . '.circle_id', $aliasMembershipCircle . '.unique_id')
+				$orXMembershipCircle
 			);
 		} catch (RequestBuilderException $e) {
 		}
@@ -1264,13 +1288,27 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 
 		$minimumLevel = $this->getInt('minimumLevel', $options);
 		$andXMember = $expr->andX();
-		$andXMember->add(
-			$this->orXCheckLevel($levelCheck, $minimumLevel)
+		$orXLevelCheck = $expr->orX();
+
+		array_map(
+			function (string $alias) use ($orXLevelCheck, $minimumLevel) {
+				$orXLevelCheck->add(
+					$this->expr()->gte(
+						$alias . '.level',
+						$this->createNamedParameter($minimumLevel)
+					)
+				);
+			},
+			$levelCheck
 		);
+		$andXMember->add($orXLevelCheck);
 
 		if (!$this->getBool('includePersonalCircles', $options, false)) {
 			$andXMember->add(
-				$this->exprFilterBitwise('config', Circle::CFG_PERSONAL, $aliasMembershipCircle)
+				$this->exprFilterBitwise(
+					'config', Circle::CFG_PERSONAL,
+					$aliasMembershipCircle
+				)
 			);
 		}
 		$orX->add($andXMember);
@@ -1624,22 +1662,5 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 		}
 
 		return $path;
-	}
-
-
-	/**
-	 * @param array $aliases
-	 * @param int $level
-	 *
-	 * @return ICompositeExpression
-	 */
-	private function orXCheckLevel(array $aliases, int $level): ICompositeExpression {
-		$expr = $this->expr();
-		$orX = $expr->orX();
-		foreach ($aliases as $alias) {
-			$orX->add($expr->gte($alias . '.level', $this->createNamedParameter($level)));
-		}
-
-		return $orX;
 	}
 }

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1164,6 +1164,7 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 				$aliasDirectInitiator = $this->generateAlias($alias, self::DIRECT_INITIATOR, $options);
 				$listMembershipCircleAlias[] = $aliasDirectInitiator;
 			} catch (RequestBuilderException $e) {
+				// meaning that this path does not require DIRECT_INITIATOR; can be safely ignored
 			}
 		}
 
@@ -1189,6 +1190,7 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 				$orXMembershipCircle
 			);
 		} catch (RequestBuilderException $e) {
+			// meaning that this path (ie. self::$SQL_PATH) does not require CONFIG; can be safely ignored
 		}
 
 		if (!$this->getBool('getData', $options, false)) {
@@ -1199,7 +1201,6 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 		if ($this->getBool('initiatorDirectMember', $options, false)) {
 			try {
 				$aliasDirectInitiator = $this->generateAlias($alias, self::DIRECT_INITIATOR, $options);
-
 				$this->generateMemberSelectAlias($aliasDirectInitiator)
 					 ->leftJoin(
 						 $helperAlias,
@@ -1211,6 +1212,7 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 						 )
 					 );
 			} catch (RequestBuilderException $e) {
+				// meaning that this path does not require DIRECT_INITIATOR; can be safely ignored
 			}
 		}
 

--- a/lib/Model/Probes/MemberProbe.php
+++ b/lib/Model/Probes/MemberProbe.php
@@ -34,7 +34,7 @@ namespace OCA\Circles\Model\Probes;
 use OCA\Circles\Model\Member;
 
 /**
- * Class CircleProbe
+ * Class MemberProbe
  *
  * @package OCA\Circles\Model\Probes
  */
@@ -49,6 +49,9 @@ class MemberProbe extends BasicProbe {
 
 	/** @var bool */
 	private $requestingMembership = false;
+
+	/** @var bool */
+	private $initiatorDirectMember = false;
 
 
 	/**
@@ -69,6 +72,25 @@ class MemberProbe extends BasicProbe {
 	 */
 	public function isRequestingMembership(): bool {
 		return $this->requestingMembership;
+	}
+
+
+	/**
+	 * @param bool $include
+	 *
+	 * @return $this
+	 */
+	public function initiatorAsDirectMember(bool $include = true): self {
+		$this->initiatorDirectMember = $include;
+
+		return $this;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function directMemberInitiator(): bool {
+		return $this->initiatorDirectMember;
 	}
 
 
@@ -144,7 +166,8 @@ class MemberProbe extends BasicProbe {
 			[
 				'minimumLevel' => $this->getMinimumLevel(),
 				'emulateVisitor' => $this->isEmulatingVisitor(),
-				'allowRequestingMembership' => $this->isRequestingMembership()
+				'allowRequestingMembership' => $this->isRequestingMembership(),
+				'initiatorDirectMember' => $this->directMemberInitiator(),
 			],
 			parent::getAsOptions()
 		);

--- a/lib/Service/MemberService.php
+++ b/lib/Service/MemberService.php
@@ -178,6 +178,7 @@ class MemberService {
 		if ($this->federatedUserService->hasRemoteInstance()) {
 			$probe->setFilterRemoteInstance($this->federatedUserService->getRemoteInstance());
 		}
+		$probe->initiatorAsDirectMember();
 		$probe->mustBeMember();
 
 		return $this->memberRequest->getMembers(

--- a/lib/Service/MembershipService.php
+++ b/lib/Service/MembershipService.php
@@ -40,6 +40,7 @@ use OCA\Circles\Exceptions\FederatedUserNotFoundException;
 use OCA\Circles\Exceptions\MembershipNotFoundException;
 use OCA\Circles\Exceptions\OwnerNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\FederatedUser;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Membership;
@@ -139,6 +140,7 @@ class MembershipService {
 	/**
 	 * @param string $circleId
 	 * @param string $singleId
+	 * @param bool $detailed
 	 *
 	 * @return Membership
 	 * @throws MembershipNotFoundException
@@ -196,6 +198,11 @@ class MembershipService {
 		$members = $this->memberRequest->getMembersBySingleId($circleId);
 		foreach ($members as $member) {
 			if (!$member->hasCircle() || $member->getLevel() < Member::LEVEL_MEMBER) {
+				continue;
+			}
+
+			if ($member->getCircle()->isConfig(Circle::CFG_NO_OWNER)
+				&& $member->getLevel() === Member::LEVEL_OWNER) {
 				continue;
 			}
 


### PR DESCRIPTION
If we keep caching memberships of owner of NO_OWNER Circles, the owner will be returned on `getInheritedMembers()`.

This PR will fix this while keeping the sql request from failing when searching for existing Circles based on a FederatedUser used as Owner of a NO_OWNER Circle