### PR TITLE
set member as INVITED only if not external

### DIFF
--- a/lib/FederatedItems/SingleMemberAdd.php
+++ b/lib/FederatedItems/SingleMemberAdd.php
@@ -411,7 +411,9 @@ class SingleMemberAdd implements
 		} catch (MemberNotFoundException $e) {
 			$member->setId($this->token(ManagedModel::ID_LENGTH));
 
-			if ($circle->isConfig(Circle::CFG_INVITE)) {
+			if ($circle->isConfig(Circle::CFG_INVITE)
+				&& $member->getUserType() !== Member::TYPE_MAIL
+				&& $member->getUserType() !== Member::TYPE_CONTACT) {
 				$member->setStatus(Member::STATUS_INVITED);
 			} else {
 				$member->setLevel(Member::LEVEL_MEMBER);


### PR DESCRIPTION
There is an issue currently where if Circle is set as INVITE when adding an external member.

This fix will accept memberships for external member without any need of confirmation from the said external member.

INVITE means "new member needs to confirm their membership (invitation)