### PR TITLE
CFG_MOUNTPOINT

### DIFF
--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -295,7 +295,8 @@ class CircleRequest extends CircleRequestBuilder {
 					$aliasMembership
 				)
 			);
-			$qb->completeProbeWithInitiator(CoreQueryBuilder::CIRCLE, 'single_id', $aliasMembership);
+
+			$qb->completeProbeWithInitiator(CoreQueryBuilder::CIRCLE, $initiator, 'circle_id', $aliasMembership);
 		}
 
 		$qb->andWhere($limit);

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1463,6 +1463,10 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$include = $probe->included();
 		$config = ($filter | $include) - $include;
 		$this->filterBitwise('config', $config, $aliasCircle);
+
+		if ($probe->hasLimitConfig()) {
+			$this->limitBitwise('config', $probe->getLimitConfig(), $aliasCircle);
+		}
 	}
 
 

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -440,8 +440,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 			$aliasRemoteInstance = $this->generateAlias($alias, self::REMOTE);
 			$this->generateRemoteInstanceSelectAlias($aliasRemoteInstance)
 				 ->leftJoin(
-				 	$alias, CoreRequestBuilder::TABLE_REMOTE, $aliasRemoteInstance,
-				 	$expr->eq($alias . '.instance', $aliasRemoteInstance . '.instance')
+					 $alias, CoreRequestBuilder::TABLE_REMOTE, $aliasRemoteInstance,
+					 $expr->eq($alias . '.instance', $aliasRemoteInstance . '.instance')
 				 );
 		} catch (RequestBuilderException $e) {
 		}
@@ -809,8 +809,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$expr = $this->expr();
 		$this->generateCircleSelectAlias($aliasInvitedBy)
 			 ->leftJoin(
-			 	$aliasMember, CoreRequestBuilder::TABLE_CIRCLE, $aliasInvitedBy,
-			 	$expr->eq($aliasMember . '.invited_by', $aliasInvitedBy . '.unique_id')
+				 $aliasMember, CoreRequestBuilder::TABLE_CIRCLE, $aliasInvitedBy,
+				 $expr->eq($aliasMember . '.invited_by', $aliasInvitedBy . '.unique_id')
 			 );
 
 		$this->leftJoinOwner($aliasInvitedBy);
@@ -840,8 +840,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$expr = $this->expr();
 		$this->generateCircleSelectAlias($aliasBasedOn)
 			 ->leftJoin(
-			 	$aliasMember, CoreRequestBuilder::TABLE_CIRCLE, $aliasBasedOn,
-			 	$expr->eq($aliasBasedOn . '.unique_id', $aliasMember . '.single_id')
+				 $aliasMember, CoreRequestBuilder::TABLE_CIRCLE, $aliasBasedOn,
+				 $expr->eq($aliasBasedOn . '.unique_id', $aliasMember . '.single_id')
 			 );
 
 		if (!is_null($initiator)) {
@@ -872,14 +872,14 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$expr = $this->expr();
 		$this->generateMemberSelectAlias($aliasMember)
 			 ->leftJoin(
-			 	$alias, CoreRequestBuilder::TABLE_MEMBER, $aliasMember,
-			 	$expr->andX(
-			 		$expr->eq($aliasMember . '.circle_id', $alias . '.' . $field),
-			 		$expr->eq(
-			 			$aliasMember . '.level',
-			 			$this->createNamedParameter(Member::LEVEL_OWNER, self::PARAM_INT)
-			 		)
-			 	)
+				 $alias, CoreRequestBuilder::TABLE_MEMBER, $aliasMember,
+				 $expr->andX(
+					 $expr->eq($aliasMember . '.circle_id', $alias . '.' . $field),
+					 $expr->eq(
+						 $aliasMember . '.level',
+						 $this->createNamedParameter(Member::LEVEL_OWNER, self::PARAM_INT)
+					 )
+				 )
 			 );
 
 		$this->leftJoinBasedOn($aliasMember);
@@ -947,12 +947,12 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$expr = $this->expr();
 		$this->generateMemberSelectAlias($aliasMember)
 			 ->leftJoin(
-			 	$alias, CoreRequestBuilder::TABLE_MEMBER, $aliasMember,
-			 	$expr->andX(
-			 		$expr->eq($aliasMember . '.circle_id', $alias . '.' . $fieldCircleId),
-			 		$expr->eq($aliasMember . '.single_id', $alias . '.' . $fieldSingleId),
-			 		$this->exprGt('level', Member::LEVEL_MEMBER, true, $aliasMember)
-			 	)
+				 $alias, CoreRequestBuilder::TABLE_MEMBER, $aliasMember,
+				 $expr->andX(
+					 $expr->eq($aliasMember . '.circle_id', $alias . '.' . $fieldCircleId),
+					 $expr->eq($aliasMember . '.single_id', $alias . '.' . $fieldSingleId),
+					 $this->exprGt('level', Member::LEVEL_MEMBER, true, $aliasMember)
+				 )
 			 );
 
 		$this->leftJoinRemoteInstance($aliasMember);
@@ -994,11 +994,11 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		}
 		$this->generateMemberSelectAlias($aliasInheritedBy)
 			 ->leftJoin(
-			 	$alias, CoreRequestBuilder::TABLE_MEMBER, $aliasInheritedBy,
-			 	$expr->andX(
-			 		$expr->eq($aliasMembership . '.inheritance_last', $aliasInheritedBy . '.circle_id'),
-			 		$expr->eq($aliasMembership . '.single_id', $aliasInheritedBy . '.single_id')
-			 	)
+				 $alias, CoreRequestBuilder::TABLE_MEMBER, $aliasInheritedBy,
+				 $expr->andX(
+					 $expr->eq($aliasMembership . '.inheritance_last', $aliasInheritedBy . '.circle_id'),
+					 $expr->eq($aliasMembership . '.single_id', $aliasInheritedBy . '.single_id')
+				 )
 			 );
 
 		$this->leftJoinBasedOn($aliasInheritedBy);
@@ -1084,11 +1084,11 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$aliasInheritanceFrom = $this->generateAlias($alias, self::INHERITANCE_FROM);
 		$this->generateMemberSelectAlias($aliasInheritanceFrom)
 			 ->leftJoin(
-			 	$aliasMembership, CoreRequestBuilder::TABLE_MEMBER, $aliasInheritanceFrom,
-			 	$expr->andX(
-			 		$expr->eq($aliasMembership . '.circle_id', $aliasInheritanceFrom . '.circle_id'),
-			 		$expr->eq($aliasMembership . '.inheritance_first', $aliasInheritanceFrom . '.single_id')
-			 	)
+				 $aliasMembership, CoreRequestBuilder::TABLE_MEMBER, $aliasInheritanceFrom,
+				 $expr->andX(
+					 $expr->eq($aliasMembership . '.circle_id', $aliasInheritanceFrom . '.circle_id'),
+					 $expr->eq($aliasMembership . '.inheritance_first', $aliasInheritanceFrom . '.single_id')
+				 )
 			 );
 	}
 
@@ -1264,13 +1264,13 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 				$aliasDirectInitiator = $this->generateAlias($alias, self::DIRECT_INITIATOR, $options);
 				$this->generateMemberSelectAlias($aliasDirectInitiator)
 					 ->leftJoin(
-					 	$helperAlias,
-					 	CoreRequestBuilder::TABLE_MEMBER,
-					 	$aliasDirectInitiator,
-					 	$expr->andX(
-					 		$this->exprLimit('single_id', $initiator->getSingleId(), $aliasDirectInitiator),
-					 		$expr->eq($aliasDirectInitiator . '.circle_id', $helperAlias . '.' . $field)
-					 	)
+						 $helperAlias,
+						 CoreRequestBuilder::TABLE_MEMBER,
+						 $aliasDirectInitiator,
+						 $expr->andX(
+							 $this->exprLimit('single_id', $initiator->getSingleId(), $aliasDirectInitiator),
+							 $expr->eq($aliasDirectInitiator . '.circle_id', $helperAlias . '.' . $field)
+						 )
 					 );
 			} catch (RequestBuilderException $e) {
 				// meaning that this path does not require DIRECT_INITIATOR; can be safely ignored
@@ -1318,6 +1318,7 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 
 	public function completeProbeWithInitiator(
 		string $alias,
+		IFederatedUser $initiator,
 		string $field = 'single_id',
 		string $helperAlias = ''
 	): void {
@@ -1336,11 +1337,11 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$expr = $this->expr();
 		$this->generateMemberSelectAlias($aliasInitiator)
 			 ->leftJoin(
-			 	$alias, CoreRequestBuilder::TABLE_MEMBER, $aliasInitiator,
-			 	$expr->andX(
-			 		$expr->eq($aliasInitiator . '.circle_id', $helperAlias . '.' . $field),
-			 		$this->exprLimitInt('level', Member::LEVEL_OWNER, $aliasInitiator)
-			 	)
+				 $alias, CoreRequestBuilder::TABLE_MEMBER, $aliasInitiator,
+				 $expr->andX(
+					 $expr->eq($aliasInitiator . '.circle_id', $helperAlias . '.' . $field),
+					 $this->exprLimit('single_id', $initiator->getSingleId(), $aliasInitiator)
+				 )
 			 );
 //
 //		$this->leftJoinBasedOn($aliasInitiator);
@@ -1525,18 +1526,18 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 			[]
 		)
 			 ->generateSelectAlias(
-			 	CoreRequestBuilder::$outsideTables[CoreRequestBuilder::TABLE_STORAGES],
-			 	$aliasStorages,
-			 	$aliasStorages,
-			 	[]
+				 CoreRequestBuilder::$outsideTables[CoreRequestBuilder::TABLE_STORAGES],
+				 $aliasStorages,
+				 $aliasStorages,
+				 []
 			 )
 			 ->leftJoin(
-			 	$aliasShare, CoreRequestBuilder::TABLE_FILE_CACHE, $aliasFileCache,
-			 	$expr->eq($aliasShare . '.file_source', $aliasFileCache . '.fileid')
+				 $aliasShare, CoreRequestBuilder::TABLE_FILE_CACHE, $aliasFileCache,
+				 $expr->eq($aliasShare . '.file_source', $aliasFileCache . '.fileid')
 			 )
 			 ->leftJoin(
-			 	$aliasFileCache, CoreRequestBuilder::TABLE_STORAGES, $aliasStorages,
-			 	$expr->eq($aliasFileCache . '.storage', $aliasStorages . '.numeric_id')
+				 $aliasFileCache, CoreRequestBuilder::TABLE_STORAGES, $aliasStorages,
+				 $expr->eq($aliasFileCache . '.storage', $aliasStorages . '.numeric_id')
 			 );
 	}
 

--- a/lib/Model/Circle.php
+++ b/lib/Model/Circle.php
@@ -139,7 +139,7 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 		8192 => 'T|Root',
 		16384 => 'CI|Circle Invite',
 		32768 => 'F|Federated',
-		65536 => 'M|Nountpoint',
+		65536 => 'M|Mountpoint',
 		131072 => 'A|App'
 	];
 

--- a/lib/Model/Mount/FederatedMount.php
+++ b/lib/Model/Mount/FederatedMount.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Model\Mount;
+
+use OCA\Circles\Exceptions\CircleNotFoundException;
+use OCA\Circles\Model\Member;
+use OCA\Circles\MountManager\CircleMountManager;
+use OCA\Circles\Tools\Db\IQueryRow;
+use OCP\Federation\ICloudIdManager;
+use OCP\Http\Client\IClientService;
+
+class FederatedMount extends Mount implements IQueryRow {
+
+	private int $id = 0;
+	private string $mountId = '';
+	private Member $owner;
+	private Member $initiator;
+	private int $parent = -1;
+	private string $token = '';
+	private string $password = '';
+	private string $mountPoint = '';
+	private string $mountPointHash = '';
+	private string $storage;
+
+	private ICloudIdManager $cloudIdManager;
+	private IClientService $httpClientService;
+	private CircleMountManager $mountManager;
+
+
+	/**
+	 * Mount constructor.
+	 */
+	public function __construct(string $circleId = '') {
+		parent::__construct($circleId);
+	}
+
+
+	/**
+	 * @return int
+	 */
+	public function getId(): int {
+		return $this->id;
+	}
+
+	public function setId(int $id): self {
+		$this->id = $id;
+
+		return $this;
+	}
+
+
+	/**
+	 *
+	 * @return string
+	 */
+	public function getMountId(): string {
+		return $this->mountId;
+	}
+
+	/**
+	 * @param string $mountId
+	 *
+	 * @return Mount
+	 */
+	public function setMountId(string $mountId): self {
+		$this->mountId = $mountId;
+
+		return $this;
+	}
+
+
+	/**
+	 * @param bool $raw
+	 *
+	 * @return string
+	 */
+	public function getMountPoint(bool $raw = true): string {
+		if ($raw) {
+			return $this->mountPoint;
+		}
+
+		return '/' . $this->getInitiator()->getUserId() . '/files/' . ltrim($this->mountPoint, '/');
+	}
+
+	/**
+	 * @param string $mountPoint
+	 *
+	 * @return Mount
+	 */
+	public function setMountPoint(string $mountPoint): self {
+		$this->mountPoint = $mountPoint;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getMountPointHash(): string {
+		return $this->mountPointHash;
+	}
+
+	/**
+	 * @param string $mountPointHash
+	 *
+	 * @return Mount
+	 */
+	public function setMountPointHash(string $mountPointHash): self {
+		$this->mountPointHash = $mountPointHash;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return int
+	 */
+	public function getParent(): int {
+		return $this->parent;
+	}
+
+	/**
+	 * @param int $parent
+	 *
+	 * @return Mount
+	 */
+	public function setParent(int $parent): self {
+		$this->parent = $parent;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return Member
+	 */
+	public function getOwner(): Member {
+		return $this->owner;
+	}
+
+	/**
+	 * @param Member $owner
+	 *
+	 * @return Mount
+	 */
+	public function setOwner(Member $owner): self {
+		$this->owner = $owner;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasInitiator(): bool {
+		return !is_null($this->initiator);
+	}
+
+	/**
+	 * @return Member
+	 */
+	public function getInitiator(): Member {
+		return $this->initiator;
+	}
+
+	/**
+	 * @param Member $initiator
+	 *
+	 * @return Mount
+	 */
+	public function setInitiator(Member $initiator): self {
+		$this->initiator = $initiator;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getToken(): string {
+		return $this->token;
+	}
+
+	/**
+	 * @param string $token
+	 *
+	 * @return Mount
+	 */
+	public function setToken(string $token): self {
+		$this->token = $token;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getPassword(): string {
+		return $this->password;
+	}
+
+	/**
+	 * @param string $password
+	 *
+	 * @return Mount
+	 */
+	public function setPassword(string $password): self {
+		$this->password = $password;
+
+		return $this;
+	}
+
+
+	/**
+	 * @param ICloudIdManager $cloudIdManager
+	 *
+	 * @return Mount
+	 */
+	public function setCloudIdManager(ICloudIdManager $cloudIdManager): self {
+		$this->cloudIdManager = $cloudIdManager;
+
+		return $this;
+	}
+
+	/**
+	 * @return ICloudIdManager
+	 */
+	public function getCloudIdManager(): ICloudIdManager {
+		return $this->cloudIdManager;
+	}
+
+
+	/**
+	 * @param IClientService $httpClientService
+	 *
+	 * @return Mount
+	 */
+	public function setHttpClientService(IClientService $httpClientService): self {
+		$this->httpClientService = $httpClientService;
+
+		return $this;
+	}
+
+	/**
+	 * @return IClientService
+	 */
+	public function getHttpClientService(): IClientService {
+		return $this->httpClientService;
+	}
+
+
+	/**
+	 * @param CircleMountManager $mountManager
+	 *
+	 * @return Mount
+	 */
+	public function setMountManager(CircleMountManager $mountManager): self {
+		$this->mountManager = $mountManager;
+
+		return $this;
+	}
+
+	/**
+	 * @return CircleMountManager
+	 */
+	public function getMountManager(): CircleMountManager {
+		return $this->mountManager;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function toMount(): array {
+		$member = $this->getOwner();
+
+		return [
+			'owner' => $member->getUserId(),
+			'remote' => $member->getRemoteInstance()->getRoot(),
+			'token' => $this->getToken(),
+			'password' => $this->getPassword(),
+			'mountpoint' => $this->getMountPoint(false),
+			//			'manager'           => $this->getMountManager(),
+			'HttpClientService' => $this->getHttpClientService(),
+			'manager' => $this->getMountManager(),
+			'cloudId' => $this->getCloudIdManager()->getCloudId(
+				$member->getUserId(),
+				$member->getRemoteInstance()->getRoot()
+			)
+		];
+	}
+
+
+	/**
+	 * @param ShareWrapper $wrappedShare
+	 *
+	 * @throws CircleNotFoundException
+	 */
+	public function fromShare(ShareWrapper $wrappedShare) {
+		if (!$wrappedShare->hasCircle()) {
+			throw new CircleNotFoundException('ShareWrapper has no Circle');
+		}
+
+		$circle = $wrappedShare->getCircle();
+		$this->setCircleId($circle->getSingleId());
+		$this->setOwner($wrappedShare->getOwner());
+		$this->setToken($wrappedShare->getToken());
+		$this->setParent(-1);
+		$this->setMountPoint($wrappedShare->getFileTarget());
+		$this->setMountPointHash(md5($wrappedShare->getFileTarget()));
+	}
+
+
+	/**
+	 * @param array $data
+	 * @param string $prefix
+	 *
+	 * @return Mount
+	 */
+	public function importFromDatabase(array $data, string $prefix = ''): IQueryRow {
+		$this->setId($this->getInt('id', $data));
+		$this->setCircleId($this->get('circle_id', $data));
+		$this->setToken($this->get('token', $data));
+		$this->setParent($this->getInt('parent', $data));
+		$this->setMountPoint($this->get('mountpoint', $data));
+		$this->setMountPointHash($this->get('mountpoint_hash', $data));
+
+//		$this->setDefaultMountPoint($this->get('mountpoint', $data));
+
+		$this->getManager()->manageImportFromDatabase($this, $data, $prefix);
+
+		return $this;
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function jsonSerialize(): array {
+		$arr = [
+			'id' => $this->getId(),
+			'circleId' => $this->getCircleId(),
+			'mountId' => $this->getMountId(),
+			'parent' => $this->getParent(),
+			'owner' => $this->getOwner(),
+			'token' => $this->getToken(),
+			'password' => $this->getPassword(),
+			'mountPoint' => $this->getMountPoint(),
+			'mountPointHash' => $this->getMountPointHash(),
+		];
+
+		if ($this->hasInitiator()) {
+			$arr['initiator'] = $this->getInitiator();
+			$arr['toMount'] = $this->toMount();
+		}
+
+		return $arr;
+	}
+}

--- a/lib/Model/Mount/FolderMount.php
+++ b/lib/Model/Mount/FolderMount.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Model\Mount;
+
+use OC\Files\Cache\CacheEntry;
+
+class FolderMount extends Mount {
+	private int $permissions = 0;
+	private ?CacheEntry $cacheEntry = null;
+
+	public function __construct(string $circleId = '') {
+		parent::__construct($circleId);
+	}
+
+	public function setPermissions(int $permissions): self {
+		$this->permissions = $permissions;
+
+		return $this;
+	}
+
+	public function getPermissions(): int {
+		return $this->permissions;
+	}
+
+	public function setCacheEntry(?CacheEntry $cacheEntry): self {
+		$this->cacheEntry = $cacheEntry;
+
+		return $this;
+	}
+
+	public function getCacheEntry(): ?CacheEntry {
+		return $this->cacheEntry;
+	}
+
+	public function hasCacheEntry(): bool {
+		return !is_null($this->cacheEntry);
+	}
+
+	public function toMount(): array {
+		return array_merge(
+			[],
+			parent::toMount()
+		);
+	}
+}

--- a/lib/Model/Mount/Mount.php
+++ b/lib/Model/Mount/Mount.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Model\Mount;
+
+use JsonSerializable;
+use OCA\Circles\Model\ManagedModel;
+use OCA\Circles\Tools\Traits\TArrayTools;
+
+/**
+ * Class Mount
+ *
+ * @package OCA\Circles\Model
+ */
+class Mount extends ManagedModel implements JsonSerializable {
+	use TArrayTools;
+
+	private string $circleId;
+	private string $mountPoint2 = '';
+	private string $absoluteMountPoint = '';
+
+	public function __construct(string $circleId = '') {
+		$this->circleId = $circleId;
+	}
+
+	public function setCircleId(string $circleId): self {
+		$this->circleId = $circleId;
+
+		return $this;
+	}
+
+	public function getCircleId(): string {
+		return $this->circleId;
+	}
+
+	public function setMountPoint2(string $mountPoint): self {
+		$this->mountPoint2 = $mountPoint;
+
+		return $this;
+	}
+
+	public function getMountPoint2(): string {
+		return $this->mountPoint2;
+	}
+
+	public function setAbsoluteMountPoint(string $absoluteMountPoint): self {
+		$this->absoluteMountPoint = $absoluteMountPoint;
+
+		return $this;
+	}
+
+	public function getAbsoluteMountPoint(): string {
+		return $this->absoluteMountPoint;
+	}
+
+
+
+//	/**
+//	 * @return string
+//	 */
+//	public function getMountPointHash(): string {
+//		return $this->mountPointHash;
+//	}
+//
+//	/**
+//	 * @param string $mountPointHash
+//	 *
+//	 * @return Mount
+//	 */
+//	public function setMountPointHash(string $mountPointHash): self {
+//		$this->mountPointHash = $mountPointHash;
+//
+//		return $this;
+//	}
+
+
+	/**
+	 * @return array
+	 */
+	public function toMount(): array {
+		return [
+		];
+	}
+
+	/**
+	 * @return array
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'circleId' => $this->getCircleId(),
+			'mountPoint' => $this->getMountPoint2(),
+			'absoluteMountPoint' => $this->getAbsoluteMountPoint()
+		];
+	}
+}

--- a/lib/Mount/ACLStorageWrapper.php
+++ b/lib/Mount/ACLStorageWrapper.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Mount;
+
+use OC\Files\Cache\Cache;
+use OC\Files\Cache\Scanner;
+use OC\Files\Cache\Wrapper\CacheWrapper;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\Constants;
+
+class ACLStorageWrapper extends Wrapper {
+	private int $permissions;
+	private bool $inShare;
+
+	public function __construct($arguments) {
+		parent::__construct($arguments);
+		$this->permissions = $arguments['permissions'];
+		$this->inShare = $arguments['in_share'];
+	}
+
+	/**
+	 * @param int $permissions
+	 *
+	 * @return bool
+	 */
+	private function checkPermissions(int $permissions): bool {
+		// if there is no read permissions, then deny everything
+		if ($this->inShare) {
+			// Check if owner of the share is actually allowed to share
+			// $canRead = $this->permissions & (Constants::PERMISSION_READ + Constants::PERMISSION_SHARE);
+			$canRead = ($this->permissions & Constants::PERMISSION_READ) &&
+				($this->permissions & Constants::PERMISSION_SHARE);
+		} else {
+			$canRead = $this->permissions & Constants::PERMISSION_READ;
+		}
+
+		return $canRead && ($this->permissions & $permissions) === $permissions;
+	}
+
+	public function isReadable($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_READ) && parent::isReadable($path);
+	}
+
+	public function isUpdatable($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_UPDATE) && parent::isUpdatable($path);
+	}
+
+	public function isCreatable($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_CREATE) && parent::isCreatable($path);
+	}
+
+	public function isDeletable($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_DELETE) && parent::isDeletable($path);
+	}
+
+	public function isSharable($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_SHARE) && parent::isSharable($path);
+	}
+
+	public function getPermissions($path) {
+		return $this->storage->getPermissions($path) & $this->permissions;
+	}
+
+	public function rename($path1, $path2): bool {
+		if (strpos($path1, $path2) === 0) {
+			$part = substr($path1, strlen($path2));
+			// This is a renaming of the transfer file to the original file
+			if (strpos($part, '.ocTransferId') === 0) {
+				return $this->checkPermissions(Constants::PERMISSION_CREATE) && parent::rename($path1, $path2);
+			}
+		}
+		$targetPermissions = $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
+		return $this->checkPermissions(Constants::PERMISSION_READ) &&
+			$this->checkPermissions(Constants::PERMISSION_DELETE) &&
+			$this->checkPermissions($targetPermissions) &&
+			parent::rename($path1, $path2);
+	}
+
+	public function opendir($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::opendir($path);
+	}
+
+	public function copy($path1, $path2): bool {
+		$targetPermissions = $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
+		return $this->checkPermissions(Constants::PERMISSION_READ) &&
+			$this->checkPermissions($targetPermissions) &&
+			parent::copy($path1, $path2);
+	}
+
+	public function touch($path, $mtime = null): bool {
+		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
+		return $this->checkPermissions($permissions) && parent::touch($path, $mtime);
+	}
+
+	public function mkdir($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_CREATE) && parent::mkdir($path);
+	}
+
+	public function rmdir($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_DELETE) && parent::rmdir($path);
+	}
+
+	public function unlink($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_DELETE) && parent::unlink($path);
+	}
+
+	public function file_put_contents($path, $data) {
+		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
+		return $this->checkPermissions($permissions) ? parent::file_put_contents($path, $data) : false;
+	}
+
+	public function fopen($path, $mode) {
+		if ($mode === 'r' || $mode === 'rb') {
+			$permissions = Constants::PERMISSION_READ;
+		} else {
+			$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
+		}
+		return $this->checkPermissions($permissions) ? parent::fopen($path, $mode) : false;
+	}
+
+	public function writeStream(string $path, $stream, int $size = null): int {
+		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
+		return $this->checkPermissions($permissions) ? parent::writeStream($path, $stream, $size) : 0;
+	}
+
+	public function getCache($path = '', $storage = null): Cache {
+		if (!$storage) {
+			$storage = $this;
+		}
+		$sourceCache = parent::getCache($path, $storage);
+		return new CacheWrapper($sourceCache);
+	}
+
+	public function getMetaData($path): ?array {
+		$data = parent::getMetaData($path);
+
+		if ($data && isset($data['permissions'])) {
+			$data['scan_permissions'] ??= $data['permissions'];
+			$data['permissions'] &= $this->permissions;
+		}
+		return $data;
+	}
+
+	public function getScanner($path = '', $storage = null): Scanner {
+		if (!$storage) {
+			$storage = $this->storage;
+		}
+		return parent::getScanner($path, $storage);
+	}
+
+	public function is_dir($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_READ) &&
+			parent::is_dir($path);
+	}
+
+	public function is_file($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_READ) &&
+			parent::is_file($path);
+	}
+
+	public function stat($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::stat($path);
+	}
+
+	public function filetype($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::filetype($path);
+	}
+
+	public function filesize($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::filesize($path);
+	}
+
+	public function file_exists($path): bool {
+		return $this->checkPermissions(Constants::PERMISSION_READ) && parent::file_exists($path);
+	}
+
+	public function filemtime($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::filemtime($path);
+	}
+
+	public function file_get_contents($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::file_get_contents($path);
+	}
+
+	public function getMimeType($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::getMimeType($path);
+	}
+
+	public function hash($type, $path, $raw = false) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::hash($type, $path, $raw);
+	}
+
+	public function getETag($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::getETag($path);
+	}
+
+	public function getDirectDownload($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::getDirectDownload($path);
+	}
+
+	public function getDirectoryContent($directory): \Traversable {
+		foreach ($this->getWrapperStorage()->getDirectoryContent($directory) as $data) {
+			$data['scan_permissions'] ??= $data['permissions'];
+			$data['permissions'] &= $this->permissions;
+
+			yield $data;
+		}
+	}
+}

--- a/lib/Mount/CirclesFolderManager.php
+++ b/lib/Mount/CirclesFolderManager.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace OCA\Circles\Mount;
+
+use Exception;
+use OC\Files\Cache\Cache;
+use OC\Files\Cache\CacheEntry;
+use OC\Files\Node\LazyFolder;
+use OC\Files\Storage\Wrapper\Jail;
+use OC\Files\Storage\Wrapper\PermissionsMask;
+use OCA\Circles\AppInfo\Application;
+use OCA\Circles\Model\Mount\FolderMount;
+use OCP\Files\Folder;
+use OCP\Files\IMimeTypeLoader;
+use OCP\Files\InvalidPathException;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+
+class CirclesFolderManager {
+	private const LANDING_PAGE_TITLE = 'Readme';
+	private const SUFFIX = '.md';
+
+	private IRootFolder $rootFolder;
+	private IDBConnection $connection;
+	private IMimeTypeLoader $mimeTypeLoader;
+	private IConfig $config;
+	private IUserSession $userSession;
+	private IRequest $request;
+	private ?string $rootPath = null;
+
+	/**
+	 * CollectiveFolderManager constructor.
+	 *
+	 * @param IRootFolder $rootFolder
+	 * @param IDBConnection $connection
+	 * @param IConfig $config
+	 * @param IUserSession $userSession
+	 * @param IRequest $request
+	 */
+	public function __construct(
+		IRootFolder $rootFolder,
+		IDBConnection $connection,
+		IMimeTypeLoader $mimeTypeLoader,
+		IConfig $config,
+		IUserSession $userSession,
+		IRequest $request
+	) {
+		$this->rootFolder = $rootFolder;
+		$this->connection = $connection;
+		$this->mimeTypeLoader = $mimeTypeLoader;
+		$this->config = $config;
+		$this->userSession = $userSession;
+		$this->request = $request;
+	}
+
+	public function getRootPath(): string {
+		if (null !== $this->rootPath) {
+			return $this->rootPath;
+		}
+
+		$instanceId = $this->config->getSystemValue('instanceid', null);
+		if (null === $instanceId) {
+			throw new \RuntimeException('no instance id!');
+		}
+
+		$this->rootPath = 'appdata_' . $instanceId . '/' . Application::APP_FOLDER;
+
+		return $this->rootPath;
+	}
+
+	public function getCircleRootPath(string $circleId): string {
+		return $this->getRootPath() . '/' . $circleId;
+	}
+
+
+	/**
+	 * @return Folder
+	 */
+	public function getRootFolder(): Folder {
+		$rootFolder = $this->rootFolder;
+
+		return (new LazyFolder(function () use ($rootFolder) {
+			try {
+				return $rootFolder->get($this->getRootPath());
+			} catch (NotFoundException $e) {
+				return $rootFolder->newFolder($this->getRootPath());
+			}
+		}));
+	}
+
+	/**
+	 * @return string|null
+	 */
+	private function getCurrentUID(): ?string {
+		try {
+			// wopi requests are not logged in, instead we need to get the editor user from the access token
+			if (strpos($this->request->getRawPathInfo(), 'apps/richdocuments/wopi')
+				&& class_exists(
+					'OCA\Richdocuments\Db\WopiMapper'
+				)) {
+				$wopiMapper = \OC::$server->query('OCA\Richdocuments\Db\WopiMapper');
+				$token = $this->request->getParam('access_token');
+				if ($token) {
+					$wopi = $wopiMapper->getPathForToken($token);
+
+					return $wopi->getEditorUid();
+				}
+			}
+		} catch (Exception $e) {
+		}
+
+		$user = $this->userSession->getUser();
+
+		return $user ? $user->getUID() : null;
+	}
+
+	/**
+	 * @param FolderMount $folderMount
+	 * @param IStorageFactory|null $loader
+	 * @param IUser|null $user
+	 *
+	 * @return IMountPoint|null
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 * @throws Exception
+	 */
+	public function getMount(
+		FolderMount $folderMount,
+		IStorageFactory $loader,
+		?IUser $user = null
+	): ?IMountPoint {
+		if (!$folderMount->hasCacheEntry()) {
+			try {
+				$folder = $this->getFolder($folderMount->getCircleId());
+			} catch (InvalidPathException | NotPermittedException $e) {
+				return null;
+			}
+
+			$cacheEntry = $this->getRootFolder()->getStorage()->getCache()->get($folder->getId());
+		} else {
+			$cacheEntry = $folderMount->getCacheEntry();
+		}
+
+		$storage = new NoExcludePropagatorStorageWrapper(['storage' => $this->getRootFolder()->getStorage()]);
+
+		if ($user) {
+			$current = $this->userSession->getUser();
+			$storage = new ACLStorageWrapper(
+				[
+					'storage' => $storage,
+					'permissions' => $folderMount->getPermissions(),
+					'in_share' => ($current->getUID() !== $user->getUID())
+				]
+			);
+			$cacheEntry['permissions'] &= $folderMount->getPermissions();
+		}
+
+		$baseStorage = new Jail(
+			[
+				'storage' => $storage,
+				'root' => $this->getRootFolder()->getInternalPath() . '/' . $folderMount->getCircleId()
+			]
+		);
+		$collectiveStorage = new CirclesFolderStorage([
+														  'storage' => $baseStorage,
+														  'folder_id' => $folderMount->getCircleId(),
+														  'rootCacheEntry' => $cacheEntry,
+														  'mountOwner' => $user
+													  ]);
+		$maskedStorage = new PermissionsMask([
+												 'storage' => $collectiveStorage,
+												 'mask' => $folderMount->getPermissions()
+											 ]);
+
+		return new CirclesFolderMountPoint(
+			$folderMount,
+			$this,
+			$maskedStorage,
+			$loader
+		);
+	}
+
+
+	private function getRootFolderStorageId(): int {
+		$qb = $this->connection->getQueryBuilder();
+
+		$qb->select('fileid')
+		   ->from('filecache')
+		   ->where(
+			   $qb->expr()->eq(
+				   'storage', $qb->createNamedParameter(
+				   $this->getRootFolder()->getStorage()->getCache()->getNumericStorageId()
+			   )
+			   )
+		   )
+		   ->andWhere($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5($this->getRootPath()))));
+
+		return (int)$qb->execute()->fetchColumn();
+	}
+
+
+	/**
+	 * @param string $path
+	 * @param string $lang
+	 *
+	 * @return string
+	 */
+	public function getLandingPagePath(string $path, string $lang): string {
+		$landingPagePathEnglish = $path . '/' . self::LANDING_PAGE_TITLE . '.en' . self::SUFFIX;
+		$landingPagePathLocalized = $path . '/' . self::LANDING_PAGE_TITLE . '.' . $lang . self::SUFFIX;
+
+		return file_exists($landingPagePathLocalized) ? $landingPagePathLocalized : $landingPagePathEnglish;
+	}
+
+
+	public function getCacheEntry(string $circleId): ?CacheEntry {
+		$cacheEntry = $this->getFolderFileCache($circleId);
+
+		if (isset($cacheEntry['fileid'])) {
+			return Cache::cacheEntryFromData($cacheEntry, $this->mimeTypeLoader);
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * @param int $circleId
+	 * @param string $name
+	 *
+	 * @return array
+	 * @throws NotFoundException
+	 * @throws \OCP\DB\Exception
+	 */
+	private function getFolderFileCache(string $circleId): array {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select(
+			'fileid',
+			'storage',
+			'path',
+			'mimetype',
+			'mimepart',
+			'size',
+			'mtime',
+			'storage_mtime',
+			'etag',
+			'encrypted',
+			'parent',
+			'permissions'
+		)
+		   ->from('filecache', 'c')
+		   ->where(
+			   $qb->expr()->andX(
+				   $qb->expr()->eq(
+					   'path_hash', $qb->createNamedParameter(md5($this->getCircleRootPath($circleId)))
+				   ),
+				   $qb->expr()->eq('parent', $qb->createNamedParameter($this->getRootFolderStorageId()))
+			   )
+		   );
+
+		$cache = $qb->execute()->fetch();
+		$cache['mount_point'] = $circleId;
+
+		return $cache;
+	}
+
+
+	/**
+	 * returns folder assigned to circleId
+	 * creates folder if not available
+	 *
+	 * @param string $circleId
+	 *
+	 * @return Folder
+	 * @throws InvalidPathException
+	 * @throws NotPermittedException
+	 */
+	public function getFolder(string $circleId): Folder {
+		try {
+			$folder = $this->getRootFolder()->get($circleId);
+			if (!$folder instanceof Folder) {
+				throw new InvalidPathException('Not a folder: ' . $folder->getPath());
+			}
+		} catch (NotFoundException $e) {
+			$folder = $this->getRootFolder()->newFolder($circleId);
+		}
+
+		return $folder;
+	}
+}

--- a/lib/Mount/CirclesFolderManager.php
+++ b/lib/Mount/CirclesFolderManager.php
@@ -36,15 +36,6 @@ class CirclesFolderManager {
 	private IRequest $request;
 	private ?string $rootPath = null;
 
-	/**
-	 * CollectiveFolderManager constructor.
-	 *
-	 * @param IRootFolder $rootFolder
-	 * @param IDBConnection $connection
-	 * @param IConfig $config
-	 * @param IUserSession $userSession
-	 * @param IRequest $request
-	 */
 	public function __construct(
 		IRootFolder $rootFolder,
 		IDBConnection $connection,
@@ -151,8 +142,8 @@ class CirclesFolderManager {
 
 		$storage = new NoExcludePropagatorStorageWrapper(['storage' => $this->getRootFolder()->getStorage()]);
 
-		if ($user) {
-			$current = $this->userSession->getUser();
+		$current = $this->userSession->getUser();
+		if ($user !== null && $current !== null) {
 			$storage = new ACLStorageWrapper(
 				[
 					'storage' => $storage,
@@ -169,14 +160,13 @@ class CirclesFolderManager {
 				'root' => $this->getRootFolder()->getInternalPath() . '/' . $folderMount->getCircleId()
 			]
 		);
-		$collectiveStorage = new CirclesFolderStorage([
-														  'storage' => $baseStorage,
-														  'folder_id' => $folderMount->getCircleId(),
-														  'rootCacheEntry' => $cacheEntry,
-														  'mountOwner' => $user
-													  ]);
+		$circlesStorage = new CirclesFolderStorage([
+													   'storage' => $baseStorage,
+													   'rootCacheEntry' => $cacheEntry,
+													   'mountOwner' => $user
+												   ]);
 		$maskedStorage = new PermissionsMask([
-												 'storage' => $collectiveStorage,
+												 'storage' => $circlesStorage,
 												 'mask' => $folderMount->getPermissions()
 											 ]);
 

--- a/lib/Mount/CirclesFolderMountPoint.php
+++ b/lib/Mount/CirclesFolderMountPoint.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Mount;
+
+use OC\Files\Mount\MountPoint;
+use OC\Files\Storage\Storage;
+use OCA\Circles\Model\Mount\FolderMount;
+use OCP\Files\Storage\IStorageFactory;
+
+class CirclesFolderMountPoint extends MountPoint {
+	private FolderMount $folderMount;
+	private CirclesFolderManager $circlesFolderManager;
+
+	public function __construct(
+		FolderMount $folderMount,
+		CirclesFolderManager $collectiveFolderManager,
+		Storage $storage,
+		IStorageFactory $loader = null
+	) {
+		$this->folderMount = $folderMount;
+		$this->circlesFolderManager = $collectiveFolderManager;
+		parent::__construct(
+			$storage,
+			$folderMount->getAbsoluteMountPoint(),
+			[],
+			$loader,
+			null,
+			0,
+			MountProvider::class
+		);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getMountType(): string {
+		return 'circles-folder';
+	}
+
+	/**
+	 * @param string $name
+	 * @param mixed $default
+	 *
+	 * @return mixed
+	 */
+	public function getOption($name, $default) {
+		$options = $this->getOptions();
+
+		return $options[$name] ?? $default;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getOptions(): array {
+		$options = parent::getOptions();
+		$options['encrypt'] = false;
+
+		return $options;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSourcePath(): string {
+		return '/' . $this->circlesFolderManager->getRootFolder()->getPath() . '/'
+			   . $this->folderMount->getCircleId();
+	}
+}

--- a/lib/Mount/CirclesFolderMountPoint.php
+++ b/lib/Mount/CirclesFolderMountPoint.php
@@ -40,12 +40,12 @@ class CirclesFolderMountPoint extends MountPoint {
 
 	public function __construct(
 		FolderMount $folderMount,
-		CirclesFolderManager $collectiveFolderManager,
+		CirclesFolderManager $circlesFolderManager,
 		Storage $storage,
 		IStorageFactory $loader = null
 	) {
 		$this->folderMount = $folderMount;
-		$this->circlesFolderManager = $collectiveFolderManager;
+		$this->circlesFolderManager = $circlesFolderManager;
 		parent::__construct(
 			$storage,
 			$folderMount->getAbsoluteMountPoint(),

--- a/lib/Mount/CirclesFolderStorage.php
+++ b/lib/Mount/CirclesFolderStorage.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OCA\Circles\Mount;
+
+use OC\Files\Cache\Scanner;
+use OC\Files\ObjectStore\NoopScanner;
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Storage\IDisableEncryptionStorage;
+use OCP\IUser;
+
+class CirclesFolderStorage extends Wrapper implements IDisableEncryptionStorage {
+	private string $folderId;
+	private ICacheEntry $rootEntry;
+	private ?IUser $mountOwner;
+	/** @var RootEntryCache */
+	public $cache;
+
+	/**
+	 * CollectiveStorage constructor.
+	 *
+	 * @param $parameters
+	 */
+	public function __construct($parameters) {
+		parent::__construct($parameters);
+		$this->folderId = $parameters['folder_id'];
+		$this->rootEntry = $parameters['rootCacheEntry'];
+		$this->mountOwner = $parameters['mountOwner'];
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getFolderId(): string {
+		return $this->folderId;
+	}
+
+	/**
+	 * @param string $path
+	 *
+	 * @return false|string
+	 */
+	public function getOwner($path) {
+		return $this->mountOwner !== null ? $this->mountOwner->getUID() : false;
+	}
+
+	/**
+	 * @param string $path
+	 * @param null   $storage
+	 *
+	 * @return RootEntryCache
+	 */
+	public function getCache($path = '', $storage = null): RootEntryCache {
+		if ($this->cache) {
+			return $this->cache;
+		}
+		if (!$storage) {
+			$storage = $this;
+		}
+
+		$this->cache = new RootEntryCache(parent::getCache($path, $storage), $this->rootEntry);
+		return $this->cache;
+	}
+
+	/**
+	 * @param string $path
+	 * @param null   $storage
+	 *
+	 * @return Scanner
+	 */
+	public function getScanner($path = '', $storage = null): Scanner {
+		if (!$storage) {
+			$storage = $this;
+		}
+		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
+			$storage->scanner = new NoopScanner($storage);
+		} elseif (!isset($storage->scanner)) {
+			$storage->scanner = new Scanner($storage);
+		}
+		return $storage->scanner;
+	}
+}

--- a/lib/Mount/CirclesFolderStorage.php
+++ b/lib/Mount/CirclesFolderStorage.php
@@ -11,29 +11,16 @@ use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\IUser;
 
 class CirclesFolderStorage extends Wrapper implements IDisableEncryptionStorage {
-	private string $folderId;
+	private string $circleId;
 	private ICacheEntry $rootEntry;
 	private ?IUser $mountOwner;
 	/** @var RootEntryCache */
 	public $cache;
 
-	/**
-	 * CollectiveStorage constructor.
-	 *
-	 * @param $parameters
-	 */
 	public function __construct($parameters) {
 		parent::__construct($parameters);
-		$this->folderId = $parameters['folder_id'];
 		$this->rootEntry = $parameters['rootCacheEntry'];
 		$this->mountOwner = $parameters['mountOwner'];
-	}
-
-	/**
-	 * @return int
-	 */
-	public function getFolderId(): string {
-		return $this->folderId;
 	}
 
 	/**

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace OCA\Circles\Mount;
+
+use Exception;
+use OC\User\NoUserException;
+use OCA\Circles\Db\CircleRequest;
+use OCA\Circles\Model\Circle;
+use OCA\Circles\Model\Mount\FolderMount;
+use OCA\Circles\Model\Probes\CircleProbe;
+use OCA\Circles\Model\Probes\DataProbe;
+use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\FederatedUserService;
+use OCP\Files\Config\IMountProvider;
+use OCP\Files\Folder;
+use OCP\Files\InvalidPathException;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotFoundException as FilesNotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\IUser;
+use OCP\Lock\LockedException;
+use Psr\Log\LoggerInterface;
+use UnexpectedValueException;
+
+class MountProvider implements IMountProvider {
+	private IRootFolder $rootFolder;
+	private LoggerInterface $logger;
+	private CircleRequest $circleRequest;
+	private FederatedUserService $federatedUserService;
+	private ConfigService $configService;
+	private CirclesFolderManager $circlesFolderManager;
+
+	/**
+	 * MountProvider constructor.
+	 *
+	 * @param IRootFolder $rootFolder
+	 * @param LoggerInterface $logger
+	 * @param CircleRequest $circleRequest
+	 * @param FederatedUserService $federatedUserService
+	 * @param ConfigService $configService
+	 * @param CirclesFolderManager $collectiveFolderManager
+	 */
+	public function __construct(
+		IRootFolder $rootFolder,
+		LoggerInterface $logger,
+		CircleRequest $circleRequest,
+		FederatedUserService $federatedUserService,
+		ConfigService $configService,
+		CirclesFolderManager $collectiveFolderManager
+	) {
+		$this->rootFolder = $rootFolder;
+		$this->circlesFolderManager = $collectiveFolderManager;
+		$this->logger = $logger;
+		$this->circleRequest = $circleRequest;
+		$this->federatedUserService = $federatedUserService;
+		$this->configService = $configService;
+	}
+
+
+	/**
+	 * /** Called by core, this will return an array of IMountPoint available to current user
+	 * This is done by retrieving FolderMount available to the user and converting each FolderMount
+	 *
+	 * @param IUser $user
+	 * @param IStorageFactory $loader
+	 *
+	 * @return IMountPoint[]
+	 * @throws FilesNotFoundException
+	 */
+	public function getMountsForUser(IUser $user, IStorageFactory $loader): array {
+		$folders = $this->getFolderMountsForUser($user);
+		try {
+			return array_filter(
+				array_map(function (FolderMount $folder) use ($user, $loader): ?IMountPoint {
+					try {
+						return $this->circlesFolderManager->getMount($folder, $loader, $user);
+					} catch (Exception $e) {
+						return null;
+					}
+				}, $folders)
+			);
+		} catch (Exception $e) {
+			$this->logger->error('error while getMountsForUser', ['exception' => $e]);
+
+			return [];
+		}
+	}
+
+
+	/**
+	 * returns list of FolderMount related to current user.
+	 * One FolderMount per Circle:
+	 *
+	 * - mountpoint_enabled must be activated by instance,
+	 * - circle must be configured as CFG_MOUNTPOINT,
+	 * - current user must be a member of the circle.
+	 *
+	 * @param IUser $user
+	 *
+	 * @return FolderMount[]
+	 * @throws FilesNotFoundException
+	 */
+	private function getFolderMountsForUser(IUser $user): array {
+		$folderMounts = [];
+		if (!$this->configService->getAppValueBool(ConfigService::MOUNTPOINT_ENABLED)) {
+			return $folderMounts;
+		}
+
+		try {
+			$federatedUser = $this->federatedUserService->getLocalFederatedUser($user->getUID());
+			$circleProbe = new CircleProbe();
+			$circleProbe->limitConfig(Circle::CFG_MOUNTPOINT);
+
+			$dataProbe = new DataProbe();
+			$dataProbe->add(DataProbe::INITIATOR);
+			$circles = $this->circleRequest->probeCircles($federatedUser, $circleProbe, $dataProbe);
+		} catch (Exception $e) {
+			$this->logger->error('error while probeCircles', ['exception' => $e]);
+
+			return $folderMounts;
+		}
+
+		try {
+			$userFolder = $this->getUserFolder($user);
+		} catch (NotPermittedException $e) {
+			return $folderMounts;
+		}
+
+		foreach ($circles as $circle) {
+			$name = $circle->getSanitizedName();
+			$mountPoint = ($this->getCirclesFolderPath($user) === '/') ? '' : ($userFolder->getName() . '/');
+			$mountPoint .= ($name !== '') ? $name : $circle->getSingleId();
+
+			$folderMount = new FolderMount($circle->getSingleId());
+			$folderMount->setMountPoint2($mountPoint);
+			$folderMount->setAbsoluteMountPoint('/' . $user->getUID() . '/files/' . $mountPoint);
+			$folderMount->setPermissions(31);
+
+			try {
+				$cacheEntry = $this->circlesFolderManager->getCacheEntry($circle->getSingleId());
+				$folderMount->setCacheEntry($cacheEntry);
+			} catch (Exception $e) {
+				$this->logger->error('error while getCacheEntry', ['exception' => $e]);
+				continue;
+			}
+
+			$folderMounts[] = $folderMount;
+		}
+
+		return $folderMounts;
+	}
+
+
+	private function getUserFolder(IUser $user): Folder {
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		} catch (NotPermittedException | NoUserException $e) {
+			throw new NotPermittedException($e->getMessage(), 0, $e);
+		}
+
+		$userFolderPath = $this->getCirclesFolderPath($user);
+		// If collectives path is empty (due to null quota), return userFolder
+		if ($userFolderPath === '/') {
+			return $userFolder;
+		}
+
+		try {
+			$circlesFolder = $userFolder->get($userFolderPath);
+			// Rename existing node if it's not a folder
+			if (!$circlesFolder instanceof Folder) {
+				$new = $this->generateFolderName($userFolder, $userFolderPath);
+				$circlesFolder->move($userFolder->getPath() . '/' . $new);
+				$circlesFolder = $userFolder->newFolder($userFolderPath);
+			}
+		} catch (FilesNotFoundException $e) {
+			try {
+				$circlesFolder = $userFolder->newFolder($userFolderPath);
+			} catch (NotPermittedException $e) {
+				throw new NotPermittedException($e->getMessage(), 0, $e);
+			}
+		} catch (InvalidPathException $e) {
+			throw new NotFoundException($e->getMessage(), 0, $e);
+		} catch (NotPermittedException | LockedException $e) {
+			throw new NotPermittedException($e->getMessage(), 0, $e);
+		}
+
+		return $circlesFolder;
+	}
+
+
+	/**
+	 * returns the path of Circles Folder, based on:
+	 *
+	 * - current settings from user (circles/user_folder)
+	 * - default settings from the instance (mountpoint_path)
+	 *
+	 * @param IUser $user
+	 *
+	 * @return string
+	 * @throws NotPermittedException
+	 */
+	public function getCirclesFolderPath(IUser $user): string {
+		$folderPath = $this->configService->getUserValue('user_folder', '', $user->getUID());
+		if ($folderPath === '') {
+			// Guest users and others with null quota are not allowed to create a subdirectory
+			if ($user->getQuota() === '0 B') {
+				return '/';
+			}
+
+			$folderPath = $this->configService->getAppValue(ConfigService::MOUNTPOINT_PATH);
+
+			try {
+				$this->configService->setUserValue('user_folder', $folderPath, $user->getUID());
+			} catch (UnexpectedValueException $e) {
+				throw new NotPermittedException($e->getMessage(), 0, $e);
+			}
+		}
+
+		return $folderPath;
+	}
+
+
+	/**
+	 * generate a new folder name based on already existing folder
+	 *
+	 * @param Folder $folder
+	 * @param string $filename
+	 * @param int $loop
+	 *
+	 * @return string
+	 */
+	private function generateFolderName(Folder $folder, string $filename, int $loop = 1): string {
+		$path = $filename;
+		$path .= ($loop > 1) ? ' (' . $loop . ')' : '';
+
+		if (!$folder->nodeExists($filename) && !$folder->nodeExists($path)) {
+			return $filename;
+		}
+
+		return $this->generateFolderName($folder, $filename, ++$loop);
+	}
+}

--- a/lib/Mount/NoExcludePropagatorStorageWrapper.php
+++ b/lib/Mount/NoExcludePropagatorStorageWrapper.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Mount;
+
+use OC\Files\Cache\Propagator;
+use OC\Files\Storage\Storage;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\IDBConnection;
+use OCP\Server;
+
+class NoExcludePropagatorStorageWrapper extends Wrapper {
+
+	/**
+	 * @param Storage|null $storage (optional) the storage to pass to the watcher
+	 *
+	 * @return Propagator
+	 */
+	public function getPropagator($storage = null): Propagator {
+		if ($storage === null) {
+			$storage = $this;
+		}
+
+		if (!isset($storage->propagator)) {
+			$storage->propagator = new Propagator($storage, Server::get(IDBConnection::class));
+		}
+
+		return $storage->propagator;
+	}
+}

--- a/lib/Mount/RootEntryCache.php
+++ b/lib/Mount/RootEntryCache.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Circles - Bring cloud-users closer together.
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2022
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Circles\Mount;
+
+use OC\Files\Cache\Wrapper\CacheWrapper;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
+
+class RootEntryCache extends CacheWrapper {
+	private ?ICacheEntry $rootEntry;
+
+	public function __construct(
+		ICache $cache,
+		?ICacheEntry $rootEntry = null
+	) {
+		parent::__construct($cache);
+		$this->rootEntry = $rootEntry;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get($file) {
+		if ($file === '' && $this->rootEntry) {
+			return $this->rootEntry;
+		}
+
+		return parent::get($file);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function insert($file, array $data): int {
+		$this->rootEntry = null;
+
+		return parent::insert($file, $data);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function update($id, array $data): void {
+		$this->rootEntry = null;
+		parent::update($id, $data);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getId($file): int {
+		if ($file === '' && $this->rootEntry) {
+			return $this->rootEntry->getId();
+		}
+
+		return parent::getId($file);
+	}
+}


### PR DESCRIPTION
Adding a setting to circle to enable the creation of a CirclesFolder available to all members of the circle

- [x] fix an issue with probeCircles
- [x] global settings `circles/mountpoint_enabled` for admin
- [x] new config flag for circle
- [x] Store data in `appdata` and make it available in `Circles/CircleSanitizedName`
- [x] permissions are based on level
- [x] permissions are stored as settings
- [ ] save new permissions
- [ ] re-implement the globalscale mount with the new mountprovider

based on `groupfolders` and `collectives` app