### PR TITLE
fix array key on import()

### DIFF
--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -732,8 +732,8 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			 ->setFileSource($this->getInt('fileSource', $data))
 			 ->setFileTarget($this->get('fileTarget', $data))
 			 ->setSharedWith($this->get('sharedWith', $data))
-			 ->setSharedBy($this->get('uidInitiator', $data))
-			 ->setShareOwner($this->get('uidOwner', $data))
+			 ->setSharedBy($this->get('sharedBy', $data))
+			 ->setShareOwner($this->get('shareOwner', $data))
 			 ->setToken($this->get('token', $data))
 			 ->setShareTime($shareTime);
 


### PR DESCRIPTION
`import()` is used to deserialize the model, array keys should fit the one used in `jsonSerialize()`