### PR TITLE
Reduce the sleep time in test-dummy-token handler

### DIFF
--- a/lib/Controller/EventWrapperController.php
+++ b/lib/Controller/EventWrapperController.php
@@ -134,7 +134,7 @@ class EventWrapperController extends Controller {
 
 		// so circles:check can check async is fine
 		if ($token === 'test-dummy-token') {
-			sleep(5);
+			sleep(4);
 		}
 
 		// exit() or useless log will be generated


### PR DESCRIPTION
reduce this sleep delay from 5s to 4s to fix an issue with the `occ circles:check` command which uses a default 5s libcurl timeout.

See e.g. https://github.com/nextcloud/circles/issues/731#issuecomment-889963271