### PR TITLE
Revert "[stable22] log failed member generation"

### DIFF
--- a/lib/FederatedItems/MassiveMemberAdd.php
+++ b/lib/FederatedItems/MassiveMemberAdd.php
@@ -68,7 +68,7 @@ class MassiveMemberAdd extends SingleMemberAdd implements
 		if (!$circle->isConfig(Circle::CFG_FRIEND)) {
 			$initiatorHelper->mustBeModerator();
 		}
-
+		
 		$members = $event->getMembers();
 		$filtered = [];
 
@@ -76,7 +76,6 @@ class MassiveMemberAdd extends SingleMemberAdd implements
 			try {
 				$filtered[] = $this->generateMember($event, $circle, $member);
 			} catch (Exception $e) {
-				$this->e($e, ['event' => $event, 'circle' => $circle, 'member' => $member]);
 			}
 		}
 


### PR DESCRIPTION
Reverts nextcloud/circles#1078

merged too early, during RC stage