### PR TITLE
[stable21] Don't overwrite share_with on read

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -450,7 +450,7 @@ class ShareByCircleProvider extends CircleProviderRequest implements IShareProvi
 			$name = $data['circle_alt_name'];
 		}
 
-		$data['share_with'] =
+		$data['share_with_displayname'] =
 			sprintf(
 				'%s (%s, %s) [%s]', $name,
 				$this->l10n->t(Circle::TypeLongString($data['circle_type'])),


### PR DESCRIPTION
When reading with getSharesBy, the display name is extended to contain
the circle id.

It seems that this was written into the wrong property and would
overwrite the id that existed already in "share_with".

This fixes the discrepancy by storing the computed value in
"share_with_displayname".

Partial fix for https://github.com/nextcloud/server/issues/29059, please refer to that ticket for more context.

@ArtificialOwl was this a mistake or will this fix cause side effects ?

- [ ] forward port to stable22 and master's deprecated provider ?