### PR TITLE
confirmKey must be uuid

### DIFF
--- a/lib/Service/RemoteStreamService.php
+++ b/lib/Service/RemoteStreamService.php
@@ -133,7 +133,7 @@ class RemoteStreamService extends NCSignature {
 		$this->fillSimpleSignatory($app, $generate);
 		$app->setUidFromKey();
 
-		if ($confirmKey !== '') {
+		if ($this->isUuid($confirmKey)) {
 			$app->setAuthSigned($this->signString($confirmKey, $app));
 		}
 

--- a/lib/Tools/Traits/TStringTools.php
+++ b/lib/Tools/Traits/TStringTools.php
@@ -86,6 +86,19 @@ trait TStringTools {
 
 
 	/**
+	 * @param string $uuid
+	 *
+	 * @return bool
+	 */
+	protected function isUuid(string $uuid): bool {
+		if ($uuid === '') {
+			return false;
+		}
+
+		return (preg_match('/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i', $uuid) === 1);
+	}
+
+	/**
 	 * @param string $line
 	 * @param int $length
 	 *


### PR DESCRIPTION
Avoid the use of `confirmKey` to encrypt headers content and spoof instance's identity