### PR TITLE
remove shares on removing members

### DIFF
--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -122,18 +122,17 @@ class ShareWrapperService {
 
 	/**
 	 * @param string $circleId
-	 * @param string $initiator
-	 * @param bool $force
+	 * @param string $userId
 	 *
 	 * @throws Exception
 	 */
-	public function deleteUserSharesToCircle(string $circleId, string $initiator): void {
-		if ($initiator === '') {
+	public function deleteUserSharesToCircle(string $circleId, string $userId): void {
+		if ($userId === '') {
 			throw new Exception('$initiator cannot be empty');
 		}
 
 		$this->cache->clear('');
-		$this->shareWrapperRequest->deleteSharesToCircle($circleId, $initiator);
+		$this->shareWrapperRequest->deleteSharesToCircle($circleId, $userId);
 	}
 
 


### PR DESCRIPTION
fixing an issue where shares were not removed when removing a member.

if a member is now removed, we checked for each inherited members if a share was done to the circle and parents.
