### PR TITLE
release 27.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ cert_dir=$(HOME)/.nextcloud/certificates
 github_account=nextcloud
 release_account=nextcloud-releases
 branch=stable27
-version=27.0.0
+version=27.0.1
 since_tag=
 
 all: appstore

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Those groups of people (or "circles") can then be used by any other app for sharing purpose.
 		]]>
 	</description>
-	<version>27.0.0</version>
+	<version>27.0.1</version>
 	<licence>agpl</licence>
 	<author>Maxence Lange</author>
 	<types>


### PR DESCRIPTION
- group can contains '@'
- probeCircles on search
- ignore personal's ownership requirement
