### PR TITLE
force join_request on old secret circles

### DIFF
--- a/lib/Service/MigrationService.php
+++ b/lib/Service/MigrationService.php
@@ -347,7 +347,7 @@ class MigrationService {
 				break;
 
 			case 2: // secret
-				$circle->setConfig(Circle::CFG_OPEN + Circle::CFG_CIRCLE);
+				$circle->setConfig(Circle::CFG_OPEN + Circle::CFG_REQUEST);
 				break;
 
 			case 4: // closed


### PR DESCRIPTION
Since 5a7ff3c713f246d8b5f5da72ee0540223ef6d79e Secret Circles on version prior to 22.x were requesting join request to be confirmed by a moderator.

Let's pass this settings during migration