### PR TITLE
allow configuration of one single password per circle

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -57,6 +57,7 @@ Those groups of users (or "circles") can then be used by any other app for shari
 		<command>OCA\Circles\Command\CirclesDestroy</command>
 		<command>OCA\Circles\Command\CirclesDetails</command>
 		<command>OCA\Circles\Command\CirclesConfig</command>
+		<command>OCA\Circles\Command\CirclesSetting</command>
 		<command>OCA\Circles\Command\CirclesSync</command>
 		<command>OCA\Circles\Command\CirclesCheck</command>
 		<command>OCA\Circles\Command\CirclesTest</command>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -58,7 +58,7 @@ return [
 
 		['name' => 'Local#editName', 'url' => '/circles/{circleId}/name', 'verb' => 'PUT'],
 		['name' => 'Local#editDescription', 'url' => '/circles/{circleId}/description', 'verb' => 'PUT'],
-		['name' => 'Local#editSettings', 'url' => '/circles/{circleId}/settings', 'verb' => 'PUT'],
+		['name' => 'Local#editSetting', 'url' => '/circles/{circleId}/setting', 'verb' => 'PUT'],
 		['name' => 'Local#editConfig', 'url' => '/circles/{circleId}/config', 'verb' => 'PUT'],
 		['name' => 'Local#link', 'url' => '/link/{circleId}/{singleId}', 'verb' => 'GET'],
 
@@ -95,7 +95,7 @@ return [
 		['name' => 'Admin#circleLeave', 'url' => '/admin/{emulated}/circles/{circleId}/leave', 'verb' => 'PUT'],
 		['name' => 'Admin#editName', 'url' => '/admin/{emulated}/circles/{circleId}/name', 'verb' => 'PUT'],
 		['name' => 'Admin#editDescription', 'url' => '/admin/{emulated}/circles/{circleId}/description', 'verb' => 'PUT'],
-		['name' => 'Admin#editSettings', 'url' => '/admin/{emulated}/circles/{circleId}/settings', 'verb' => 'PUT'],
+		['name' => 'Admin#editSetting', 'url' => '/admin/{emulated}/circles/{circleId}/setting', 'verb' => 'PUT'],
 		['name' => 'Admin#editConfig', 'url' => '/admin/{emulated}/circles/{circleId}/config', 'verb' => 'PUT'],
 		['name' => 'Admin#link', 'url' => '/admin/{emulated}/link/{circleId}/{singleId}', 'verb' => 'GET']
 	],

--- a/lib/Circles/FileSharingBroadcaster.php
+++ b/lib/Circles/FileSharingBroadcaster.php
@@ -220,14 +220,14 @@ class FileSharingBroadcaster implements IBroadcaster {
 
 				$password = '';
 				$sendPasswordByMail = true;
-				if ($this->configService->enforcePasswordProtection($circle)) {
-					if ($circle->getSetting('password_single_enabled') === 'true') {
-						$password = $circle->getPasswordSingle();
-						$sendPasswordByMail = false;
-					} else {
-						$password = $this->miscService->token(15);
-					}
-				}
+//				if ($this->configService->enforcePasswordProtection($circle)) {
+//					if ($circle->getSetting('password_single_enabled') === 'true') {
+//						$password = $circle->getPasswordSingle();
+//						$sendPasswordByMail = false;
+//					} else {
+//						$password = $this->miscService->token(15);
+//					}
+//				}
 
 				$sharesToken =
 					$this->tokensRequest->generateTokenForMember($member, $share->getId(), $password);
@@ -473,9 +473,9 @@ class FileSharingBroadcaster implements IBroadcaster {
 	 * @throws Exception
 	 */
 	protected function sendPasswordByMail(IShare $share, $circleName, $email, $password) {
-		if (!$this->configService->sendPasswordByMail() || $password === '') {
-			return;
-		}
+//		if (!$this->configService->sendPasswordByMail() || $password === '') {
+//			return;
+//		}
 
 		$message = $this->mailer->createMessage();
 
@@ -594,9 +594,9 @@ class FileSharingBroadcaster implements IBroadcaster {
 		$data = [];
 
 		$password = '';
-		if ($this->configService->enforcePasswordProtection($circle)) {
-			$password = $this->miscService->token(15);
-		}
+//		if ($this->configService->enforcePasswordProtection($circle)) {
+//			$password = $this->miscService->token(15);
+//		}
 
 		foreach ($unknownShares as $share) {
 			try {
@@ -628,9 +628,9 @@ class FileSharingBroadcaster implements IBroadcaster {
 	 * @throws Exception
 	 */
 	protected function sendPasswordExistingShares(DeprecatedMember $author, string $email, string $password) {
-		if (!$this->configService->sendPasswordByMail() || $password === '') {
-			return;
-		}
+//		if (!$this->configService->sendPasswordByMail() || $password === '') {
+//			return;
+//		}
 
 		$message = $this->mailer->createMessage();
 

--- a/lib/Command/CirclesSetting.php
+++ b/lib/Command/CirclesSetting.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\Command;
+
+use OC\Core\Command\Base;
+use OCA\Circles\Exceptions\CircleNotFoundException;
+use OCA\Circles\Exceptions\FederatedEventException;
+use OCA\Circles\Exceptions\FederatedItemException;
+use OCA\Circles\Exceptions\FederatedUserException;
+use OCA\Circles\Exceptions\FederatedUserNotFoundException;
+use OCA\Circles\Exceptions\InitiatorNotConfirmedException;
+use OCA\Circles\Exceptions\InitiatorNotFoundException;
+use OCA\Circles\Exceptions\InvalidIdException;
+use OCA\Circles\Exceptions\MemberNotFoundException;
+use OCA\Circles\Exceptions\OwnerNotFoundException;
+use OCA\Circles\Exceptions\RemoteInstanceException;
+use OCA\Circles\Exceptions\RemoteNotFoundException;
+use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
+use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\Exceptions\SingleCircleNotFoundException;
+use OCA\Circles\Exceptions\UnknownRemoteException;
+use OCA\Circles\Exceptions\UserTypeNotFoundException;
+use OCA\Circles\Model\Helpers\MemberHelper;
+use OCA\Circles\Model\Member;
+use OCA\Circles\Service\CircleService;
+use OCA\Circles\Service\FederatedUserService;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CirclesSetting extends Base {
+
+
+	/** @var FederatedUserService */
+	private $federatedUserService;
+
+	/** @var CircleService */
+	private $circleService;
+
+
+	/**
+	 * @param FederatedUserService $federatedUserService
+	 * @param CircleService $circlesService
+	 */
+	public function __construct(FederatedUserService $federatedUserService, CircleService $circlesService) {
+		parent::__construct();
+
+		$this->federatedUserService = $federatedUserService;
+		$this->circleService = $circlesService;
+	}
+
+
+	/**
+	 *
+	 */
+	protected function configure() {
+		parent::configure();
+		$this->setName('circles:manage:setting')
+			 ->setDescription('edit setting for a Circle')
+			 ->addArgument('circle_id', InputArgument::REQUIRED, 'ID of the circle')
+			 ->addArgument('setting', InputArgument::OPTIONAL, 'setting to edit', '')
+			 ->addArgument('value', InputArgument::OPTIONAL, 'value', '')
+			 ->addOption('unset', '', InputOption::VALUE_NONE, 'unset the setting')
+			 ->addOption('initiator', '', InputOption::VALUE_REQUIRED, 'set an initiator to the request', '')
+			 ->addOption('initiator-type', '', InputOption::VALUE_REQUIRED, 'set initiator type', '0')
+			 ->addOption('status-code', '', InputOption::VALUE_NONE, 'display status code on exception');
+	}
+
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int
+	 * @throws FederatedEventException
+	 * @throws FederatedItemException
+	 * @throws InitiatorNotFoundException
+	 * @throws RequestBuilderException
+	 * @throws CircleNotFoundException
+	 * @throws FederatedUserException
+	 * @throws FederatedUserNotFoundException
+	 * @throws InitiatorNotConfirmedException
+	 * @throws InvalidIdException
+	 * @throws MemberNotFoundException
+	 * @throws OwnerNotFoundException
+	 * @throws RemoteInstanceException
+	 * @throws RemoteNotFoundException
+	 * @throws RemoteResourceNotFoundException
+	 * @throws SingleCircleNotFoundException
+	 * @throws UnknownRemoteException
+	 * @throws UserTypeNotFoundException
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$circleId = (string)$input->getArgument('circle_id');
+		$setting = (string)$input->getArgument('setting');
+		$value = (string)$input->getArgument('value');
+
+		try {
+			$this->federatedUserService->commandLineInitiator(
+				$input->getOption('initiator'),
+				Member::parseTypeString($input->getOption('initiator-type')),
+				$circleId,
+				false
+			);
+
+			if ($setting === '') {
+				$circle = $this->circleService->getCircle($circleId);
+				$initiatorHelper = new MemberHelper($circle->getInitiator());
+				$initiatorHelper->mustBeAdmin();
+				$output->writeln(json_encode($circle->getSettings(), JSON_PRETTY_PRINT));
+
+				return 0;
+			}
+
+			if (!$input->getOption('unset') && $value === '') {
+				throw new InvalidArgumentException('you need to specify a value');
+			}
+
+			$outcome = $this->circleService->updateSetting(
+				$circleId,
+				$setting,
+				($input->getOption('unset')) ? null : $value,
+			);
+		} catch (FederatedItemException $e) {
+			if ($input->getOption('status-code')) {
+				throw new FederatedItemException(
+					' [' . get_class($e) . ', ' . $e->getStatus() . ']' . "\n" . $e->getMessage()
+				);
+			}
+
+			throw $e;
+		}
+
+		if (strtolower($input->getOption('output')) === 'json') {
+			$output->writeln(json_encode($outcome, JSON_PRETTY_PRINT));
+		}
+
+		return 0;
+	}
+}

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -462,23 +462,27 @@ class AdminController extends OcsController {
 	/**
 	 * @param string $emulated
 	 * @param string $circleId
-	 * @param array $value
+	 * @param string $setting
+	 * @param string|null $value
 	 *
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function editSettings(string $emulated, string $circleId, array $value): DataResponse {
+	public function editSetting(string $emulated, string $circleId, string $setting, ?string $value = null): DataResponse {
 		try {
 			$this->setLocalFederatedUser($emulated);
 
-			$outcome = $this->circleService->updateSettings($circleId, $value);
+			$outcome = $this->circleService->updateSetting($circleId, $setting, $value);
 
 			return new DataResponse($this->serializeArray($outcome));
 		} catch (Exception $e) {
-			$this->e($e, ['emulated' => $emulated, 'circleId' => $circleId, 'value' => $value]);
+			$this->e($e, ['circleId' => $circleId, 'setting' => $setting, 'value' => $value]);
 			throw new OCSException($e->getMessage(), $e->getCode());
 		}
 	}
+
+
+
 
 
 	/**

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -413,6 +413,7 @@ class LocalController extends OcsController {
 	 *
 	 * @param int $limit
 	 * @param int $offset
+	 *
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
@@ -505,20 +506,21 @@ class LocalController extends OcsController {
 	 * @NoAdminRequired
 	 *
 	 * @param string $circleId
-	 * @param array $value
+	 * @param string $setting
+	 * @param string|null $value
 	 *
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function editSettings(string $circleId, array $value): DataResponse {
+	public function editSetting(string $circleId, string $setting, ?string $value = null): DataResponse {
 		try {
 			$this->setCurrentFederatedUser();
 
-			$outcome = $this->circleService->updateSettings($circleId, $value);
+			$outcome = $this->circleService->updateSetting($circleId, $setting, $value);
 
 			return new DataResponse($this->serializeArray($outcome));
 		} catch (Exception $e) {
-			$this->e($e, ['circleId' => $circleId, 'value' => $value]);
+			$this->e($e, ['circleId' => $circleId, 'setting' => $setting, 'value' => $value]);
 			throw new OCSException($e->getMessage(), $e->getCode());
 		}
 	}

--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -151,6 +151,18 @@ class CircleRequest extends CircleRequestBuilder {
 
 
 	/**
+	 * @param Circle $circle
+	 */
+	public function updateSettings(Circle $circle) {
+		$qb = $this->getCircleUpdateSql();
+		$qb->set('settings', $qb->createNamedParameter(json_encode($circle->getSettings())));
+		$qb->limitToUniqueId($circle->getSingleId());
+
+		$qb->execute();
+	}
+
+
+	/**
 	 * @param IFederatedUser|null $initiator
 	 * @param CircleProbe $probe
 	 *

--- a/lib/FederatedItems/CircleSetting.php
+++ b/lib/FederatedItems/CircleSetting.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Circles\FederatedItems;
+
+use ArtificialOwl\MySmallPhpTools\Traits\Nextcloud\nc22\TNC22Deserialize;
+use OCA\Circles\Db\CircleRequest;
+use OCA\Circles\IFederatedItem;
+use OCA\Circles\IFederatedItemAsyncProcess;
+use OCA\Circles\Model\Federated\FederatedEvent;
+use OCA\Circles\Model\Helpers\MemberHelper;
+
+class CircleSetting implements
+	IFederatedItem,
+	IFederatedItemAsyncProcess {
+	use TNC22Deserialize;
+
+
+	/** @var CircleRequest */
+	private $circleRequest;
+
+
+	/**
+	 * CircleConfig constructor.
+	 *
+	 * @param CircleRequest $circleRequest
+	 */
+	public function __construct(CircleRequest $circleRequest) {
+		$this->circleRequest = $circleRequest;
+	}
+
+
+	/**
+	 * @param FederatedEvent $event
+	 */
+	public function verify(FederatedEvent $event): void {
+		$circle = $event->getCircle();
+
+		$initiatorHelper = new MemberHelper($circle->getInitiator());
+		$initiatorHelper->mustBeAdmin();
+
+		$params = $event->getParams();
+		$setting = $params->g('setting');
+		$value = $params->gBool('unset') ? null : $params->g('value');
+
+		$settings = $circle->getSettings();
+
+		if (!is_null($value)) {
+			$settings[$setting] = $value;
+		} elseif (array_key_exists($setting, $settings)) {
+			unset($settings[$setting]);
+		}
+
+		$event->getData()->sArray('settings', $settings);
+
+		$new = clone $circle;
+		$new->setSettings($settings);
+
+		$event->setOutcome($this->serialize($new));
+	}
+
+
+	/**
+	 * @param FederatedEvent $event
+	 */
+	public function manage(FederatedEvent $event): void {
+		$circle = clone $event->getCircle();
+		$settings = $event->getData()->gArray('settings');
+
+		$circle->setSettings($settings);
+		// TODO list imported from FederatedItem/CircleConfig.php - need to check first there.
+
+		// TODO: Check locally that circle is not un-federated during the process
+		// TODO: if the circle is managed remotely, remove the circle locally
+		// TODO: if the circle is managed locally, remove non-local users
+
+		// TODO: Check locally that circle is not federated during the process
+		// TODO: sync if it is to broadcast to Trusted RemoteInstance
+
+		$this->circleRequest->updateSettings($circle);
+	}
+
+
+	/**
+	 * @param FederatedEvent $event
+	 * @param array $results
+	 */
+	public function result(FederatedEvent $event, array $results): void {
+	}
+}

--- a/lib/GlobalScale/FileShare.php
+++ b/lib/GlobalScale/FileShare.php
@@ -198,14 +198,14 @@ class FileShare extends AGlobalScaleEvent {
 		$newCircle = $this->circlesRequest->forceGetCircle($circle->getUniqueId(), true);
 		$password = '';
 		$sendPasswordByMail = true;
-		if ($this->configService->enforcePasswordProtection($newCircle)) {
-			if ($newCircle->getSetting('password_single_enabled') === 'true') {
-				$password = $newCircle->getPasswordSingle();
-				$sendPasswordByMail = false;
-			} else {
-				$password = $this->miscService->token(15);
-			}
-		}
+//		if ($this->configService->enforcePasswordProtection($newCircle)) {
+//			if ($newCircle->getSetting('password_single_enabled') === 'true') {
+//				$password = $newCircle->getPasswordSingle();
+//				$sendPasswordByMail = false;
+//			} else {
+//				$password = $this->miscService->token(15);
+//			}
+//		}
 
 		try {
 			$sharesToken =
@@ -310,9 +310,9 @@ class FileShare extends AGlobalScaleEvent {
 	 * @throws Exception
 	 */
 	protected function sendPasswordByMail(IShare $share, $circleName, $email, $password) {
-		if (!$this->configService->sendPasswordByMail() || $password === '') {
-			return;
-		}
+//		if (!$this->configService->sendPasswordByMail() || $password === '') {
+//			return;
+//		}
 
 		$message = $this->mailer->createMessage();
 

--- a/lib/GlobalScale/MemberAdd.php
+++ b/lib/GlobalScale/MemberAdd.php
@@ -55,7 +55,7 @@ use OCP\Util;
 
 /**
  * Class MemberAdd
- *
+ * @deprecated
  * @package OCA\Circles\GlobalScale
  */
 class MemberAdd extends AGlobalScaleEvent {
@@ -111,14 +111,14 @@ class MemberAdd extends AGlobalScaleEvent {
 
 		$password = '';
 		$sendPasswordByMail = false;
-		if ($this->configService->enforcePasswordProtection($circle)) {
-			if ($circle->getSetting('password_single_enabled') === 'true') {
-				$password = $circle->getPasswordSingle();
-			} else {
-				$sendPasswordByMail = true;
-				$password = $this->miscService->token(15);
-			}
-		}
+//		if ($this->configService->enforcePasswordProtection($circle)) {
+//			if ($circle->getSetting('password_single_enabled') === 'true') {
+//				$password = $circle->getPasswordSingle();
+//			} else {
+//				$sendPasswordByMail = true;
+//				$password = $this->miscService->token(15);
+//			}
+//		}
 
 		$event->setData(
 			new SimpleDataStore(

--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -57,7 +57,7 @@ use OCA\Circles\FederatedItems\CircleDestroy;
 use OCA\Circles\FederatedItems\CircleEdit;
 use OCA\Circles\FederatedItems\CircleJoin;
 use OCA\Circles\FederatedItems\CircleLeave;
-use OCA\Circles\FederatedItems\CircleSettings;
+use OCA\Circles\FederatedItems\CircleSetting;
 use OCA\Circles\IEntity;
 use OCA\Circles\IFederatedUser;
 use OCA\Circles\Model\Circle;
@@ -69,12 +69,8 @@ use OCA\Circles\Model\Probes\CircleProbe;
 use OCA\Circles\Model\Probes\MemberProbe;
 use OCA\Circles\StatusCode;
 use OCP\IL10N;
+use OCP\Security\IHasher;
 
-/**
- * Class CircleService
- *
- * @package OCA\Circles\Service
- */
 class CircleService {
 	use TArrayTools;
 	use TStringTools;
@@ -83,6 +79,9 @@ class CircleService {
 
 	/** @var IL10N */
 	private $l10n;
+
+	/** @var IHasher */
+	private $hasher;
 
 	/** @var CircleRequest */
 	private $circleRequest;
@@ -107,8 +106,8 @@ class CircleService {
 
 
 	/**
-	 * CircleService constructor.
-	 *
+	 * @param IL10N $l10n
+	 * @param IHasher $hasher
 	 * @param CircleRequest $circleRequest
 	 * @param MemberRequest $memberRequest
 	 * @param RemoteStreamService $remoteStreamService
@@ -119,6 +118,7 @@ class CircleService {
 	 */
 	public function __construct(
 		IL10N $l10n,
+		IHasher $hasher,
 		CircleRequest $circleRequest,
 		MemberRequest $memberRequest,
 		RemoteStreamService $remoteStreamService,
@@ -128,6 +128,7 @@ class CircleService {
 		ConfigService $configService
 	) {
 		$this->l10n = $l10n;
+		$this->hasher = $hasher;
 		$this->circleRequest = $circleRequest;
 		$this->memberRequest = $memberRequest;
 		$this->remoteStreamService = $remoteStreamService;
@@ -274,6 +275,51 @@ class CircleService {
 
 
 	/**
+	 * if $value is null, setting is unset
+	 *
+	 * @param string $circleId
+	 * @param string $setting
+	 * @param string|null $value
+	 *
+	 * @return array
+	 * @throws CircleNotFoundException
+	 * @throws FederatedEventException
+	 * @throws FederatedItemException
+	 * @throws InitiatorNotConfirmedException
+	 * @throws InitiatorNotFoundException
+	 * @throws OwnerNotFoundException
+	 * @throws RemoteInstanceException
+	 * @throws RemoteNotFoundException
+	 * @throws RemoteResourceNotFoundException
+	 * @throws RequestBuilderException
+	 * @throws UnknownRemoteException
+	 */
+	public function updateSetting(string $circleId, string $setting, ?string $value): array {
+		$circle = $this->getCircle($circleId);
+
+		if (strtolower($setting) === 'password_single' && !is_null($value)) {
+			$value = $this->hasher->hash($value);
+		}
+
+		$event = new FederatedEvent(CircleSetting::class);
+		$event->setCircle($circle);
+		$event->setParams(
+			new SimpleDataStore(
+				[
+					'setting' => $setting,
+					'value' => $value,
+					'unset' => is_null($value)
+				]
+			)
+		);
+
+		$this->federatedEventService->newEvent($event);
+
+		return $event->getOutcome();
+	}
+
+
+	/**
 	 * @param string $circleId
 	 * @param string $name
 	 *
@@ -325,35 +371,6 @@ class CircleService {
 		$event = new FederatedEvent(CircleEdit::class);
 		$event->setCircle($circle);
 		$event->setParams(new SimpleDataStore(['description' => $description]));
-
-		$this->federatedEventService->newEvent($event);
-
-		return $event->getOutcome();
-	}
-
-	/**
-	 * @param string $circleId
-	 * @param array $settings
-	 *
-	 * @return array
-	 * @throws CircleNotFoundException
-	 * @throws FederatedEventException
-	 * @throws FederatedItemException
-	 * @throws InitiatorNotConfirmedException
-	 * @throws InitiatorNotFoundException
-	 * @throws OwnerNotFoundException
-	 * @throws RemoteInstanceException
-	 * @throws RemoteNotFoundException
-	 * @throws RemoteResourceNotFoundException
-	 * @throws RequestBuilderException
-	 * @throws UnknownRemoteException
-	 */
-	public function updateSettings(string $circleId, array $settings): array {
-		$circle = $this->getCircle($circleId);
-
-		$event = new FederatedEvent(CircleSettings::class);
-		$event->setCircle($circle);
-		$event->setParams(new SimpleDataStore(['settings' => $settings]));
 
 		$this->federatedEventService->newEvent($event);
 


### PR DESCRIPTION
- [x] Managing circle's settings from the command line
- [x] Allow multiple configuration to use this feature (in order):
  * Enforcing password protection if the Enforce password protection is enabled.
  * Enforcing password protection if the Circle App is configured to: 
       `./occ config:app:set --value '1' circles enforce_password`
  * Enforcing password protection if the Circle's settings is configured to:
      `./occ circles:manage:setting y8JczmViR3zZraCXhbpfR8v4x8s5A8c enforce_password true`

- [x] Allow the use of a single password when sharing a new file to external members of a circle,
- [x] Allow the use of a single password when adding a new external member to a circle,
- [x] confirm behavior in globalscale env.
- [x] providing API and Feature Request for Contacts
- [x] filtering some setting before sending ocs data about circle


### display settings from a `circleId`

```
$ ./occ circles:manage:setting y8JczmViR3zZraCXhbpfR8v4x8s5A8c 
{
    "enforce_password": "true",
    "password_single_enabled": "true",
    "password_single": "3|$argon2id$v=19$m=65536,t=4,p=1$NktudFp4UmluSGZtRGhEeA$VJuD1vhKuKG+oFFT1nlmXHU3O3aTUw1ZFkjW8Vw9gxU"
}
```


### Add/Edit setting from a `circleId`


```
$ ./occ circles:manage:setting y8JczmViR3zZraCXhbpfR8v4x8s5A8c enforce_password true
$ ./occ circles:manage:setting y8JczmViR3zZraCXhbpfR8v4x8s5A8c password_single_enable true
$ ./occ circles:manage:setting y8JczmViR3zZraCXhbpfR8v4x8s5A8c password_single my_clear_password
```

_Note: when setting the param `password_single` the clear password will be instantly be hashed_


### Remote a setting from a `circleId`

```
$ ./occ circles:manage:setting y8JczmViR3zZraCXhbpfR8v4x8s5A8c enforce_password --unset
```

