### PR TITLE
cache getCircles when executed from an other app

### DIFF
--- a/lib/CirclesManager.php
+++ b/lib/CirclesManager.php
@@ -70,8 +70,6 @@ use OCA\Circles\Tools\Exceptions\InvalidItemException;
  * @package OCA\Circles
  */
 class CirclesManager {
-
-
 	/** @var FederatedUserService */
 	private $federatedUserService;
 
@@ -331,7 +329,7 @@ class CirclesManager {
 				  ->filterBackendCircles();
 		}
 
-		return $this->circleService->getCircles($probe);
+		return $this->circleService->getCircles($probe, true);
 	}
 
 


### PR DESCRIPTION
this is a quick fix, before the implementation of DataProbe (#1088)