### PR TITLE
ignore exception to group sync

### DIFF
--- a/lib/Service/SyncService.php
+++ b/lib/Service/SyncService.php
@@ -299,7 +299,11 @@ class SyncService {
 			$event = new FederatedEvent(SingleMemberAdd::class);
 			$event->setCircle($circle);
 			$event->setMember($member);
-			$this->federatedEventService->newEvent($event);
+
+			try {
+				$this->federatedEventService->newEvent($event);
+			} catch (Exception $e) {
+			}
 
 //			$this->memberRequest->insertOrUpdate($member);
 		}


### PR DESCRIPTION
The method returns an exception if a user is already in the circle; making the sync failing