### PR TITLE
display spent time on request

### DIFF
--- a/lib/Command/CirclesCheck.php
+++ b/lib/Command/CirclesCheck.php
@@ -340,19 +340,25 @@ class CirclesCheck extends Base {
 			return false;
 		}
 
+		$timer = round(microtime(true) * 1000);
 		$output->write('- Creating async FederatedEvent ');
 		$test = new FederatedEvent(LoopbackTest::class);
 		$this->federatedEventService->newEvent($test);
-
-		$output->writeln('<info>' . $test->getWrapperToken() . '</info>');
+		$output->writeln(
+			'<info>' . $test->getWrapperToken() . '</info> ' .
+			'(took ' . (round(microtime(true) * 1000) - $timer) . 'ms)'
+		);
 
 		$output->writeln('- Waiting for async process to finish (5s)');
 		sleep(5);
 
 		$output->write('- Checking status on FederatedEvent ');
 		$wrappers = $this->remoteUpstreamService->getEventsByToken($test->getWrapperToken());
+
 		if (count($wrappers) !== 1) {
 			$output->writeln('<error>Event created too many Wrappers</error>');
+
+			return false;
 		}
 
 		$wrapper = array_shift($wrappers);
@@ -392,8 +398,10 @@ class CirclesCheck extends Base {
 		[$scheme, $cloudId, $path] = $this->parseAddress($loopback);
 
 		$question = new ConfirmationQuestion(
-			'- Do you want to save <info>' . $loopback
-			. '</info> as your <info>loopback</info> address ? (y/N) ', false, '/^(y|Y)/i'
+			'- Do you want to save <info>'
+			. $loopback
+			. '</info> as your <info>loopback</info> address ? (y/N) ',
+			false, '/^(y|Y)/i'
 		);
 
 		$helper = $this->getHelper('question');
@@ -573,8 +581,10 @@ class CirclesCheck extends Base {
 
 		$output->writeln('');
 		$question = new ConfirmationQuestion(
-			'- Do you want to save <info>' . $internal
-			. '</info> as your <info>internal</info> address ? (y/N) ', false, '/^(y|Y)/i'
+			'- Do you want to save <info>'
+			. $internal
+			. '</info> as your <info>internal</info> address ? (y/N) ',
+			false, '/^(y|Y)/i'
 		);
 
 		$helper = $this->getHelper('question');


### PR DESCRIPTION
Might be interesting to verify if the loopback request takes more than usual:

```
$ ./occ circles:check
[...]
- Creating async FederatedEvent 62337a0d-38a8-4864-b66a-18e44fb00db3 (took 135ms)
[...]
```