### PR TITLE
fix(dashboard): Add `icon-teams` CSS class and fix path to app icon

### DIFF
--- a/lib/Dashboard/TeamDashboardWidget.php
+++ b/lib/Dashboard/TeamDashboardWidget.php
@@ -147,7 +147,7 @@ class TeamDashboardWidget implements IAPIWidgetV2, IIconWidget, IButtonWidget, I
 	}
 
 	public function getIconUrl(): string {
-		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('circles', 'app.svg'));
+		return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('circles', 'circles.svg'));
 	}
 
 	private function getTeamPage(): string {


### PR DESCRIPTION
Fixing the path to the app icon fixes dashboard widgets. Otherwise getting the widgets throws an error and all widgets are broken.

Adding the `icon-teams` CSS class fixes displaying the teams icon in the teams dashboard widget.

![2024-03-05T17:36:08,669081871+01:00](https://github.com/nextcloud/circles/assets/3582805/ab893c10-3742-4ec5-963c-81777e51a47d)
