### PR TITLE
Cache getSharedWith() result

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -112,25 +112,10 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 	/**
 	 * @param Membership $membership
 	 */
-	public function removeByMembership(Membership $membership) {
+	public function deleteByMembership(Membership $membership) {
 		$qb = $this->getShareDeleteSql();
 		$qb->limitToShareWith($membership->getCircleId());
 		$qb->limit('uid_initiator', $membership->getSingleId());
-
-		$qb->execute();
-	}
-
-
-	/**
-	 * @param string $initiator
-	 * @param string $shareWith
-	 *
-	 * @deprecated in NC30 when initiator uses FederatedUser - then, we can use removeByMembership()
-	 */
-	public function removeByInitiatorAndShareWith(string $initiator, string $shareWith) {
-		$qb = $this->getShareDeleteSql();
-		$qb->limitToShareWith($shareWith);
-		$qb->limit('uid_initiator', $initiator);
 
 		$qb->execute();
 	}
@@ -441,13 +426,16 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		$qb->execute();
 	}
 
-
 	/**
 	 * @param string $circleId
+	 * @param string $initiator
 	 */
-	public function deleteFromCircle(string $circleId): void {
+	public function deleteSharesToCircle(string $circleId, string $initiator = ''): void {
 		$qb = $this->getShareDeleteSql();
 		$qb->andWhere($qb->exprLimit('share_with', $circleId));
+		if ($initiator !== '') {
+			$qb->limit('uid_initiator', $initiator);
+		}
 
 		$qb->execute();
 	}

--- a/lib/FederatedItems/Files/FileShare.php
+++ b/lib/FederatedItems/Files/FileShare.php
@@ -121,58 +121,6 @@ class FileShare implements
 		}
 
 		$this->eventService->fileShareCreating($event, $mount);
-
-//		$this->eventService->federatedShareCreated($wrappedShare, $mount);
-
-
-//		$this->eventService->fileSharing($event);
-
-//		$this->mountRequest->create($mount);
-//		$circle = $event->getDeprecatedCircle();
-//
-//		// if event is not local, we create a federated file to the right instance of Nextcloud, using the right token
-//		if (!$this->configService->isLocalInstance($event->getSource())) {
-//			try {
-//				$share = $this->getShareFromData($event->getData());
-//			} catch (Exception $e) {
-//				return;
-//			}
-//
-//			$data = $event->getData();
-//			$token = $data->g('gs_federated');
-//			$filename = $data->g('gs_filename');
-//
-//			$gsShare = new GSShare($share->getSharedWith(), $token);
-//			$gsShare->setOwner($share->getShareOwner());
-//			$gsShare->setInstance($event->getSource());
-//			$gsShare->setParent(-1);
-//			$gsShare->setMountPoint($filename);
-//
-//			$this->gsSharesRequest->create($gsShare);
-//		} else {
-//			// if the event is local, we send mail to mail-as-members
-//			$members = $this->membersRequest->forceGetMembers(
-//				$circle->getUniqueId(), DeprecatedMember::LEVEL_MEMBER, DeprecatedMember::TYPE_MAIL, true
-//			);
-//
-//			foreach ($members as $member) {
-//				$this->sendShareToContact($event, $circle, $member->getMemberId(), [$member->getUserId()]);
-//			}
-//		}
-//
-//		// we also fill the event's result for further things, like contact-as-members
-//		$members = $this->membersRequest->forceGetMembers(
-//			$circle->getUniqueId(), DeprecatedMember::LEVEL_MEMBER, DeprecatedMember::TYPE_CONTACT, true
-//		);
-//
-//		$accounts = [];
-//		foreach ($members as $member) {
-//			if ($member->getInstance() === '') {
-//				$accounts[] = $this->miscService->getInfosFromContact($member);
-//			}
-//		}
-//
-//		$event->setResult(new SimpleDataStore(['contacts' => $accounts]));
 	}
 
 
@@ -182,25 +130,5 @@ class FileShare implements
 	 */
 	public function result(FederatedEvent $event, array $results): void {
 		$this->eventService->fileShareCreated($event, $results);
-
-//		$event = null;
-//		$contacts = [];
-//		foreach (array_keys($events) as $instance) {
-//			$event = $events[$instance];
-//			$contacts = array_merge(
-//				$contacts, $event->getResult()
-//								 ->gArray('contacts')
-//			);
-//		}
-//
-//		if ($event === null || !$event->hasCircle()) {
-//			return;
-//		}
-//
-//		$circle = $event->getDeprecatedCircle();
-//
-//		foreach ($contacts as $contact) {
-//			$this->sendShareToContact($event, $circle, $contact['memberId'], $contact['emails']);
-//		}
 	}
 }

--- a/lib/Listeners/Files/DestroyingCircle.php
+++ b/lib/Listeners/Files/DestroyingCircle.php
@@ -77,6 +77,6 @@ class DestroyingCircle implements IEventListener {
 		}
 
 		$circle = $event->getCircle();
-		$this->shareWrapperService->deleteSharesToCircle($circle->getSingleId());
+		$this->shareWrapperService->deleteSharesToCircle($circle->getSingleId(), '', true);
 	}
 }

--- a/lib/Listeners/Files/MembershipsRemoved.php
+++ b/lib/Listeners/Files/MembershipsRemoved.php
@@ -31,7 +31,6 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Listeners\Files;
 
-use OCA\Circles\Tools\Traits\TStringTools;
 use OCA\Circles\CirclesManager;
 use OCA\Circles\Db\ShareWrapperRequest;
 use OCA\Circles\Events\MembershipsRemovedEvent;
@@ -51,6 +50,8 @@ use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\Exceptions\UserTypeNotFoundException;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Service\FederatedUserService;
+use OCA\Circles\Service\ShareWrapperService;
+use OCA\Circles\Tools\Traits\TStringTools;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
@@ -66,8 +67,7 @@ class MembershipsRemoved implements IEventListener {
 	/** @var CirclesManager */
 	private $circlesManager;
 
-	/** @var ShareWrapperRequest */
-	private $shareWrapperRequest;
+	private ShareWrapperService $shareWrapperService;
 
 	/** @var FederatedUserService */
 	private $federatedUserService;
@@ -77,16 +77,16 @@ class MembershipsRemoved implements IEventListener {
 	 * MembershipsRemoved constructor.
 	 *
 	 * @param CirclesManager $circlesManager
-	 * @param ShareWrapperRequest $shareWrapperRequest
+	 * @param ShareWrapperService $shareWrapperService
 	 * @param FederatedUserService $federatedUserService
 	 */
 	public function __construct(
 		CirclesManager $circlesManager,
-		ShareWrapperRequest $shareWrapperRequest,
+		ShareWrapperService $shareWrapperService,
 		FederatedUserService $federatedUserService
 	) {
 		$this->circlesManager = $circlesManager;
-		$this->shareWrapperRequest = $shareWrapperRequest;
+		$this->shareWrapperService = $shareWrapperService;
 		$this->federatedUserService = $federatedUserService;
 	}
 
@@ -123,9 +123,9 @@ class MembershipsRemoved implements IEventListener {
 			$federatedUser = $this->circlesManager->getFederatedUser($membership->getSingleId());
 			if ($federatedUser->getUserType() === Member::TYPE_USER
 				&& $federatedUser->isLocal()) {
-				$this->shareWrapperRequest->removeByInitiatorAndShareWith(
-					$federatedUser->getUserId(),
-					$membership->getCircleId()
+				$this->shareWrapperService->deleteSharesToCircle(
+					$membership->getCircleId(),
+					$federatedUser->getUserId()
 				);
 			}
 		}

--- a/lib/Model/FileCacheWrapper.php
+++ b/lib/Model/FileCacheWrapper.php
@@ -475,7 +475,7 @@ class FileCacheWrapper extends ManagedModel implements IQueryRow, IDeserializabl
 			 ->setPath($this->get('path', $data))
 			 ->setPermissions($this->getInt('permissions', $data))
 			 ->setStorage($this->get('storage', $data))
-			 ->setStorageId($this->getInt('storage', $data))
+			 ->setStorageId($this->getInt('storageId', $data))
 			 ->setPathHash($this->get('pathHash', $data))
 			 ->setParent($this->getInt('parent', $data))
 			 ->setName($this->get('name', $data))

--- a/lib/Model/Probes/CircleProbe.php
+++ b/lib/Model/Probes/CircleProbe.php
@@ -367,6 +367,13 @@ class CircleProbe extends MemberProbe {
 
 
 	/**
+	 * @return string
+	 */
+	public function getChecksum(): string {
+		return md5(json_encode($this->getAsOptions()));
+	}
+
+	/**
 	 * Return a JSON object with includes as options
 	 *
 	 * @return array

--- a/lib/Service/MaintenanceService.php
+++ b/lib/Service/MaintenanceService.php
@@ -42,8 +42,8 @@ use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\CircleProbe;
 use OCA\Circles\Model\ShareWrapper;
-use OCP\IGroupManager;
 use OCA\Circles\Tools\Traits\TNCLogger;
+use OCP\IGroupManager;
 use OCP\IUserManager;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -80,6 +80,8 @@ class MaintenanceService {
 	/** @var FederatedUserService */
 	private $federatedUserService;
 
+	private ShareWrapperService $shareWrapperService;
+
 	/** @var MembershipService */
 	private $membershipService;
 
@@ -101,11 +103,13 @@ class MaintenanceService {
 	 * MaintenanceService constructor.
 	 *
 	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
 	 * @param CircleRequest $circleRequest
 	 * @param MemberRequest $memberRequest
 	 * @param ShareWrapperRequest $shareWrapperRequest
 	 * @param SyncService $syncService
 	 * @param FederatedUserService $federatedUserService
+	 * @param ShareWrapperService $shareWrapperService
 	 * @param MembershipService $membershipService
 	 * @param EventWrapperService $eventWrapperService
 	 * @param CircleService $circleService
@@ -119,6 +123,7 @@ class MaintenanceService {
 		ShareWrapperRequest $shareWrapperRequest,
 		SyncService $syncService,
 		FederatedUserService $federatedUserService,
+		ShareWrapperService $shareWrapperService,
 		MembershipService $membershipService,
 		EventWrapperService $eventWrapperService,
 		CircleService $circleService,
@@ -131,6 +136,7 @@ class MaintenanceService {
 		$this->shareWrapperRequest = $shareWrapperRequest;
 		$this->syncService = $syncService;
 		$this->federatedUserService = $federatedUserService;
+		$this->shareWrapperService = $shareWrapperService;
 		$this->eventWrapperService = $eventWrapperService;
 		$this->membershipService = $membershipService;
 		$this->circleService = $circleService;
@@ -347,7 +353,7 @@ class MaintenanceService {
 
 		foreach ($shares as $share) {
 			if (!in_array($share, $circles)) {
-				$this->shareWrapperRequest->deleteFromCircle($share);
+				$this->shareWrapperService->deleteSharesToCircle($share, '', true);
 			}
 		}
 	}
@@ -405,7 +411,7 @@ class MaintenanceService {
 	private function fixSubCirclesDisplayName(): void {
 		$probe = new CircleProbe();
 		$probe->includeSingleCircles();
-		
+
 		$circles = $this->circleService->getCircles($probe);
 
 		foreach ($circles as $circle) {

--- a/lib/Tools/Traits/TDeserialize.php
+++ b/lib/Tools/Traits/TDeserialize.php
@@ -78,14 +78,19 @@ trait TDeserialize {
 
 
 	/**
-	 * @param array $data
+	 * @param string $json
 	 * @param string $class
 	 *
 	 * @return IDeserializable[]
 	 * @throws InvalidItemException
 	 */
-	public function deserializeArray(array $data, string $class): array {
+	public function deserializeArray(string $json, string $class): array {
 		$arr = [];
+		$data = json_decode($json, true);
+		if (!is_array($data)) {
+			return $arr;
+		}
+
 		foreach ($data as $entry) {
 			$arr[] = $this->deserialize($entry, $class);
 		}


### PR DESCRIPTION
The idea is to cache the result from getSharedWith() which can be requested multiple times (at least 4) when loading a new page on Files App. 

Each cache is identified by a key based on:

- the singleId of the initiator, 
- the nodeId of the request, can be `0`
- the checksum of the `Probe` object.

The cache related to the singleId of the membership is reset when membership is updated.
All the cache is clear when creating/editing/deleting a share. _(It might be interesting to filter the memberships affected by the share)_

