### PR TITLE
Make changes to circle config synchroneous

### DIFF
--- a/lib/FederatedItems/CircleConfig.php
+++ b/lib/FederatedItems/CircleConfig.php
@@ -36,7 +36,6 @@ use OCA\Circles\Exceptions\FederatedItemBadRequestException;
 use OCA\Circles\Exceptions\FederatedItemException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\IFederatedItem;
-use OCA\Circles\IFederatedItemAsyncProcess;
 use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Model\Helpers\MemberHelper;
@@ -50,8 +49,7 @@ use OCA\Circles\Tools\Traits\TDeserialize;
  * @package OCA\Circles\FederatedItems
  */
 class CircleConfig implements
-	IFederatedItem,
-	IFederatedItemAsyncProcess {
+	IFederatedItem {
 	use TDeserialize;
 
 


### PR DESCRIPTION
Required for Collectives to allow unflagging a circle as app managed and delete the circle in the same request.