### PR TITLE
Rename selectors for files app elements

### DIFF
--- a/js/files/circles.files.list.js
+++ b/js/files/circles.files.list.js
@@ -30,7 +30,7 @@
 	 * @classdesc Circles file list.
 	 * Contains a list of files filtered by circles
 	 *
-	 * @param $el container element with existing markup for the #controls
+	 * @param $el container element with existing markup for the .files-controls
 	 * and a table
 	 * @param [options] map of options, see other parameters
 	 * @param {Array.<string>} [options.circlesIds] array of system tag ids to
@@ -72,7 +72,7 @@
 
 			OC.Plugins.attach('OCA.Circles.FileList', this);
 
-			var $controls = this.$el.find('#controls').empty();
+			var $controls = this.$el.find('.files-controls').empty();
 
 			this._initFilterField($controls);
 		},
@@ -222,15 +222,15 @@
 				// root has special permissions
 				if (!this._circlesIds.length) {
 					// no tags selected
-					this.$el.find('#emptycontent').html('<div class="icon-systemtags"></div>' +
+					this.$el.find('.emptyfilelist.emptycontent').html('<div class="icon-systemtags"></div>' +
 						'<h2>' + t('circles', 'Please select circles to filter by') + '</h2>');
 				} else {
 					// tags selected but no results
-					this.$el.find('#emptycontent').html('<div class="icon-systemtags"></div>' +
+					this.$el.find('.emptyfilelist.emptycontent').html('<div class="icon-systemtags"></div>' +
 						'<h2>' + t('circles', 'No files found for the selected circles') + '</h2>');
 				}
-				this.$el.find('#emptycontent').toggleClass('hidden', !this.isEmpty);
-				this.$el.find('#filestable thead th').toggleClass('hidden', this.isEmpty);
+				this.$el.find('.emptyfilelist.emptycontent').toggleClass('hidden', !this.isEmpty);
+				this.$el.find('.files-filestable thead th').toggleClass('hidden', this.isEmpty);
 			}
 			else {
 				OCA.Files.FileList.prototype.updateEmptyContent.apply(this, arguments);

--- a/templates/files/list.php
+++ b/templates/files/list.php
@@ -1,7 +1,7 @@
-<div id="controls">
+<div class="files-controls">
 </div>
 
-<div id="emptycontent" class="hidden">
+<div class="emptyfilelist emptycontent" class="hidden">
 	<div class="icon-folder"></div>
 	<h2><?php p($l->t('No files in here')); ?></h2>
 	<p class="uploadmessage hidden"></p>
@@ -13,23 +13,23 @@
 	<p></p>
 </div>
 
-<table id="filestable" data-preview-x="32" data-preview-y="32">
+<table class="files-filestable" data-preview-x="32" data-preview-y="32">
 	<thead>
 		<tr>
-			<th id='headerName' class="hidden column-name">
-				<div id="headerName-container">
+			<th class="hidden column-name">
+				<div id="column-name-container">
 					<a class="name sort columntitle" data-sort="name"><span><?php p($l->t('Name')); ?></span><span class="sort-indicator"></span></a>
 				</div>
 			</th>
-			<th id="headerSize" class="hidden column-size">
+			<th class="hidden column-size">
 				<a class="size sort columntitle" data-sort="size"><span><?php p($l->t('Size')); ?></span><span class="sort-indicator"></span></a>
 			</th>
-			<th id="headerDate" class="hidden column-mtime">
+			<th class="hidden column-mtime">
 				<a id="modified" class="columntitle" data-sort="mtime"><span><?php p($l->t('Modified')); ?></span><span class="sort-indicator"></span></a>
 			</th>
 		</tr>
 	</thead>
-	<tbody id="fileList">
+	<tbody class="files-fileList">
 	</tbody>
 	<tfoot>
 	</tfoot>


### PR DESCRIPTION
Elements in the files app have been renamed to avoid duplicate ids.

For https://github.com/nextcloud/server/pull/33320