### PR TITLE
Fix getAllShare crash

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -671,5 +671,6 @@ class ShareByCircleProvider implements IShareProvider {
 //			};
 //		}
 //		$cursor->closeCursor();
+		return [];
 	}
 }


### PR DESCRIPTION
Internal Server Error\nReturn value of OCA\\Circles\\ShareByCircleProvider::getAllShares()
must be iterable, none returned in file '/var/www/html/apps-extra/circles/lib/ShareByCircleProvider.php' line 674

Signed-off-by: Carl Schwan <carl@carlschwan.eu>