### PR TITLE
check owner attendance

### DIFF
--- a/lib/Model/FederatedUser.php
+++ b/lib/Model/FederatedUser.php
@@ -385,6 +385,10 @@ class FederatedUser extends ManagedModel implements
 	 * @throws OwnerNotFoundException
 	 */
 	public function importFromCircle(Circle $circle): self {
+		if (!$circle->hasOwner()) {
+			throw new OwnerNotFoundException();
+		}
+
 		$this->setSingleId($circle->getSingleId());
 
 		if ($circle->isConfig(Circle::CFG_SINGLE)) {


### PR DESCRIPTION
to avoid unhandled exception in case of badly configured circles app when running occ user:list