### PR TITLE
+getSingleId(): string;

### DIFF
--- a/lib/IFederatedUser.php
+++ b/lib/IFederatedUser.php
@@ -43,6 +43,11 @@ interface IFederatedUser extends IFederatedModel {
 	/**
 	 * @return string
 	 */
+	public function getSingleId(): string;
+
+	/**
+	 * @return string
+	 */
 	public function getUserId(): string;
 
 	/**


### PR DESCRIPTION
No idea why it was missing ...

The method is already available in both class that `implements IFederatedUser`: `FederaedUser` and `Member`.