### PR TITLE
returns empty array on empty param

### DIFF
--- a/lib/Api/v1/Circles.php
+++ b/lib/Api/v1/Circles.php
@@ -229,6 +229,9 @@ class Circles {
 	 *
 	 */
 	public static function getFilesForCircles($circleUniqueIds) {
+		if (empty($circleUniqueIds)) {
+			return [];
+		}
 		throw new \BadMethodCallException('Method is deprecated and not longer works');
 	}
 }


### PR DESCRIPTION
Quick fix to avoid an exception when using dav client:

https://github.com/nextcloud/server/blob/5cd5245ca8b7b37156476ad128131ac5abc3891c/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php#L302

the feature is gone but let's not crash even when not used.
The feature will be back for nc24.