### PR TITLE
feat: Implement teams dashboard widget

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -36,6 +36,7 @@ namespace OCA\Circles\AppInfo;
 
 use Closure;
 use OC;
+use OCA\Circles\Dashboard\TeamDashboardWidget;
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleMemberAddedEvent;
 use OCA\Circles\Events\DestroyingCircleEvent;
@@ -137,6 +138,8 @@ class Application extends App implements IBootstrap {
 
 		$context->registerSearchProvider(UnifiedSearchProvider::class);
 		$context->registerWellKnownHandler(WebfingerHandler::class);
+
+		$context->registerDashboardWidget(TeamDashboardWidget::class);
 	}
 
 

--- a/lib/Dashboard/TeamDashboardWidget.php
+++ b/lib/Dashboard/TeamDashboardWidget.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * @copyright Copyright (c) 2024 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Circles\Dashboard;
+
+use OCA\Circles\Exceptions\FrontendException;
+use OCA\Circles\Model\Circle;
+use OCA\Circles\Model\ModelManager;
+use OCA\Circles\Model\Probes\CircleProbe;
+use OCA\Circles\Service\CircleService;
+use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\FederatedUserService;
+use OCP\Dashboard\IAPIWidgetV2;
+use OCP\Dashboard\IButtonWidget;
+use OCP\Dashboard\IConditionalWidget;
+use OCP\Dashboard\IIconWidget;
+use OCP\Dashboard\Model\WidgetButton;
+use OCP\Dashboard\Model\WidgetItem;
+use OCP\Dashboard\Model\WidgetItems;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+class TeamDashboardWidget implements IAPIWidgetV2, IIconWidget, IButtonWidget, IConditionalWidget {
+	public function __construct(
+		private IURLGenerator $urlGenerator,
+		private IL10N $l10n,
+		private CircleService $circleService,
+		private ModelManager $modelManager,
+		private FederatedUserService $federatedUserService,
+		private ConfigService $configService,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getItemsV2(string $userId, ?string $since = null, int $limit = 7): WidgetItems {
+		$circles = [];
+
+		try {
+			if (!$this->configService->getAppValueBool(ConfigService::FRONTEND_ENABLED)) {
+				throw new FrontendException('frontend disabled');
+			}
+
+			$user = $this->userSession->getUser();
+			$this->federatedUserService->setLocalCurrentUser($user);
+
+			$probe = new CircleProbe();
+			$probe->filterHiddenCircles()
+				->filterBackendCircles()
+				->setItemsLimit($limit)
+				->setItemsOffset($since ? (int)$since : 0);
+
+			$circles = array_map(function (Circle $circle) {
+				return new WidgetItem(
+					$circle->getDisplayName(),
+					'',
+					$this->urlGenerator->getAbsoluteURL($this->modelManager->generateLinkToCircle($circle->getSingleId())),
+					$this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('core.GuestAvatar.getAvatar', ['guestName' => $circle->getDisplayName(), 'size' => 64]))
+				);
+			}, $this->circleService->probeCircles($probe));
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+		}
+		return new WidgetItems($circles);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return 'circles';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return 'Teams';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOrder(): int {
+		return 0;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconClass(): string {
+		return 'icon-teams';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getUrl(): ?string {
+		return $this->getTeamPage();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function load(): void {
+	}
+
+	public function getWidgetButtons(string $userId): array {
+		return [
+			new WidgetButton(
+				WidgetButton::TYPE_MORE,
+				$this->getTeamPage(),
+				$this->l10n->t('Show all teams')
+			),
+			new WidgetButton(
+				WidgetButton::TYPE_SETUP,
+				$this->getTeamPage(),
+				$this->l10n->t('Create a new team')
+			),
+		];
+	}
+
+	public function getIconUrl(): string {
+		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('circles', 'app.svg'));
+	}
+
+	private function getTeamPage(): string {
+		return $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('contacts.page.index')
+		);
+	}
+
+	public function isEnabled(): bool {
+		return $this->configService->getAppValueBool(ConfigService::FRONTEND_ENABLED);
+	}
+}


### PR DESCRIPTION
Resolves #1506 

<img width="1076" alt="Screenshot 2024-02-20 at 15 31 56" src="https://github.com/nextcloud/circles/assets/3404133/63efb047-2c17-450c-a7bb-167cd89eee6a">

@marcoambrosini @jancborchardt I used the generated avatars as they are also used in contacts right now

Needs upstream adjustments in the dashboard API:
- [x] Center text if no subline is provided https://github.com/nextcloud-libraries/nextcloud-vue/pull/5271
- [x] Also (apart from the vertical alignment you noted), the icons should be horizontally aligned below the heading icon of the widget, just like the text should be left-aligned with the heading text. Currently everything is a bit shifted to the right. https://github.com/nextcloud/server/pull/43702

## Follow up requiring server / API adjustments
- [ ] Add icon to add button
- [ ] Add empty content placeholder text through API
- [ ] Show action button if not all list item slots are filled