### PR TITLE
download permissions on share for internal/external members

### DIFF
--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -169,6 +169,7 @@ class CoreRequestBuilder {
 			'file_source',
 			'file_target',
 			'permissions',
+			'attributes',
 			'stime',
 			'accepted',
 			'expiration',

--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -801,7 +801,7 @@ class CircleService {
 	 * @param CircleProbe $circleProbe
 	 * @param DataProbe|null $dataProbe
 	 *
-	 * @return array
+	 * @return Circle[]
 	 * @throws InitiatorNotFoundException
 	 * @throws RequestBuilderException
 	 */

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -225,8 +225,9 @@ class ShareByCircleProvider implements IShareProvider {
 	public function update(IShare $share): IShare {
 		$wrappedShare = $this->shareWrapperService->getShareById((int)$share->getId());
 		$wrappedShare->setPermissions($share->getPermissions())
-					 ->setShareOwner($share->getShareOwner())
-					 ->setSharedBy($share->getSharedBy());
+			->setShareOwner($share->getShareOwner())
+			->setAttributes($share->getAttributes())
+			->setSharedBy($share->getSharedBy());
 
 		$this->shareWrapperService->update($wrappedShare);
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,6 +29,7 @@
 				<referencedClass name="OCA\Files\App" />
 				<referencedClass name="OCP\Accounts\UserUpdatedEvent" />
 				<referencedClass name="OCA\Files\Event\LoadAdditionalScriptsEvent" />
+				<referencedClass name="OC\Share20\ShareAttributes" />
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -430,8 +430,9 @@
     </InvalidReturnType>
   </file>
   <file src="lib/Model/ShareWrapper.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument occurrences="2">
       <code>Cache::cacheEntryFromData($this-&gt;getFileCache()-&gt;toCache(), OC::$server-&gt;getMimeTypeLoader())</code>
+      <code>$this-&gt;setAttributes($attributes)</code>
     </InvalidArgument>
     <InvalidNullableReturnType occurrences="5">
       <code>Circle</code>


### PR DESCRIPTION
manage `allow download` on shares to Circles using the same mechanism that internal shares and shareByMail.

- local account as members of a Circle will not be able to download the shared content,
- remote account (mail address) as members will not be able to see the download button.


the attributes is stored/converted the same way than in core.