### PR TITLE
feat: dismiss notification when accepting an invitation

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -106,6 +106,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, ListenerFilesLoadScripts::class);
 		$context->registerEventListener(PreparingCircleMemberEvent::class, ListenerFilesPreparingMemberSendMail::class);
 		$context->registerEventListener(AddingCircleMemberEvent::class, ListenerFilesAddingMemberSendMail::class);
+		$context->registerEventListener(AddingCircleMemberEvent::class, ListenerNotificationsRequestingMember::class);
 		$context->registerEventListener(CircleMemberAddedEvent::class, ListenerFilesMemberAddedSendMail::class);
 		$context->registerEventListener(PreparingFileShareEvent::class, ListenerFilesPreparingShareSendMail::class);
 		$context->registerEventListener(CreatingFileShareEvent::class, ListenerFilesCreatingShareSendMail::class);

--- a/lib/Listeners/Notifications/RequestingMember.php
+++ b/lib/Listeners/Notifications/RequestingMember.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Listeners\Notifications;
 
+use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleGenericEvent;
 use OCA\Circles\Events\RequestingCircleMemberEvent;
+use OCA\Circles\Model\Circle;
 use OCA\Circles\Service\NotificationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -22,13 +24,15 @@ class RequestingMember implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!$event instanceof RequestingCircleMemberEvent) {
+		if (!$event instanceof RequestingCircleMemberEvent && !$event instanceof AddingCircleMemberEvent) {
 			return;
 		}
 
 		$member = $event->getMember();
 		if ($event->getType() === CircleGenericEvent::REQUESTED) {
 			$this->notificationService->notificationRequested($member);
+		} elseif ($event->getType() === CircleGenericEvent::JOINED && $event->getCircle()->isConfig(Circle::CFG_INVITE)) {
+			$this->notificationService->markInvitationAsProcessed($member);
 		} else {
 			$this->notificationService->notificationInvited($member);
 		}

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -205,4 +205,18 @@ class NotificationService {
 
 		return parse_url($absolute, PHP_URL_PATH);
 	}
+
+	public function markInvitationAsProcessed(Member $member): void {
+		if ($member->getUserType() !== Member::TYPE_USER || !$member->isLocal()) {
+			return;
+		}
+
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('circles')
+			->setUser($member->getUserId())
+			->setObject('member', $member->getId())
+			->setSubject('invitation');
+
+		$this->notificationManager->markProcessed($notification);
+	}
 }


### PR DESCRIPTION
For https://github.com/nextcloud/circles/issues/810

I only tested the case (circle needs invitation, user is invited, user press accept, notification is gone). 
Needs a careful review.