### PR TITLE
enforce password on new share

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -40,8 +40,10 @@ use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleMemberAddedEvent;
 use OCA\Circles\Events\Files\CreatingFileShareEvent;
 use OCA\Circles\Events\Files\FileShareCreatedEvent;
+use OCA\Circles\Events\Files\PreparingFileShareEvent;
 use OCA\Circles\Events\MembershipsCreatedEvent;
 use OCA\Circles\Events\MembershipsRemovedEvent;
+use OCA\Circles\Events\PreparingCircleMemberEvent;
 use OCA\Circles\Events\RemovingCircleMemberEvent;
 use OCA\Circles\Events\RequestingCircleMemberEvent;
 use OCA\Circles\Handlers\WebfingerHandler;
@@ -52,7 +54,9 @@ use OCA\Circles\Listeners\Examples\ExampleMembershipsRemoved;
 use OCA\Circles\Listeners\Examples\ExampleRequestingCircleMember;
 use OCA\Circles\Listeners\Files\AddingMemberSendMail as ListenerFilesAddingMemberSendMail;
 use OCA\Circles\Listeners\Files\CreatingShareSendMail as ListenerFilesCreatingShareSendMail;
+use OCA\Circles\Listeners\Files\PreparingShareSendMail as ListenerFilesPreparingShareSendMail;
 use OCA\Circles\Listeners\Files\MemberAddedSendMail as ListenerFilesMemberAddedSendMail;
+use OCA\Circles\Listeners\Files\PreparingMemberSendMail as ListenerFilesPreparingMemberSendMail;
 use OCA\Circles\Listeners\Files\RemovingMember as ListenerFilesRemovingMember;
 use OCA\Circles\Listeners\Files\ShareCreatedSendMail as ListenerFilesShareCreatedSendMail;
 use OCA\Circles\Listeners\GroupCreated;
@@ -142,12 +146,20 @@ class Application extends App implements IBootstrap {
 
 		// Local Events (for Files/Shares/Notifications management)
 		$context->registerEventListener(
+			PreparingCircleMemberEvent::class,
+			ListenerFilesPreparingMemberSendMail::class
+		);
+		$context->registerEventListener(
 			AddingCircleMemberEvent::class,
 			ListenerFilesAddingMemberSendMail::class
 		);
 		$context->registerEventListener(
 			CircleMemberAddedEvent::class,
 			ListenerFilesMemberAddedSendMail::class
+		);
+		$context->registerEventListener(
+			PreparingFileShareEvent::class,
+			ListenerFilesPreparingShareSendMail::class
 		);
 		$context->registerEventListener(
 			CreatingFileShareEvent::class,

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1049,6 +1049,13 @@ class CoreQueryBuilder extends NC22ExtendedQueryBuilder {
 		$this->leftJoinShareToken($alias);
 
 		$aliasShareToken = $this->generateAlias($alias, self::TOKEN, $options);
+		$this->generateSelectAlias(
+			CoreRequestBuilder::$tables[CoreRequestBuilder::TABLE_TOKEN],
+			$aliasShareToken,
+			$aliasShareToken,
+			[]
+		);
+
 		$this->limit('token', $token, $aliasShareToken);
 	}
 

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -37,7 +37,7 @@ use OCA\Circles\IFederatedUser;
 use OCA\Circles\Model\Mount;
 
 /**
- * Class GSSharesRequest
+ * Class MountRequest
  *
  * @package OCA\Circles\Db
  */
@@ -49,8 +49,6 @@ class MountRequest extends MountRequestBuilder {
 	 * @param Mount $mount
 	 */
 	public function save(Mount $mount): void {
-		// TODO: fix hash
-		$hash = $this->token();
 		$qb = $this->getMountInsertSql();
 		$qb->setValue('circle_id', $qb->createNamedParameter($mount->getCircleId()))
 		   ->setValue('mount_id', $qb->createNamedParameter($mount->getMountId()))
@@ -58,7 +56,7 @@ class MountRequest extends MountRequestBuilder {
 		   ->setValue('token', $qb->createNamedParameter($mount->getToken()))
 		   ->setValue('parent', $qb->createNamedParameter($mount->getParent()))
 		   ->setValue('mountpoint', $qb->createNamedParameter($mount->getMountPoint()))
-		   ->setValue('mountpoint_hash', $qb->createNamedParameter($hash));
+		   ->setValue('mountpoint_hash', $qb->createNamedParameter(md5($mount->getMountPoint())));
 
 		$qb->execute();
 	}

--- a/lib/Events/Files/PreparingFileShareEvent.php
+++ b/lib/Events/Files/PreparingFileShareEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2021
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\Events\Files;
+
+use OCA\Circles\Events\CircleGenericEvent;
+use OCA\Circles\Model\Federated\FederatedEvent;
+use OCA\Circles\Model\Mount;
+
+/**
+ * Class PreparingFileShareEvent
+ *
+ * @package OCA\Circles\Events\Files
+ */
+class PreparingFileShareEvent extends CircleGenericEvent {
+
+
+	/** @var Mount */
+	private $mount;
+
+
+	/**
+	 * PreparingFileShareEvent constructor.
+	 *
+	 * @param FederatedEvent $federatedEvent
+	 */
+	public function __construct(FederatedEvent $federatedEvent) {
+		parent::__construct($federatedEvent);
+	}
+}

--- a/lib/Events/PreparingCircleMemberEvent.php
+++ b/lib/Events/PreparingCircleMemberEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2021
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\Events;
+
+use OCA\Circles\Model\Federated\FederatedEvent;
+
+/**
+ * Class PreparingCircleMemberEvent
+ *
+ * This event is called when one or multiple members are added to a Circle.
+ *
+ * This event is called on the master instance of the circle, before AddingCircleMemberEvent.
+ *
+ * @package OCA\Circles\Events
+ */
+class PreparingCircleMemberEvent extends CircleMemberGenericEvent {
+
+
+	/**
+	 * PreparingCircleMemberEvent constructor.
+	 *
+	 * @param FederatedEvent $federatedEvent
+	 */
+	public function __construct(FederatedEvent $federatedEvent) {
+		parent::__construct($federatedEvent);
+	}
+}

--- a/lib/FederatedItems/Files/FileShare.php
+++ b/lib/FederatedItems/Files/FileShare.php
@@ -32,7 +32,6 @@ declare(strict_types=1);
 namespace OCA\Circles\FederatedItems\Files;
 
 use ArtificialOwl\MySmallPhpTools\Exceptions\InvalidItemException;
-use ArtificialOwl\MySmallPhpTools\Exceptions\ItemNotFoundException;
 use ArtificialOwl\MySmallPhpTools\Exceptions\UnknownTypeException;
 use ArtificialOwl\MySmallPhpTools\Traits\Nextcloud\nc22\TNC22Logger;
 use ArtificialOwl\MySmallPhpTools\Traits\TStringTools;
@@ -94,24 +93,26 @@ class FileShare implements
 	 * @param FederatedEvent $event
 	 */
 	public function verify(FederatedEvent $event): void {
-		// TODO: check and improve
-		// TODO: Could we use a share lock ?
+		// TODO: check (origin of file ?) and improve
+		// TODO: Use a share lock
+
+		$this->eventService->fileSharePreparing($event);
 	}
 
 
 	/**
 	 * @param FederatedEvent $event
 	 *
+	 * @throws CircleNotFoundException
 	 * @throws InvalidItemException
 	 * @throws UnknownTypeException
-	 * @throws CircleNotFoundException
-	 * @throws ItemNotFoundException
 	 */
 	public function manage(FederatedEvent $event): void {
 		$mount = null;
 		if (!$this->configService->isLocalInstance($event->getOrigin())) {
 			/** @var ShareWrapper $wrappedShare */
 			$wrappedShare = $event->getParams()->gObj('wrappedShare', ShareWrapper::class);
+
 			$mount = new Mount();
 			$mount->fromShare($wrappedShare);
 			$mount->setMountId($this->token(15));

--- a/lib/FederatedItems/MassiveMemberAdd.php
+++ b/lib/FederatedItems/MassiveMemberAdd.php
@@ -81,6 +81,11 @@ class MassiveMemberAdd extends SingleMemberAdd implements
 
 		$event->setMembers($filtered);
 		$event->setOutcome($this->serializeArray($filtered));
+
+		foreach ($event->getMembers() as $member) {
+			$event->setMember($member);
+			$this->eventService->memberPreparing($event);
+		}
 	}
 
 

--- a/lib/FederatedItems/SingleMemberAdd.php
+++ b/lib/FederatedItems/SingleMemberAdd.php
@@ -76,9 +76,9 @@ use OCA\Circles\StatusCode;
 use OCP\IUserManager;
 
 /**
- * Class MemberAdd
+ * Class SingleMemberAdd
  *
- * @package OCA\Circles\GlobalScale
+ * @package OCA\Circles\FederatedItems
  */
 class SingleMemberAdd implements
 	IFederatedItem,
@@ -182,35 +182,7 @@ class SingleMemberAdd implements
 		$event->setMembers([$member]);
 		$event->setOutcome($this->serialize($member));
 
-		return;
-
-
-//		$member = $this->membersRequest->getFreshNewMember(
-//			$circle->getUniqueId(), $ident, $eventMember->getType(), $eventMember->getInstance()
-//		);
-//		$member->hasToBeInviteAble()
-//
-//		$this->membersService->addMemberBasedOnItsType($circle, $member);
-//
-//		$password = '';
-//		$sendPasswordByMail = false;
-//		if ($this->configService->enforcePasswordProtection($circle)) {
-//			if ($circle->getSetting('password_single_enabled') === 'true') {
-//				$password = $circle->getPasswordSingle();
-//			} else {
-//				$sendPasswordByMail = true;
-//				$password = $this->miscService->token(15);
-//			}
-//		}
-//
-//		$event->setData(
-//			new SimpleDataStore(
-//				[
-//					'password'       => $password,
-//					'passwordByMail' => $sendPasswordByMail
-//				]
-//			)
-//		);
+		$this->eventService->memberPreparing($event);
 	}
 
 
@@ -234,7 +206,7 @@ class SingleMemberAdd implements
 			$this->eventService->memberAdding($event);
 		}
 
-//
+
 //		//
 //		// TODO: verifiez comment se passe le cached name sur un member_add
 //		//

--- a/lib/Listeners/Files/CreatingShareSendMail.php
+++ b/lib/Listeners/Files/CreatingShareSendMail.php
@@ -114,8 +114,8 @@ class CreatingShareSendMail implements IEventListener {
 		}
 
 		$circle = $event->getCircle();
-
 		$federatedEvent = $event->getFederatedEvent();
+		$hashedPasswords = $federatedEvent->getParams()->gArray('hashedPasswords');
 
 		$result = [];
 		foreach ($circle->getInheritedMembers(false, true) as $member) {
@@ -136,7 +136,12 @@ class CreatingShareSendMail implements IEventListener {
 						throw new ShareWrapperNotFoundException();
 					}
 
-					$shareToken = $this->shareTokenService->generateShareToken($share, $member);
+					$shareToken = $this->shareTokenService->generateShareToken(
+						$share,
+						$member,
+						$this->get($member->getSingleId(), $hashedPasswords)
+					);
+
 					$share->setShareToken($shareToken);
 				} catch (Exception $e) {
 					$share = null;
@@ -149,6 +154,6 @@ class CreatingShareSendMail implements IEventListener {
 			];
 		}
 
-		$event->getFederatedEvent()->setResultEntry('info', $result);
+		$federatedEvent->setResultEntry('info', $result);
 	}
 }

--- a/lib/Listeners/Files/PreparingMemberSendMail.php
+++ b/lib/Listeners/Files/PreparingMemberSendMail.php
@@ -33,10 +33,14 @@ namespace OCA\Circles\Listeners\Files;
 
 use ArtificialOwl\MySmallPhpTools\Traits\Nextcloud\nc22\TNC22Logger;
 use ArtificialOwl\MySmallPhpTools\Traits\TStringTools;
-use Exception;
 use OCA\Circles\AppInfo\Application;
-use OCA\Circles\Events\AddingCircleMemberEvent;
+use OCA\Circles\Events\PreparingCircleMemberEvent;
+use OCA\Circles\Exceptions\FederatedItemException;
+use OCA\Circles\Exceptions\RemoteInstanceException;
+use OCA\Circles\Exceptions\RemoteNotFoundException;
+use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Service\ConfigService;
 use OCA\Circles\Service\ContactService;
@@ -44,16 +48,20 @@ use OCA\Circles\Service\ShareTokenService;
 use OCA\Circles\Service\ShareWrapperService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Security\IHasher;
 
 /**
- * Class AddingMemberSendMail
+ * Class PreparingMemberSendMail
  *
  * @package OCA\Circles\Listeners\Files
  */
-class AddingMemberSendMail implements IEventListener {
+class PreparingMemberSendMail implements IEventListener {
 	use TStringTools;
 	use TNC22Logger;
 
+
+	/** @var IHasher */
+	private $hasher;
 
 	/** @var ShareWrapperService */
 	private $shareWrapperService;
@@ -71,17 +79,20 @@ class AddingMemberSendMail implements IEventListener {
 	/**
 	 * AddingMember constructor.
 	 *
+	 * @param IHasher $hasher
 	 * @param ShareWrapperService $shareWrapperService
 	 * @param ShareTokenService $shareTokenService
 	 * @param ContactService $contactService
 	 * @param ConfigService $configService
 	 */
 	public function __construct(
+		IHasher $hasher,
 		ShareWrapperService $shareWrapperService,
 		ShareTokenService $shareTokenService,
 		ContactService $contactService,
 		ConfigService $configService
 	) {
+		$this->hasher = $hasher;
 		$this->shareWrapperService = $shareWrapperService;
 		$this->shareTokenService = $shareTokenService;
 		$this->contactService = $contactService;
@@ -95,9 +106,15 @@ class AddingMemberSendMail implements IEventListener {
 	 * @param Event $event
 	 *
 	 * @throws RequestBuilderException
+	 * @throws FederatedItemException
+	 * @throws RemoteInstanceException
+	 * @throws RemoteNotFoundException
+	 * @throws RemoteResourceNotFoundException
+	 * @throws UnknownRemoteException
 	 */
 	public function handle(Event $event): void {
-		if (!$event instanceof AddingCircleMemberEvent) {
+		if (!$event instanceof PreparingCircleMemberEvent
+			|| !$this->configService->enforcePasswordOnSharedFile()) {
 			return;
 		}
 
@@ -108,41 +125,24 @@ class AddingMemberSendMail implements IEventListener {
 			$members = [$member];
 		}
 
-		$circle = $event->getCircle();
 		$federatedEvent = $event->getFederatedEvent();
-		$shares = $this->shareWrapperService->getSharesToCircle($circle->getSingleId());
+		$clearPasswords = $federatedEvent->getInternal()->gArray('clearPasswords');
 		$hashedPasswords = $federatedEvent->getParams()->gArray('hashedPasswords');
 
-		$result = [];
 		foreach ($members as $member) {
-			if ($member->getUserType() !== Member::TYPE_MAIL
-				&& $member->getUserType() !== Member::TYPE_CONTACT
+			if (($member->getUserType() !== Member::TYPE_MAIL
+				 && $member->getUserType() !== Member::TYPE_CONTACT)
+				|| array_key_exists($member->getSingleId(), $clearPasswords)
 			) {
 				continue;
 			}
 
-			$files = [];
-			foreach ($shares as $share) {
-				try {
-					$shareToken = $this->shareTokenService->generateShareToken(
-						$share,
-						$member,
-						$this->get($member->getSingleId(), $hashedPasswords)
-					);
-				} catch (Exception $e) {
-					continue;
-				}
-
-				$share->setShareToken($shareToken);
-				$files[] = clone $share;
-			}
-
-			$result[$member->getId()] = [
-				'shares' => $files,
-				'mails' => $this->contactService->getMailAddressesFromMember($member)
-			];
+			$clearPassword = $this->token(14);
+			$clearPasswords[$member->getSingleId()] = $clearPassword;
+			$hashedPasswords[$member->getSingleId()] = $this->hasher->hash($clearPassword);
 		}
 
-		$federatedEvent->addResultEntry('files', $result);
+		$federatedEvent->getInternal()->aArray('clearPasswords', $clearPasswords);
+		$federatedEvent->getParams()->aArray('hashedPasswords', $hashedPasswords);
 	}
 }

--- a/lib/Listeners/Files/PreparingShareSendMail.php
+++ b/lib/Listeners/Files/PreparingShareSendMail.php
@@ -128,6 +128,7 @@ class PreparingShareSendMail implements IEventListener {
 				 && $member->getUserType() !== Member::TYPE_CONTACT)
 				|| array_key_exists($member->getSingleId(), $clearPasswords)
 			) {
+				// Ignore members that are not 'mail' or the one we already generated a password
 				continue;
 			}
 

--- a/lib/Listeners/Files/PreparingShareSendMail.php
+++ b/lib/Listeners/Files/PreparingShareSendMail.php
@@ -33,10 +33,14 @@ namespace OCA\Circles\Listeners\Files;
 
 use ArtificialOwl\MySmallPhpTools\Traits\Nextcloud\nc22\TNC22Logger;
 use ArtificialOwl\MySmallPhpTools\Traits\TStringTools;
-use Exception;
 use OCA\Circles\AppInfo\Application;
-use OCA\Circles\Events\AddingCircleMemberEvent;
+use OCA\Circles\Events\Files\PreparingFileShareEvent;
+use OCA\Circles\Exceptions\FederatedItemException;
+use OCA\Circles\Exceptions\RemoteInstanceException;
+use OCA\Circles\Exceptions\RemoteNotFoundException;
+use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Service\ConfigService;
 use OCA\Circles\Service\ContactService;
@@ -44,16 +48,20 @@ use OCA\Circles\Service\ShareTokenService;
 use OCA\Circles\Service\ShareWrapperService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Security\IHasher;
 
 /**
- * Class AddingMemberSendMail
+ * Class PreparingShareSendMail
  *
  * @package OCA\Circles\Listeners\Files
  */
-class AddingMemberSendMail implements IEventListener {
+class PreparingShareSendMail implements IEventListener {
 	use TStringTools;
 	use TNC22Logger;
 
+
+	/** @var IHasher */
+	private $hasher;
 
 	/** @var ShareWrapperService */
 	private $shareWrapperService;
@@ -69,19 +77,22 @@ class AddingMemberSendMail implements IEventListener {
 
 
 	/**
-	 * AddingMember constructor.
+	 * PreparingShareSendMail constructor.
 	 *
+	 * @param IHasher $hasher
 	 * @param ShareWrapperService $shareWrapperService
 	 * @param ShareTokenService $shareTokenService
 	 * @param ContactService $contactService
 	 * @param ConfigService $configService
 	 */
 	public function __construct(
+		IHasher $hasher,
 		ShareWrapperService $shareWrapperService,
 		ShareTokenService $shareTokenService,
 		ContactService $contactService,
 		ConfigService $configService
 	) {
+		$this->hasher = $hasher;
 		$this->shareWrapperService = $shareWrapperService;
 		$this->shareTokenService = $shareTokenService;
 		$this->contactService = $contactService;
@@ -94,55 +105,38 @@ class AddingMemberSendMail implements IEventListener {
 	/**
 	 * @param Event $event
 	 *
+	 * @throws FederatedItemException
+	 * @throws RemoteInstanceException
+	 * @throws RemoteNotFoundException
+	 * @throws RemoteResourceNotFoundException
 	 * @throws RequestBuilderException
+	 * @throws UnknownRemoteException
 	 */
 	public function handle(Event $event): void {
-		if (!$event instanceof AddingCircleMemberEvent) {
+		if (!$event instanceof PreparingFileShareEvent
+			|| !$this->configService->enforcePasswordOnSharedFile()) {
 			return;
-		}
-
-		$member = $event->getMember();
-		if ($member->getUserType() === Member::TYPE_CIRCLE) {
-			$members = $member->getBasedOn()->getInheritedMembers();
-		} else {
-			$members = [$member];
 		}
 
 		$circle = $event->getCircle();
 		$federatedEvent = $event->getFederatedEvent();
-		$shares = $this->shareWrapperService->getSharesToCircle($circle->getSingleId());
+		$clearPasswords = $federatedEvent->getInternal()->gArray('clearPasswords');
 		$hashedPasswords = $federatedEvent->getParams()->gArray('hashedPasswords');
 
-		$result = [];
-		foreach ($members as $member) {
-			if ($member->getUserType() !== Member::TYPE_MAIL
-				&& $member->getUserType() !== Member::TYPE_CONTACT
+		foreach ($circle->getInheritedMembers(false, true) as $member) {
+			if (($member->getUserType() !== Member::TYPE_MAIL
+				 && $member->getUserType() !== Member::TYPE_CONTACT)
+				|| array_key_exists($member->getSingleId(), $clearPasswords)
 			) {
 				continue;
 			}
 
-			$files = [];
-			foreach ($shares as $share) {
-				try {
-					$shareToken = $this->shareTokenService->generateShareToken(
-						$share,
-						$member,
-						$this->get($member->getSingleId(), $hashedPasswords)
-					);
-				} catch (Exception $e) {
-					continue;
-				}
-
-				$share->setShareToken($shareToken);
-				$files[] = clone $share;
-			}
-
-			$result[$member->getId()] = [
-				'shares' => $files,
-				'mails' => $this->contactService->getMailAddressesFromMember($member)
-			];
+			$clearPassword = $this->token(14);
+			$clearPasswords[$member->getSingleId()] = $clearPassword;
+			$hashedPasswords[$member->getSingleId()] = $this->hasher->hash($clearPassword);
 		}
 
-		$federatedEvent->addResultEntry('files', $result);
+		$federatedEvent->getInternal()->aArray('clearPasswords', $clearPasswords);
+		$federatedEvent->getParams()->aArray('hashedPasswords', $hashedPasswords);
 	}
 }

--- a/lib/Listeners/Files/ShareCreatedSendMail.php
+++ b/lib/Listeners/Files/ShareCreatedSendMail.php
@@ -126,6 +126,7 @@ class ShareCreatedSendMail implements IEventListener {
 		}
 
 		$circle = $event->getCircle();
+		$clearPasswords = $event->getFederatedEvent()->getInternal()->gArray('clearPasswords');
 
 		foreach ($circle->getInheritedMembers(false, true) as $member) {
 			if ($member->getUserType() !== Member::TYPE_MAIL
@@ -153,6 +154,7 @@ class ShareCreatedSendMail implements IEventListener {
 				}
 
 				try {
+					// are we sure the 'share' entry is valid and not spoofed !?
 					/** @var ShareWrapper $share */
 					$share = $data->gObj('share', ShareWrapper::class);
 				} catch (Exception $e) {
@@ -166,7 +168,14 @@ class ShareCreatedSendMail implements IEventListener {
 					$author = 'someone';
 				}
 
-				$this->sendMailService->generateMail($author, $circle, $member, [$share], $mails);
+				$this->sendMailService->generateMail(
+					$author,
+					$circle,
+					$member,
+					[$share],
+					$mails,
+					$this->get($member->getSingleId(), $clearPasswords)
+				);
 			}
 		}
 	}

--- a/lib/Migration/Version0023Date20211216113101.php
+++ b/lib/Migration/Version0023Date20211216113101.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2021
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Class Version0023Date20211216113101
+ *
+ * @package OCA\Circles\Migration
+ */
+class Version0023Date20211216113101 extends SimpleMigrationStep {
+
+
+	/**
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+	}
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return null|ISchemaWrapper
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('circles_token')) {
+			$table = $schema->getTable('circles_token');
+			$table->changeColumn(
+				'password', [
+					'length' => 127
+				]
+			);
+		}
+
+		if ($schema->hasTable('circles_event')) {
+			$table = $schema->getTable('circles_event');
+			$table->setPrimaryKey(['token']);
+		}
+		
+		return $schema;
+	}
+}

--- a/lib/Model/Federated/FederatedEvent.php
+++ b/lib/Model/Federated/FederatedEvent.php
@@ -81,6 +81,9 @@ class FederatedEvent implements JsonSerializable {
 	private $params;
 
 	/** @var SimpleDataStore */
+	private $internal;
+
+	/** @var SimpleDataStore */
 	private $data;
 
 	/** @var int */
@@ -120,6 +123,7 @@ class FederatedEvent implements JsonSerializable {
 	public function __construct(string $class = '') {
 		$this->class = $class;
 		$this->params = new SimpleDataStore();
+		$this->internal = new SimpleDataStore();
 		$this->data = new SimpleDataStore();
 		$this->result = new SimpleDataStore();
 	}
@@ -392,6 +396,34 @@ class FederatedEvent implements JsonSerializable {
 
 
 	/**
+	 * @param SimpleDataStore $internal
+	 *
+	 * @return self
+	 */
+	public function setInternal(SimpleDataStore $internal): self {
+		$this->internal = $internal;
+
+		return $this;
+	}
+
+	/**
+	 * @return SimpleDataStore
+	 */
+	public function getInternal(): SimpleDataStore {
+		return $this->internal;
+	}
+
+	/**
+	 * @return $this
+	 */
+	public function resetInternal(): self {
+		$this->internal = new SimpleDataStore();
+
+		return $this;
+	}
+
+
+	/**
 	 * @param SimpleDataStore $data
 	 *
 	 * @return self
@@ -413,6 +445,7 @@ class FederatedEvent implements JsonSerializable {
 	 * @return $this
 	 */
 	public function resetData(): self {
+		$this->resetInternal();
 		$this->data = new SimpleDataStore();
 
 		return $this;
@@ -550,6 +583,7 @@ class FederatedEvent implements JsonSerializable {
 		$this->setClass($this->get('class', $data));
 		$this->setSeverity($this->getInt('severity', $data));
 		$this->setParams(new SimpleDataStore($this->getArray('params', $data)));
+		$this->setInternal(new SimpleDataStore($this->getArray('internal', $data)));
 		$this->setData(new SimpleDataStore($this->getArray('data', $data)));
 		$this->setResult(new SimpleDataStore($this->getArray('result', $data)));
 		$this->setOrigin($this->get('origin', $data));
@@ -587,6 +621,7 @@ class FederatedEvent implements JsonSerializable {
 			'class' => $this->getClass(),
 			'severity' => $this->getSeverity(),
 			'params' => $this->getParams(),
+			'internal' => $this->getInternal(),
 			'data' => $this->getData(),
 			'result' => $this->getResult(),
 			'origin' => $this->getOrigin(),

--- a/lib/Model/ModelManager.php
+++ b/lib/Model/ModelManager.php
@@ -48,6 +48,7 @@ use OCA\Circles\Exceptions\RemoteInstanceException;
 use OCA\Circles\Exceptions\RemoteNotFoundException;
 use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\Exceptions\ShareTokenNotFoundException;
 use OCA\Circles\Exceptions\UnknownInterfaceException;
 use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\IEntity;
@@ -461,6 +462,15 @@ class ModelManager {
 					$fileCache->importFromDatabase($data, $prefix);
 					$shareWrapper->setFileCache($fileCache);
 				} catch (FileCacheNotFoundException $e) {
+				}
+				break;
+
+			case CoreQueryBuilder::TOKEN:
+				try {
+					$token = new ShareToken();
+					$token->importFromDatabase($data, $prefix);
+					$shareWrapper->setShareToken($token);
+				} catch (ShareTokenNotFoundException $e) {
 				}
 				break;
 		}

--- a/lib/Model/ShareToken.php
+++ b/lib/Model/ShareToken.php
@@ -36,6 +36,7 @@ use ArtificialOwl\MySmallPhpTools\Exceptions\InvalidItemException;
 use ArtificialOwl\MySmallPhpTools\IDeserializable;
 use ArtificialOwl\MySmallPhpTools\Traits\TArrayTools;
 use JsonSerializable;
+use OCA\Circles\Exceptions\ShareTokenNotFoundException;
 use OCP\Share\IShare;
 
 class ShareToken implements IDeserializable, INC22QueryRow, JsonSerializable {
@@ -277,8 +278,13 @@ class ShareToken implements IDeserializable, INC22QueryRow, JsonSerializable {
 	 * @param string $prefix
 	 *
 	 * @return INC22QueryRow
+	 * @throws ShareTokenNotFoundException
 	 */
 	public function importFromDatabase(array $data, string $prefix = ''): INC22QueryRow {
+		if ($this->get($prefix . 'token', $data) === '') {
+			throw new ShareTokenNotFoundException();
+		}
+
 		$this->setShareId($this->getInt($prefix . 'share_id', $data));
 		$this->setCircleId($this->get($prefix . 'circle_id', $data));
 		$this->setSingleId($this->get($prefix . 'single_id', $data));

--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -623,6 +623,9 @@ class ShareWrapper extends ManagedModel implements IDeserializable, INC22QueryRo
 		$share->setTarget($this->getFileTarget());
 		$share->setProviderId($this->getProviderId());
 		$share->setStatus($this->getStatus());
+		if ($this->hasShareToken() && $this->getShareToken()->getPassword() !== '') {
+			$share->setPassword($this->getShareToken()->getPassword());
+		}
 
 		$share->setShareTime($this->getShareTime())
 			  ->setSharedWith($this->getSharedWith())

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -52,8 +52,10 @@ use OCA\Circles\Events\EditingCircleEvent;
 use OCA\Circles\Events\EditingCircleMemberEvent;
 use OCA\Circles\Events\Files\CreatingFileShareEvent;
 use OCA\Circles\Events\Files\FileShareCreatedEvent;
+use OCA\Circles\Events\Files\PreparingFileShareEvent;
 use OCA\Circles\Events\MembershipsCreatedEvent;
 use OCA\Circles\Events\MembershipsRemovedEvent;
+use OCA\Circles\Events\PreparingCircleMemberEvent;
 use OCA\Circles\Events\RemovingCircleMemberEvent;
 use OCA\Circles\Events\RequestingCircleMemberEvent;
 use OCA\Circles\Model\Federated\FederatedEvent;
@@ -140,6 +142,14 @@ class EventService {
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
+
+	/**
+	 * @param FederatedEvent $federatedEvent
+	 */
+	public function memberPreparing(FederatedEvent $federatedEvent): void {
+		$event = new PreparingCircleMemberEvent($federatedEvent);
+		$this->eventDispatcher->dispatchTyped($event);
+	}
 
 	/**
 	 * @param FederatedEvent $federatedEvent
@@ -304,6 +314,14 @@ class EventService {
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
+
+	/**
+	 * @param FederatedEvent $federatedEvent
+	 */
+	public function fileSharePreparing(FederatedEvent $federatedEvent): void {
+		$event = new PreparingFileShareEvent($federatedEvent);
+		$this->eventDispatcher->dispatchTyped($event);
+	}
 
 	/**
 	 * @param FederatedEvent $federatedEvent

--- a/lib/Service/FederatedEventService.php
+++ b/lib/Service/FederatedEventService.php
@@ -155,7 +155,8 @@ class FederatedEventService extends NC22Signature {
 	 * @throws RequestBuilderException
 	 */
 	public function newEvent(FederatedEvent $event): array {
-		$event->setOrigin($this->interfaceService->getLocalInstance());
+		$event->setOrigin($this->interfaceService->getLocalInstance())
+			  ->resetData();
 
 		$federatedItem = $this->getFederatedItem($event, false);
 		$this->confirmInitiator($event, true);

--- a/lib/Service/RemoteUpstreamService.php
+++ b/lib/Service/RemoteUpstreamService.php
@@ -108,12 +108,15 @@ class RemoteUpstreamService {
 	 * @throws UnknownRemoteException
 	 */
 	public function broadcastEvent(EventWrapper $wrapper): void {
+		$event = clone $wrapper->getEvent();
+		$event->resetInternal();
+
 		$this->interfaceService->setCurrentInterface($wrapper->getInterface());
 		$data = $this->remoteStreamService->resultRequestRemoteInstance(
 			$wrapper->getInstance(),
 			RemoteInstance::INCOMING,
 			Request::TYPE_POST,
-			$wrapper->getEvent()
+			$event
 		);
 
 		$wrapper->getEvent()->setResult(new SimpleDataStore($data));

--- a/lib/Service/ShareTokenService.php
+++ b/lib/Service/ShareTokenService.php
@@ -87,7 +87,7 @@ class ShareTokenService {
 	/**
 	 * @param ShareWrapper $share
 	 * @param Member $member
-	 * @param string $password
+	 * @param string $hashedPassword
 	 *
 	 * @return ShareToken
 	 * @throws ShareTokenAlreadyExistException
@@ -96,7 +96,7 @@ class ShareTokenService {
 	public function generateShareToken(
 		ShareWrapper $share,
 		Member $member,
-		string $password = ''
+		string $hashedPassword = ''
 	): ShareToken {
 		if ($member->getUserType() !== Member::TYPE_MAIL
 			&& $member->getUserType() !== Member::TYPE_CONTACT) {
@@ -104,14 +104,13 @@ class ShareTokenService {
 		}
 
 		$token = $this->token(19);
-
 		$shareToken = new ShareToken();
 		$shareToken->setShareId((int)$share->getId())
 				   ->setCircleId($share->getSharedWith())
 				   ->setSingleId($member->getSingleId())
 				   ->setMemberId($member->getId())
 				   ->setToken($token)
-				   ->setPassword($password)
+				   ->setPassword($hashedPassword)
 				   ->setAccepted(IShare::STATUS_ACCEPTED);
 
 		try {

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -143,8 +143,13 @@ class ShareByCircleProvider implements IShareProvider {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function __construct(
-		IDBConnection $connection, ISecureRandom $secureRandom, IUserManager $userManager,
-		IRootFolder $rootFolder, IL10N $l10n, ILogger $logger, IURLGenerator $urlGenerator
+		IDBConnection $connection,
+		ISecureRandom $secureRandom,
+		IUserManager $userManager,
+		IRootFolder $rootFolder,
+		IL10N $l10n,
+		ILogger $logger,
+		IURLGenerator $urlGenerator
 	) {
 		$this->userManager = $userManager;
 		$this->rootFolder = $rootFolder;
@@ -232,8 +237,8 @@ class ShareByCircleProvider implements IShareProvider {
 		}
 
 		$event = new FederatedEvent(FileShare::class);
-		$event->setCircle($circle)
-			  ->getParams()->sObj('wrappedShare', $wrappedShare);
+		$event->setCircle($circle);
+		$event->getParams()->sObj('wrappedShare', $wrappedShare);
 
 		$this->federatedEventService->newEvent($event);
 		$this->eventService->localShareCreated($wrappedShare);


### PR DESCRIPTION
So, the hard part was to keep the clear password on the master instance while creating shares on slaves (in global scale setup)

- When a new member is added, or a new share is created, the main instance will generate a list of Clean Passwords and their Hash. Hash will be shared to slaves to be used when generating the share token,
- Each slave will use a different hashed password for each members and inherited members of the circle. And will returns the list of generate share,
- Main instance get informations about the generate shares, and generate a mail per members and inherited members with the right password from the list.

- [x] test in large global scale env,
- [x] test in single instance with mass member add,
- [x] create password the same way that shared by mail,
- [x] check local settings for enforcing password, add also an option in the apps itself

