### PR TITLE
remove child shares

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -431,11 +431,56 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 	 * @param string $initiator
 	 */
 	public function deleteSharesToCircle(string $circleId, string $initiator = ''): void {
-		$qb = $this->getShareDeleteSql();
-		$qb->andWhere($qb->exprLimit('share_with', $circleId));
+		$qb = $this->getShareSelectSql();
+		$qb->limit('share_with', $circleId);
 		if ($initiator !== '') {
 			$qb->limit('uid_initiator', $initiator);
 		}
+
+		$ids = array_map(
+			function (ShareWrapper $share): string {
+				return $share->getId();
+			},
+			$this->getItemsFromRequest($qb)
+		);
+
+		$this->deleteSharesAndChild($ids);
+	}
+
+
+	public function removeOrphanShares(): void {
+		$qb = $this->getShareSelectSql();
+		$expr = $qb->expr();
+		$qb->leftJoin(
+			CoreQueryBuilder::SHARE, CoreRequestBuilder::TABLE_SHARE, 'p',
+			$expr->andX($expr->eq('p.id', CoreQueryBuilder::SHARE . '.parent'))
+		);
+
+		$qb->filterNull('parent');
+		$qb->limitNull('id', false, 'p');
+
+		$ids = [];
+		$cursor = $qb->execute();
+		while ($data = $cursor->fetch()) {
+			$ids[] = $data['id'];
+		}
+		$cursor->closeCursor();
+
+		$this->deleteSharesAndChild($ids);
+	}
+
+
+	/**
+	 * @param array $ids
+	 */
+	private function deleteSharesAndChild(array $ids): void {
+		$qb = $this->getShareDeleteSql();
+		$qb->andWhere(
+			$qb->expr()->orX(
+				$qb->exprLimitInArray('id', $ids),
+				$qb->exprLimitInArray('parent', $ids)
+			)
+		);
 
 		$qb->execute();
 	}

--- a/lib/Listeners/Files/DestroyingCircle.php
+++ b/lib/Listeners/Files/DestroyingCircle.php
@@ -77,6 +77,6 @@ class DestroyingCircle implements IEventListener {
 		}
 
 		$circle = $event->getCircle();
-		$this->shareWrapperService->deleteSharesToCircle($circle->getSingleId(), '', true);
+		$this->shareWrapperService->deleteAllSharesToCircle($circle->getSingleId());
 	}
 }

--- a/lib/Listeners/Files/MembershipsRemoved.php
+++ b/lib/Listeners/Files/MembershipsRemoved.php
@@ -123,7 +123,7 @@ class MembershipsRemoved implements IEventListener {
 			$federatedUser = $this->circlesManager->getFederatedUser($membership->getSingleId());
 			if ($federatedUser->getUserType() === Member::TYPE_USER
 				&& $federatedUser->isLocal()) {
-				$this->shareWrapperService->deleteSharesToCircle(
+				$this->shareWrapperService->deleteUserSharesToCircle(
 					$membership->getCircleId(),
 					$federatedUser->getUserId()
 				);

--- a/lib/Service/MaintenanceService.php
+++ b/lib/Service/MaintenanceService.php
@@ -290,6 +290,13 @@ class MaintenanceService {
 
 		try {
 			// Can be removed in NC27.
+			$this->output('Remove orphan shares');
+			$this->removeOrphanShares();
+		} catch (Exception $e) {
+		}
+
+		try {
+			// Can be removed in NC27.
 			$this->output('fix sub-circle display name');
 			$this->fixSubCirclesDisplayName();
 		} catch (Exception $e) {
@@ -331,6 +338,14 @@ class MaintenanceService {
 	}
 
 
+	private function removeOrphanShares(): void {
+		$this->shareWrapperRequest->removeOrphanShares();
+	}
+
+
+	/**
+	 * @throws RequestBuilderException
+	 */
 	private function removeDeprecatedShares(): void {
 		$probe = new CircleProbe();
 		$probe->includePersonalCircles()
@@ -353,7 +368,7 @@ class MaintenanceService {
 
 		foreach ($shares as $share) {
 			if (!in_array($share, $circles)) {
-				$this->shareWrapperService->deleteSharesToCircle($share, '', true);
+				$this->shareWrapperService->deleteAllSharesToCircle($share);
 			}
 		}
 	}

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -126,13 +126,22 @@ class ShareWrapperService {
 	 *
 	 * @throws Exception
 	 */
-	public function deleteSharesToCircle(string $circleId, string $initiator = '', bool $force = false): void {
-		if ($initiator === '' && !$force) {
-			throw new Exception('if initiator is empty, you need to set $force as true');
+	public function deleteUserSharesToCircle(string $circleId, string $initiator): void {
+		if ($initiator === '') {
+			throw new Exception('$initiator cannot be empty');
 		}
 
 		$this->cache->clear('');
 		$this->shareWrapperRequest->deleteSharesToCircle($circleId, $initiator);
+	}
+
+
+	/**
+	 * @param string $circleId
+	 */
+	public function deleteAllSharesToCircle(string $circleId): void {
+		$this->cache->clear('');
+		$this->shareWrapperRequest->deleteSharesToCircle($circleId, '');
 	}
 
 


### PR DESCRIPTION
1000!

Issue:

- userA shares a first file to a Circle (including userA and userB),
- userB leaves the share,
- Circle is destroyed, a new Circle is created (including userA and userB)
- Sharing the same file.


Fix:

- split getUserShares from a single user to a circle and getAllShares to a circle
- when a circle is deleted, or when a member is removed, get affected shares ids
- get orphans on a maintenance process
- delete all shares and child based on ids.
 

The request that get all orphan shares, based on `parent` `not null` and entry with `id`=`parent` exists:
```
SELECT `sh`.`id`, `sh`.`share_type`, `sh`.`share_with`, `sh`.`uid_owner`, `sh`.`uid_initiator`, `sh`.`parent`, `sh`.`item_type`, `sh`.`item_source`, `sh`.`item_target`, `sh`.`file_source`, `sh`.`file_target`, `sh`.`permissions`, `sh`.`stime`, `sh`.`accepted`, `sh`.`expiration`, `sh`.`token`, `sh`.`mail_send` FROM `oc_share` `sh` LEFT JOIN `oc_share` `p` ON `p`.`id` = `sh`.`parent` WHERE (`sh`.`share_type` = 7) AND (`sh`.`parent` IS NOT NULL) AND (`p`.`id` IS NULL)
```


The request that drop shares and child based on an array of ids:
```
DELETE FROM `oc_share` WHERE (`share_type` = 7) AND ((`id` IN ('6')) OR (`parent` IN ('6')))
```