### PR TITLE
support sharing files_external root

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -401,6 +401,11 @@ class ShareByCircleProvider implements IShareProvider {
 			if ($wrappedShare->getFileCache()->isAccessible()) {
 				$result[$wrappedShare->getFileSource()][] =
 					$wrappedShare->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
+			} else {
+				$this->logger->debug('shared document is not available anymore', ['wrappedShare' => $wrappedShare]);
+				if ($wrappedShare->getFileCache()->getPath() === '') {
+					$this->logger->notice('share is not available while path is empty. might comes from an unsupported storage.', ['wrappedShare' => $wrappedShare]);
+				}
 			}
 		}
 


### PR DESCRIPTION
This fix an issue when sharing the top folder of an external storage.
path is empty in that case, meaning we should not return `false` when checking availability if path is empty but storage is managed by `files_external`