### PR TITLE
[stable22] Avoid using non-existing \OCP\Server::get

### DIFF
--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -678,8 +678,8 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 
 		$display = $circle->getDisplayName();
 		if ($circle->getSource() === Member::TYPE_CIRCLE) {
-			$l10n = \OCP\Server::get(IFactory::class)->get('circles');
-			$display = $l10n->t('%1 (Circle owned by %2)', [$display, $circle->getOwner()->getDisplayName()]);
+			$l10n = \OC::$server->get(IFactory::class)->get('circles');
+			$display = $l10n->t('%s (Circle owned by %s)', [$display, $circle->getOwner()->getDisplayName()]);
 		} else {
 			$display .= ' (' . Circle::$DEF_SOURCE[$circle->getSource()] . ')';
 		}


### PR DESCRIPTION
and fix translation as it seems I forgot to push it to stable22 in a previous PR of mine