### PR TITLE
fix/remove broken scripts

### DIFF
--- a/lib/Listeners/Files/ListenerFilesLoadScripts.php
+++ b/lib/Listeners/Files/ListenerFilesLoadScripts.php
@@ -45,8 +45,9 @@ class ListenerFilesLoadScripts implements IEventListener {
 			return;
 		}
 
-		Util::addScript('circles', 'files/circles.files.app');
-		Util::addScript('circles', 'files/circles.files.list');
+		// FIXME: Those scripts need to be migrated to the new files API first
+		// Util::addScript('circles', 'files/circles.files.app');
+		// Util::addScript('circles', 'files/circles.files.list');
 		Util::addStyle('circles', 'files/circles.filelist');
 	}
 }


### PR DESCRIPTION
We need to migrate those scripts to the new files API but this is more work there is currently no time. It seems those scripts can cause failures as reported in https://github.com/nextcloud/circles/issues/1434

As they don't work right now there is no need to load them and this also has been a regular annoyance when running cypress tests locally where the random console errors cause failures.

Left the script files in place to know what to implement with the new API.