### PR TITLE
bypass circle types

### DIFF
--- a/lib/Command/CirclesConfig.php
+++ b/lib/Command/CirclesConfig.php
@@ -164,6 +164,14 @@ class CirclesConfig extends Base {
 
 		if (strtolower($input->getOption('output')) === 'json') {
 			$output->writeln(json_encode($outcome, JSON_PRETTY_PRINT));
+		} elseif (strtolower($input->getOption('output')) !== 'none') {
+			$circle = $this->circleService->getCircle($circleId);
+			$output->writeln(
+				json_encode(
+					Circle::getCircleFlags($circle, Circle::FLAGS_LONG),
+					JSON_PRETTY_PRINT
+				)
+			);
 		}
 
 		return 0;

--- a/lib/FederatedItems/CircleConfig.php
+++ b/lib/FederatedItems/CircleConfig.php
@@ -76,6 +76,7 @@ class CircleConfig implements
 	 * @param FederatedEvent $event
 	 *
 	 * @throws FederatedItemException
+	 * @throws \OCA\Circles\Exceptions\RequestBuilderException
 	 */
 	public function verify(FederatedEvent $event): void {
 		$circle = $event->getCircle();
@@ -141,7 +142,8 @@ class CircleConfig implements
 
 		$new = clone $circle;
 		$new->setConfig($config);
-		$this->configService->confirmAllowedCircleTypes($new);
+
+		$this->configService->confirmAllowedCircleTypes($new, $circle);
 
 		$event->getData()->sInt('config', $new->getConfig());
 

--- a/lib/Model/Member.php
+++ b/lib/Model/Member.php
@@ -737,7 +737,9 @@ class Member extends ManagedModel implements
 	 * @throws RequestBuilderException
 	 */
 	public function getLink(string $singleId, bool $detailed = false): Membership {
-		$this->getManager()->getLink($this, $singleId, $detailed);
+		if ($singleId !== '') {
+			return $this->getManager()->getLink($this, $singleId, $detailed);
+		}
 
 		throw new MembershipNotFoundException();
 	}

--- a/lib/Service/MembershipService.php
+++ b/lib/Service/MembershipService.php
@@ -31,8 +31,6 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Service;
 
-use OCA\Circles\Tools\Exceptions\ItemNotFoundException;
-use OCA\Circles\Tools\Traits\TNCLogger;
 use OCA\Circles\Db\CircleRequest;
 use OCA\Circles\Db\MemberRequest;
 use OCA\Circles\Db\MembershipRequest;
@@ -44,6 +42,8 @@ use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\FederatedUser;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Membership;
+use OCA\Circles\Tools\Exceptions\ItemNotFoundException;
+use OCA\Circles\Tools\Traits\TNCLogger;
 
 /**
  * Class MembershipService


### PR DESCRIPTION
This PR allow to assign an entity that can bypass force/block rules on Circles' types.

The entity is a singleId and can be a group, a circle or a single user

```
./occ config:app:set circles bypass_circle_types --value <singleId>
```