### PR TITLE
limit some feature when Circles is managed by an app

### DIFF
--- a/lib/Command/CirclesConfig.php
+++ b/lib/Command/CirclesConfig.php
@@ -102,6 +102,10 @@ class CirclesConfig extends Base {
 			 )
 			 ->addOption('initiator', '', InputOption::VALUE_REQUIRED, 'set an initiator to the request', '')
 			 ->addOption('initiator-type', '', InputOption::VALUE_REQUIRED, 'set initiator type', '0')
+			 ->addOption(
+				 'super-session', '',
+				 InputOption::VALUE_NONE, 'use super session to bypass some condition'
+			 )
 			 ->addOption('status-code', '', InputOption::VALUE_NONE, 'display status code on exception');
 	}
 
@@ -133,12 +137,16 @@ class CirclesConfig extends Base {
 		$circleId = (string)$input->getArgument('circle_id');
 
 		try {
-			$this->federatedUserService->commandLineInitiator(
-				$input->getOption('initiator'),
-				Member::parseTypeString($input->getOption('initiator-type')),
-				$circleId,
-				false
-			);
+			if ($input->getArgument('super-session')) {
+				$this->federatedUserService->bypassCurrentUserCondition(true);
+			} else {
+				$this->federatedUserService->commandLineInitiator(
+					$input->getOption('initiator'),
+					Member::parseTypeString($input->getOption('initiator-type')),
+					$circleId,
+					false
+				);
+			}
 
 			$circle = $this->circleService->getCircle($circleId);
 

--- a/lib/Exceptions/RemoteCircleException.php
+++ b/lib/Exceptions/RemoteCircleException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2021
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Exceptions;
+
+class RemoteCircleException extends FederatedItemBadRequestException {
+}

--- a/lib/Exceptions/SuperSessionException.php
+++ b/lib/Exceptions/SuperSessionException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Exceptions;
+
+class SuperSessionException extends FederatedItemUnauthorizedException {
+}

--- a/lib/FederatedItems/CircleConfig.php
+++ b/lib/FederatedItems/CircleConfig.php
@@ -31,7 +31,6 @@ declare(strict_types=1);
 
 namespace OCA\Circles\FederatedItems;
 
-use OCA\Circles\Tools\Traits\TDeserialize;
 use OCA\Circles\Db\CircleRequest;
 use OCA\Circles\Exceptions\FederatedItemBadRequestException;
 use OCA\Circles\Exceptions\FederatedItemException;
@@ -41,6 +40,7 @@ use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Model\Helpers\MemberHelper;
 use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Tools\Traits\TDeserialize;
 
 /**
  * Class CircleConfig
@@ -87,6 +87,15 @@ class CircleConfig implements
 		$listing = Circle::$DEF_CFG_CORE_FILTER;
 		if (!$circle->isConfig(Circle::CFG_SYSTEM)) {
 			$listing = array_merge($listing, Circle::$DEF_CFG_SYSTEM_FILTER);
+		}
+
+		// filtering config values when not using Super Session
+		if (!$event->getParams()->gBool('superSession')) {
+			if ($circle->isConfig(Circle::CFG_APP)) {
+				$config |= Circle::CFG_APP;
+			} else {
+				$config &= ~Circle::CFG_APP;
+			}
 		}
 
 		$confirmed = true;

--- a/lib/FederatedItems/CircleDestroy.php
+++ b/lib/FederatedItems/CircleDestroy.php
@@ -31,18 +31,22 @@ declare(strict_types=1);
 
 namespace OCA\Circles\FederatedItems;
 
-use OCA\Circles\Tools\Traits\TDeserialize;
 use OCA\Circles\Db\CircleRequest;
 use OCA\Circles\Db\MemberRequest;
+use OCA\Circles\Exceptions\FederatedItemBadRequestException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\IFederatedItem;
 use OCA\Circles\IFederatedItemAsyncProcess;
 use OCA\Circles\IFederatedItemHighSeverity;
 use OCA\Circles\IFederatedItemMemberEmpty;
+use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Model\Helpers\MemberHelper;
 use OCA\Circles\Service\EventService;
 use OCA\Circles\Service\MembershipService;
+use OCA\Circles\StatusCode;
+use OCA\Circles\Tools\Traits\TDeserialize;
+use OCA\Circles\Tools\Traits\TStringTools;
 
 /**
  * Class CircleDestroy
@@ -54,6 +58,7 @@ class CircleDestroy implements
 	IFederatedItemHighSeverity,
 	IFederatedItemAsyncProcess,
 	IFederatedItemMemberEmpty {
+	use TStringTools;
 	use TDeserialize;
 
 
@@ -91,9 +96,18 @@ class CircleDestroy implements
 
 	/**
 	 * @param FederatedEvent $event
+	 *
+	 * @throws FederatedItemBadRequestException
 	 */
 	public function verify(FederatedEvent $event): void {
 		$circle = $event->getCircle();
+		if ($circle->isConfig(Circle::CFG_APP)) {
+			throw new FederatedItemBadRequestException(
+				StatusCode::$CIRCLE_DESTROY[120],
+				120
+			);
+		}
+
 		$initiator = $circle->getInitiator();
 
 		$initiatorHelper = new MemberHelper($initiator);

--- a/lib/Model/Circle.php
+++ b/lib/Model/Circle.php
@@ -31,11 +31,6 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Model;
 
-use OCA\Circles\Tools\Db\IQueryRow;
-use OCA\Circles\Tools\Exceptions\InvalidItemException;
-use OCA\Circles\Tools\IDeserializable;
-use OCA\Circles\Tools\Traits\TDeserialize;
-use OCA\Circles\Tools\Traits\TArrayTools;
 use DateTime;
 use JsonSerializable;
 use OCA\Circles\Db\CircleRequest;
@@ -52,6 +47,11 @@ use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\IEntity;
 use OCA\Circles\Model\Helpers\MemberHelper;
+use OCA\Circles\Tools\Db\IQueryRow;
+use OCA\Circles\Tools\Exceptions\InvalidItemException;
+use OCA\Circles\Tools\IDeserializable;
+use OCA\Circles\Tools\Traits\TArrayTools;
+use OCA\Circles\Tools\Traits\TDeserialize;
 use OCP\Security\IHasher;
 
 /**
@@ -112,8 +112,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	public const CFG_CIRCLE_INVITE = 16384;     // Circle must confirm when invited in another circle
 	public const CFG_FEDERATED = 32768;         // Federated
 	public const CFG_MOUNTPOINT = 65536;        // Generate a Files folder for this Circle
-
-	public static $DEF_CFG_MAX = 131071;
+	public const CFG_APP = 131072;          // Some features are not available to the OCS API (ie. destroying Circle)
+	public static $DEF_CFG_MAX = 262143;
 
 
 	/**
@@ -139,7 +139,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 		8192 => 'T|Root',
 		16384 => 'CI|Circle Invite',
 		32768 => 'F|Federated',
-		65536 => 'M|Nountpoint'
+		65536 => 'M|Nountpoint',
+		131072 => 'A|App'
 	];
 
 
@@ -157,7 +158,9 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 		16 => 'Circle',
 		10000 => 'Nextcloud App',
 		10001 => 'Circles App',
-		10002 => 'Admin Command Line'
+		10002 => 'Admin Command Line',
+		11000 => '3rd party app',
+		11010 => 'Collectives App'
 	];
 
 

--- a/lib/Model/Member.php
+++ b/lib/Model/Member.php
@@ -82,6 +82,7 @@ class Member extends ManagedModel implements
 
 	public const APP_CIRCLES = 10001;
 	public const APP_OCC = 10002;
+	public const APP_DEFAULT = 11000;
 
 
 	public static $TYPE = [

--- a/lib/Model/Probes/CircleProbe.php
+++ b/lib/Model/Probes/CircleProbe.php
@@ -68,9 +68,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includePersonalCircles(bool $include = true): self {
-		$this->include |= Circle::CFG_PERSONAL;
-		if (!$include) {
-			$this->include -= Circle::CFG_PERSONAL;
+		if ($include) {
+			$this->include |= Circle::CFG_PERSONAL;
+		} else {
+			$this->include &= ~Circle::CFG_PERSONAL;
 		}
 
 		return $this;
@@ -84,9 +85,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeSingleCircles(bool $include = true): self {
-		$this->include |= Circle::CFG_SINGLE;
-		if (!$include) {
-			$this->include -= Circle::CFG_SINGLE;
+		if ($include) {
+			$this->include |= Circle::CFG_SINGLE;
+		} else {
+			$this->include &= ~Circle::CFG_SINGLE;
 		}
 
 		return $this;
@@ -100,9 +102,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeSystemCircles(bool $include = true): self {
-		$this->include |= Circle::CFG_SYSTEM;
-		if (!$include) {
-			$this->include -= Circle::CFG_SYSTEM;
+		if ($include) {
+			$this->include |= Circle::CFG_SYSTEM;
+		} else {
+			$this->include &= ~Circle::CFG_SYSTEM;
 		}
 
 		return $this;
@@ -116,9 +119,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeHiddenCircles(bool $include = true): self {
-		$this->include |= Circle::CFG_HIDDEN;
-		if (!$include) {
-			$this->include -= Circle::CFG_HIDDEN;
+		if ($include) {
+			$this->include |= Circle::CFG_HIDDEN;
+		} else {
+			$this->include &= ~Circle::CFG_HIDDEN;
 		}
 
 		return $this;
@@ -132,9 +136,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeBackendCircles(bool $include = true): self {
-		$this->include |= Circle::CFG_BACKEND;
-		if (!$include) {
-			$this->include -= Circle::CFG_BACKEND;
+		if ($include) {
+			$this->include |= Circle::CFG_BACKEND;
+		} else {
+			$this->include &= ~Circle::CFG_BACKEND;
 		}
 
 		return $this;
@@ -215,9 +220,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterPersonalCircles(bool $filter = true): self {
-		$this->filter |= Circle::CFG_PERSONAL;
-		if (!$filter) {
-			$this->filter -= Circle::CFG_PERSONAL;
+		if ($filter) {
+			$this->filter |= Circle::CFG_PERSONAL;
+		} else {
+			$this->filter &= ~Circle::CFG_PERSONAL;
 		}
 
 		return $this;
@@ -231,9 +237,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterSingleCircles(bool $filter = true): self {
-		$this->filter |= Circle::CFG_SINGLE;
-		if (!$filter) {
-			$this->filter -= Circle::CFG_SINGLE;
+		if ($filter) {
+			$this->filter |= Circle::CFG_SINGLE;
+		} else {
+			$this->filter &= ~Circle::CFG_SINGLE;
 		}
 
 		return $this;
@@ -247,9 +254,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterSystemCircles(bool $filter = true): self {
-		$this->filter |= Circle::CFG_SYSTEM;
-		if (!$filter) {
-			$this->filter -= Circle::CFG_SYSTEM;
+		if ($filter) {
+			$this->filter |= Circle::CFG_SYSTEM;
+		} else {
+			$this->filter &= ~Circle::CFG_SYSTEM;
 		}
 
 		return $this;
@@ -263,9 +271,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterHiddenCircles(bool $filter = true): self {
-		$this->filter |= Circle::CFG_HIDDEN;
-		if (!$filter) {
-			$this->filter -= Circle::CFG_HIDDEN;
+		if ($filter) {
+			$this->filter |= Circle::CFG_HIDDEN;
+		} else {
+			$this->filter &= ~Circle::CFG_HIDDEN;
 		}
 
 		return $this;
@@ -279,9 +288,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterBackendCircles(bool $filter = true): self {
-		$this->filter |= Circle::CFG_BACKEND;
-		if (!$filter) {
-			$this->filter -= Circle::CFG_BACKEND;
+		if ($filter) {
+			$this->filter |= Circle::CFG_BACKEND;
+		} else {
+			$this->filter &= ~Circle::CFG_BACKEND;
 		}
 
 		return $this;
@@ -297,9 +307,10 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterConfig(int $config, bool $filter = true): self {
-		$this->filter |= $config;
-		if (!$filter) {
-			$this->filter -= $config;
+		if ($filter) {
+			$this->filter |= $config;
+		} else {
+			$this->filter &= ~$config;
 		}
 
 		return $this;

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -31,16 +31,16 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Service;
 
-use OCA\Circles\Tools\Model\NCRequest;
-use OCA\Circles\Tools\Traits\TNCLogger;
-use OCA\Circles\Tools\Traits\TArrayTools;
-use OCA\Circles\Tools\Traits\TStringTools;
 use OC;
 use OCA\Circles\AppInfo\Application;
 use OCA\Circles\Exceptions\GSStatusException;
 use OCA\Circles\IFederatedUser;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Member;
+use OCA\Circles\Tools\Model\NCRequest;
+use OCA\Circles\Tools\Traits\TArrayTools;
+use OCA\Circles\Tools\Traits\TNCLogger;
+use OCA\Circles\Tools\Traits\TStringTools;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 
@@ -343,7 +343,7 @@ class ConfigService {
 		}
 
 		return (!$this->getBool('password_single_enabled', $circle->getSettings(), false)
-			|| $this->get('password_single', $circle->getSettings()) === '');
+				|| $this->get('password_single', $circle->getSettings()) === '');
 	}
 
 
@@ -761,9 +761,7 @@ class ConfigService {
 	public function confirmAllowedCircleTypes(Circle $circle): void {
 		$config = $circle->getConfig();
 		$config |= $this->getAppValueInt(ConfigService::CIRCLE_TYPES_FORCE);
-		$block = $this->getAppValueInt(ConfigService::CIRCLE_TYPES_BLOCK);
-		$config |= $block;
-		$config -= $block;
+		$config &= ~$this->getAppValueInt(ConfigService::CIRCLE_TYPES_BLOCK);
 		$circle->setConfig($config);
 	}
 }

--- a/lib/Service/FederatedUserService.php
+++ b/lib/Service/FederatedUserService.php
@@ -50,11 +50,13 @@ use OCA\Circles\Exceptions\InitiatorNotFoundException;
 use OCA\Circles\Exceptions\InvalidIdException;
 use OCA\Circles\Exceptions\MemberNotFoundException;
 use OCA\Circles\Exceptions\OwnerNotFoundException;
+use OCA\Circles\Exceptions\RemoteCircleException;
 use OCA\Circles\Exceptions\RemoteInstanceException;
 use OCA\Circles\Exceptions\RemoteNotFoundException;
 use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\Exceptions\SingleCircleNotFoundException;
+use OCA\Circles\Exceptions\SuperSessionException;
 use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\Exceptions\UserTypeNotFoundException;
 use OCA\Circles\FederatedItems\CircleCreate;
@@ -263,8 +265,12 @@ class FederatedUserService {
 	 * @param string $appId
 	 * @param int $appNumber
 	 *
+	 * @throws ContactAddressBookNotFoundException
+	 * @throws ContactFormatException
+	 * @throws ContactNotFoundException
 	 * @throws FederatedUserException
 	 * @throws InvalidIdException
+	 * @throws RequestBuilderException
 	 * @throws SingleCircleNotFoundException
 	 */
 	public function setLocalCurrentApp(string $appId, int $appNumber): void {
@@ -320,7 +326,7 @@ class FederatedUserService {
 		if ($this->bypass) {
 			return;
 		}
-		if (!$this->hasCurrentUser() && !$this->hasRemoteInstance()) {
+		if (!$this->hasCurrentEntity() && !$this->hasRemoteInstance()) {
 			throw new InitiatorNotFoundException('Invalid initiator');
 		}
 	}
@@ -337,6 +343,17 @@ class FederatedUserService {
 	 */
 	public function canBypassCurrentUserCondition(): bool {
 		return $this->bypass;
+	}
+
+	/**
+	 * @throws SuperSessionException
+	 */
+	public function confirmSuperSession(): void {
+		if ($this->canBypassCurrentUserCondition()) {
+			return;
+		}
+
+		throw new SuperSessionException('Must initialise Super Session');
 	}
 
 
@@ -406,7 +423,9 @@ class FederatedUserService {
 	 * @throws SingleCircleNotFoundException
 	 */
 	public function setMemberPatron(Member $member): void {
-		if ($this->isInitiatedByOcc()) {
+		if ($this->hasCurrentApp()) {
+			$member->setInvitedBy($this->getCurrentApp());
+		} elseif ($this->isInitiatedByOcc()) {
 			$member->setInvitedBy($this->getAppInitiator('occ', Member::APP_OCC));
 		} elseif ($this->isInitiatedByAdmin()) {
 			$member->setInvitedBy($this->getInitiatedByAdmin());
@@ -428,6 +447,25 @@ class FederatedUserService {
 	 */
 	public function hasCurrentApp(): bool {
 		return !is_null($this->currentApp);
+	}
+
+
+	/**
+	 * @return FederatedUser|null
+	 */
+	public function getCurrentEntity(): ?FederatedUser {
+		if ($this->hasCurrentUser()) {
+			return $this->getCurrentUser();
+		}
+
+		return $this->getCurrentApp();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasCurrentEntity(): bool {
+		return !is_null($this->currentApp) || !is_null($this->currentUser);
 	}
 
 
@@ -514,7 +552,11 @@ class FederatedUserService {
 		string $appDisplayName = ''
 	): FederatedUser {
 		if ($appDisplayName === '') {
-			$appDisplayName = $this->get((string)$appNumber, Circle::$DEF_SOURCE, $appId);
+			$appDisplayName = $this->get(
+				(string)$appNumber,
+				Circle::$DEF_SOURCE,
+				Circle::$DEF_SOURCE[Member::APP_DEFAULT]
+			);
 		}
 
 		$circle = new Circle();
@@ -567,14 +609,11 @@ class FederatedUserService {
 		}
 
 		if ($circleId !== '') {
-			$probe = new CircleProbe();
-			$probe->includeSystemCircles()
-				  ->includePersonalCircles();
-			$localCircle = $this->circleRequest->getCircle($circleId, null, $probe);
-			if ($this->configService->isLocalInstance($localCircle->getInstance())) {
-				$this->setCurrentUser($localCircle->getOwner());
+			try {
+				$this->setOwnerAsCurrentUser($circleId);
 
 				return;
+			} catch (RemoteCircleException $e) {
 			}
 		}
 
@@ -585,6 +624,29 @@ class FederatedUserService {
 		}
 
 		$this->bypassCurrentUserCondition($bypass);
+	}
+
+
+	/**
+	 * @param string $circleId
+	 *
+	 * @throws CircleNotFoundException
+	 * @throws FederatedUserException
+	 * @throws OwnerNotFoundException
+	 * @throws RemoteCircleException
+	 * @throws RequestBuilderException
+	 */
+	public function setOwnerAsCurrentUser(string $circleId): void {
+		$probe = new CircleProbe();
+		$probe->includeSystemCircles()
+			  ->includePersonalCircles();
+		
+		$localCircle = $this->circleRequest->getCircle($circleId, null, $probe);
+		if ($this->configService->isLocalInstance($localCircle->getInstance())) {
+			$this->setCurrentUser($localCircle->getOwner());
+		} else {
+			throw new RemoteCircleException();
+		}
 	}
 
 

--- a/lib/StatusCode.php
+++ b/lib/StatusCode.php
@@ -72,6 +72,10 @@ class StatusCode {
 		132 => 'Member type not allowed'
 	];
 
+	public static $CIRCLE_DESTROY = [
+		120 => 'Circle is managed from an other app'
+	];
+
 	public static $MEMBER_LEVEL = [
 		120 => 'The designed member\'s level is too high',
 		121 => 'Incorrect Level'


### PR DESCRIPTION
- Allow an App to gain control over a Circle:
```
		/** @var CirclesManager $circleManager */
		$circleManager = \OC::$server->get(CirclesManager::class);
		$circleManager->startSuperSession();
		$circleManager->flagAsAppManaged('tnxgB4xdBpgew6H4l9CJXEUauUNql71');
		$circleManager->stopSession();

```

- When marked as AppManaged, the Circle cannot be removed from the OCS API (ie. Contacts App)

- Allow an App to create its own Entity:
```
		/** @var CirclesManager $circleManager */
		$circleManager = \OC::$server->get(CirclesManager::class);
		$circleManager->startAppSession('my app', 11010);

		$circle = $circleManager->createCircle(
			'Test Circle',
			$circleManager->getLocalFederatedUser('test1')
		);
```
_identifying as an App does not give more rights. To have rights over a Circle, the Entity of the App needs to be member/moderator/admin of the targetted Circle._

- Also cleaning some bitwise operations.
