### PR TITLE
update share on password change

### DIFF
--- a/lib/Db/ShareTokenRequest.php
+++ b/lib/Db/ShareTokenRequest.php
@@ -92,6 +92,20 @@ class ShareTokenRequest extends ShareTokenRequestBuilder {
 
 
 	/**
+	 * @param string $circleId
+	 * @param string $hashedPassword
+	 */
+	public function updateSharePassword(string $circleId, string $hashedPassword) {
+		$qb = $this->getTokenUpdateSql();
+		$qb->limitToCircleId($circleId);
+
+		$qb->set('password', $qb->createNamedParameter($hashedPassword));
+
+		$qb->executeStatement();
+	}
+
+
+	/**
 	 * @param string $singleId
 	 * @param string $circleId
 	 */

--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -31,19 +31,18 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Model;
 
-use OCA\Circles\Tools\Db\IQueryRow;
-use OCA\Circles\Tools\Exceptions\InvalidItemException;
-use OCA\Circles\Tools\IDeserializable;
-use OCA\Circles\Tools\Traits\TDeserialize;
-use OCA\Circles\Tools\Traits\TArrayTools;
 use DateTime;
-use DateTimeInterface;
 use JsonSerializable;
 use OC;
 use OC\Files\Cache\Cache;
 use OC\Share20\Share;
 use OCA\Circles\AppInfo\Application;
 use OCA\Circles\ShareByCircleProvider;
+use OCA\Circles\Tools\Db\IQueryRow;
+use OCA\Circles\Tools\Exceptions\InvalidItemException;
+use OCA\Circles\Tools\IDeserializable;
+use OCA\Circles\Tools\Traits\TArrayTools;
+use OCA\Circles\Tools\Traits\TDeserialize;
 use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -70,7 +69,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 	private string $token = '';
 	private int $status = 0;
 	private string $providerId = '';
-	private DateTimeInterface $shareTime;
+	private DateTime $shareTime;
 	private string $sharedWith = '';
 	private string $sharedBy = '';
 	private string $shareOwner = '';
@@ -188,13 +187,13 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 		return $this->providerId;
 	}
 
-	public function setShareTime(DateTimeInterface $shareTime): self {
+	public function setShareTime(DateTime $shareTime): self {
 		$this->shareTime = $shareTime;
 
 		return $this;
 	}
 
-	public function getShareTime(): DateTimeInterface {
+	public function getShareTime(): DateTime {
 		return $this->shareTime;
 	}
 
@@ -355,8 +354,12 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 		$share->setTarget($this->getFileTarget());
 		$share->setProviderId($this->getProviderId());
 		$share->setStatus($this->getStatus());
-		if ($this->hasShareToken() && $this->getShareToken()->getPassword() !== '') {
-			$share->setPassword($this->getShareToken()->getPassword());
+
+		if ($this->hasShareToken()) {
+			$password = $this->getShareToken()->getPassword();
+			if ($password !== '') {
+				$share->setPassword($password);
+			}
 		}
 
 		$share->setShareTime($this->getShareTime())
@@ -439,6 +442,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 
 	/**
 	 * @param array $data
+	 *
 	 * @throws InvalidItemException
 	 */
 	public function import(array $data): IDeserializable {

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -356,6 +356,26 @@ class ConfigService {
 
 	/**
 	 * true if:
+	 * - password enforced for Circle
+	 * - single password enabled for Circle
+	 * - single password defined within Circle's settings
+	 *
+	 * @param Circle $circle
+	 *
+	 * @return bool
+	 */
+	public function isSinglePasswordAvailable(Circle $circle): bool {
+		if (!$this->enforcePasswordOnSharedFile($circle)) {
+			return false;
+		}
+
+		return ($this->getBool('password_single_enabled', $circle->getSettings(), false)
+				&& $this->get('password_single', $circle->getSettings()) !== '');
+	}
+
+
+	/**
+	 * true if:
 	 *   - global setting of Nextcloud enforce password on shares.
 	 *   - setting of Circles' app enforce password on shares.
 	 *   - setting for specific Circle enforce password on shares.

--- a/lib/Service/ShareTokenService.php
+++ b/lib/Service/ShareTokenService.php
@@ -31,13 +31,13 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Service;
 
-use OCA\Circles\Tools\Traits\TStringTools;
 use OCA\Circles\Db\ShareTokenRequest;
 use OCA\Circles\Exceptions\ShareTokenAlreadyExistException;
 use OCA\Circles\Exceptions\ShareTokenNotFoundException;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\ShareToken;
 use OCA\Circles\Model\ShareWrapper;
+use OCA\Circles\Tools\Traits\TStringTools;
 use OCP\IURLGenerator;
 use OCP\Share\IShare;
 
@@ -138,6 +138,29 @@ class ShareTokenService {
 		$shareToken->setLink($link);
 	}
 
+
+	/**
+	 * update password on files previously shared to circleId
+	 *
+	 * @param string $circleId
+	 * @param string $hashedPassword
+	 */
+	public function updateSharePassword(string $circleId, string $hashedPassword): void {
+		if ($hashedPassword === '') {
+			return;
+		}
+
+		$this->shareTokenRequest->updateSharePassword($circleId, $hashedPassword);
+	}
+
+	/**
+	 * remove password on files previously shared to circleId
+	 *
+	 * @param string $circleId
+	 */
+	public function removeSharePassword(string $circleId): void {
+		$this->shareTokenRequest->updateSharePassword($circleId, '');
+	}
 
 	/**
 	 * @param string $singleId


### PR DESCRIPTION

- remove password on previous share if enforce password protection is disabled (globally, not just on current circle)
- update password on previous shares on static password changes (if password protection is enabled)
- adding '--test-password' option in ./occ circles:manage:setting to confirm password protection of shares
- notice log on getShareByToken if password protected, including hashed password

