### PR TITLE
fix: Do not spam the log if contacts is disabled

### DIFF
--- a/lib/Model/ModelManager.php
+++ b/lib/Model/ModelManager.php
@@ -58,6 +58,7 @@ use OCA\Circles\Service\InterfaceService;
 use OCA\Circles\Service\MembershipService;
 use OCA\Circles\Service\RemoteService;
 use OCA\Circles\Tools\Traits\TNCLogger;
+use OCP\App\IAppManager;
 use OCP\IURLGenerator;
 
 /**
@@ -556,8 +557,10 @@ class ModelManager {
 	public function generateLinkToCircle(string $singleId): string {
 		$path = $this->configService->getAppValue(ConfigService::ROUTE_TO_CIRCLE);
 
+		[$appName] = explode('.', $path, 3);
+		$frontendAppAvailable = $appName === 'contacts' ? \OCP\Server::get(IAppManager::class)->isEnabledForUser('contacts') : true;
 		try {
-			if ($path !== '') {
+			if ($frontendAppAvailable && $path !== '') {
 				return $this->urlGenerator->linkToRoute($path, ['singleId' => $singleId]);
 			}
 		} catch (Exception $e) {


### PR DESCRIPTION
Avoid spamming the log if the contacts app is disabled. I consider this more a workaround as I don't have enough insight on why the route is configurable in that case. Are there other use cases where the route could be served by another app? If not that could clean up the code quite a bit by hardcoding it to checking if contacts is enabled and then returning the route, otherwise none.