### PR TITLE
use master to test oci

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -210,6 +210,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['oci']
+        server-versions: ["master"]
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}
 


### PR DESCRIPTION
Just to make it easier to parse and replace master to stable* when stable-branching