### PR TITLE
Fix loosing memberships in low depth

### DIFF
--- a/lib/FederatedItems/MemberLevel.php
+++ b/lib/FederatedItems/MemberLevel.php
@@ -151,6 +151,7 @@ class MemberLevel implements
 			$oldOwner = clone $event->getCircle()->getOwner();
 			$oldOwner->setLevel(Member::LEVEL_ADMIN);
 			$this->memberRequest->updateLevel($oldOwner);
+			$this->membershipService->onUpdate($oldOwner->getSingleId());
 		}
 
 		$this->membershipService->onUpdate($member->getSingleId());

--- a/lib/Model/Membership.php
+++ b/lib/Model/Membership.php
@@ -95,7 +95,7 @@ class Membership extends ManagedModel implements IDeserializable, INC22QueryRow,
 		$this->setSingleId($singleId);
 		$this->setCircleId($circle->getSingleId());
 		$this->setInheritanceFirst($member->getSingleId());
-		$this->setInheritanceLast($inheritanceLast === '' ? $member->getCircleId() : $inheritanceLast);
+		$this->setInheritanceLast($inheritanceLast ?: $member->getCircleId());
 		$this->setLevel($member->getLevel());
 	}
 

--- a/lib/Service/MaintenanceService.php
+++ b/lib/Service/MaintenanceService.php
@@ -76,6 +76,9 @@ class MaintenanceService {
 	/** @var FederatedUserService */
 	private $federatedUserService;
 
+	/** @var MembershipService */
+	private $membershipService;
+
 	/** @var EventWrapperService */
 	private $eventWrapperService;
 
@@ -99,6 +102,7 @@ class MaintenanceService {
 	 * @param ShareWrapperRequest $shareWrapperRequest
 	 * @param SyncService $syncService
 	 * @param FederatedUserService $federatedUserService
+	 * @param MembershipService $membershipService
 	 * @param EventWrapperService $eventWrapperService
 	 * @param CircleService $circleService
 	 * @param ConfigService $configService
@@ -110,6 +114,7 @@ class MaintenanceService {
 		ShareWrapperRequest $shareWrapperRequest,
 		SyncService $syncService,
 		FederatedUserService $federatedUserService,
+		MembershipService $membershipService,
 		EventWrapperService $eventWrapperService,
 		CircleService $circleService,
 		ConfigService $configService
@@ -121,6 +126,7 @@ class MaintenanceService {
 		$this->syncService = $syncService;
 		$this->federatedUserService = $federatedUserService;
 		$this->eventWrapperService = $eventWrapperService;
+		$this->membershipService = $membershipService;
 		$this->circleService = $circleService;
 		$this->configService = $configService;
 	}
@@ -257,6 +263,12 @@ class MaintenanceService {
 	 * every week
 	 */
 	private function runMaintenance5(): void {
+		try {
+			$this->output('Update memberships');
+			$this->updateAllMemberships();
+		} catch (Exception $e) {
+		}
+
 //		try {
 //			$this->output('refresh displayNames older than 7d');
 //			//	$this->refreshOldDisplayNames();
@@ -328,6 +340,21 @@ class MaintenanceService {
 		}
 	}
 
+
+	/**
+	 * @throws InitiatorNotFoundException
+	 * @throws RequestBuilderException
+	 */
+	private function updateAllMemberships(): void {
+		$probe = new CircleProbe();
+		$probe->includeSystemCircles()
+			  ->includeSingleCircles()
+			  ->includePersonalCircles();
+
+		foreach ($this->circleService->getCircles($probe) as $circle) {
+			$this->membershipService->manageMemberships($circle->getSingleId());
+		}
+	}
 
 	/**
 	 * @throws RequestBuilderException

--- a/lib/Service/MembershipService.php
+++ b/lib/Service/MembershipService.php
@@ -358,6 +358,8 @@ class MembershipService {
 				if ($item->getLevel() !== $membership->getLevel()) {
 					$this->membershipRequest->update($membership);
 					$new[] = $item;
+				} else if ($item->getInheritancePath() !== $membership->getInheritancePath()) {
+					$this->membershipRequest->update($membership);
 				}
 			} catch (ItemNotFoundException $e) {
 				$this->membershipRequest->insert($membership);

--- a/lib/Service/MembershipService.php
+++ b/lib/Service/MembershipService.php
@@ -358,7 +358,7 @@ class MembershipService {
 				if ($item->getLevel() !== $membership->getLevel()) {
 					$this->membershipRequest->update($membership);
 					$new[] = $item;
-				} else if ($item->getInheritancePath() !== $membership->getInheritancePath()) {
+				} elseif ($item->getInheritancePath() !== $membership->getInheritancePath()) {
 					$this->membershipRequest->update($membership);
 				}
 			} catch (ItemNotFoundException $e) {


### PR DESCRIPTION
fix 2 issues:

- update old owner membership on ownership transfer,
- update membership if inherited level is kept but inheritance path changed
