### PR TITLE
Add `$shallow` arg to `ShareByCircleProvider::getSharesInFolder`

### DIFF
--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -45,6 +45,7 @@ use OCP\Files\NotFoundException;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\Share\IShare;
+use OCP\Files\Folder;
 
 /**
  * Class ShareWrapperService
@@ -267,14 +268,15 @@ class ShareWrapperService {
 
 	/**
 	 * @param FederatedUser $federatedUser
-	 * @param int $nodeId
+	 * @param Folder $node
 	 * @param bool $reshares
+	 * @param bool $shallow Whether the method should stop at the first level, or look into sub-folders.
 	 *
 	 * @return ShareWrapper[]
 	 * @throws RequestBuilderException
 	 */
-	public function getSharesInFolder(FederatedUser $federatedUser, int $nodeId, bool $reshares): array {
-		return $this->shareWrapperRequest->getSharesInFolder($federatedUser, $nodeId, $reshares);
+	public function getSharesInFolder(FederatedUser $federatedUser, Folder $node, bool $reshares, bool $shallow = true): array {
+		return $this->shareWrapperRequest->getSharesInFolder($federatedUser, $node, $reshares, $shallow);
 	}
 
 

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -390,7 +390,7 @@ class ShareByCircleProvider implements IShareProvider {
 	 * @param string $userId
 	 * @param Folder $node
 	 * @param bool $reshares
-	 *
+	 * @param bool $shallow Whether the method should stop at the first level, or look into sub-folders.
 	 * @return array
 	 * @throws ContactAddressBookNotFoundException
 	 * @throws ContactFormatException
@@ -404,12 +404,13 @@ class ShareByCircleProvider implements IShareProvider {
 	 * @throws RequestBuilderException
 	 * @throws SingleCircleNotFoundException
 	 */
-	public function getSharesInFolder($userId, Folder $node, $reshares): array {
+	public function getSharesInFolder($userId, Folder $node, $reshares, $shallow = true): array {
 		$federatedUser = $this->federatedUserService->getLocalFederatedUser($userId);
 		$wrappedShares = $this->shareWrapperService->getSharesInFolder(
 			$federatedUser,
-			(!is_null($node)) ? $node->getId() : 0,
-			$reshares
+			$node,
+			$reshares,
+			$shallow
 		);
 
 		$result = [];

--- a/lib/ShareByCircleProviderDeprecated.php
+++ b/lib/ShareByCircleProviderDeprecated.php
@@ -378,10 +378,11 @@ class ShareByCircleProviderDeprecated extends CircleProviderRequest implements I
 	 * @param Folder $node
 	 * @param bool $reshares Also get the shares where $user is the owner instead of just the
 	 *     shares where $user is the initiator
+	 * @param bool $shallow Whether the method should stop at the first level, or look into sub-folders.
 	 *
 	 * @return Share[]
 	 */
-	public function getSharesInFolder($userId, Folder $node, $reshares) {
+	public function getSharesInFolder($userId, Folder $node, $reshares, $shallow = true) {
 		\OC::$server->getLogger()->log(3, 'deprecated>getSharesInFolder');
 		return [];
 //


### PR DESCRIPTION
A new `$shallow` argument was introduced to `IShareProvider::getSharesInFolder` in NC25 by https://github.com/nextcloud/server/pull/31728.

This PR adds this new argument and the necessary changes to make it work based on this example https://github.com/nextcloud/server/pull/31728/files#diff-dee1351696d7eae959761edf66c8e5a9052e28be73319733d857a9ab2d9fc967=


Looks like in the context of `ShareWrapperRequest`, the `$shallow` argument can't be used as we only have the `nodeId` so we cannot use the same method as in other places:

```php
if ($shallow) {
	$qb->andWhere($qb->expr()->eq('f.parent', $qb->createNamedParameter($node->getId())));
} else {
	$qb->andWhere($qb->expr()->like('f.path', $qb->createNamedParameter($this->dbConnection->escapeLikeParameter($node->getInternalPath()) . '/%')));
}
```

Should we change the methods to forward `$node` instead of `$nodeId`?
