### PR TITLE
fix(notifications): Don't trigger invite notifications for system groups

### DIFF
--- a/lib/Listeners/Notifications/RequestingMember.php
+++ b/lib/Listeners/Notifications/RequestingMember.php
@@ -16,7 +16,7 @@ use OCA\Circles\Service\NotificationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
-/** @template-implements IEventListener<RequestingCircleMemberEvent|Event> */
+/** @template-implements IEventListener<RequestingCircleMemberEvent|AddingCircleMemberEvent|Event> */
 class RequestingMember implements IEventListener {
 	public function __construct(
 		private NotificationService $notificationService,
@@ -24,17 +24,26 @@ class RequestingMember implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!$event instanceof RequestingCircleMemberEvent && !$event instanceof AddingCircleMemberEvent) {
-			return;
+		if ($event instanceof RequestingCircleMemberEvent) {
+			$this->handleRequestingCircleMemberEvent($event);
+		} elseif ($event instanceof AddingCircleMemberEvent) {
+			$this->handleAddingCircleMemberEvent($event);
 		}
+	}
 
+	public function handleRequestingCircleMemberEvent(RequestingCircleMemberEvent $event): void {
 		$member = $event->getMember();
 		if ($event->getType() === CircleGenericEvent::REQUESTED) {
 			$this->notificationService->notificationRequested($member);
-		} elseif ($event->getType() === CircleGenericEvent::JOINED && $event->getCircle()->isConfig(Circle::CFG_INVITE)) {
-			$this->notificationService->markInvitationAsProcessed($member);
 		} else {
 			$this->notificationService->notificationInvited($member);
+		}
+	}
+
+	public function handleAddingCircleMemberEvent(AddingCircleMemberEvent $event): void {
+		if ($event->getType() === CircleGenericEvent::JOINED && $event->getCircle()->isConfig(Circle::CFG_INVITE)) {
+			$member = $event->getMember();
+			$this->notificationService->markInvitationAsProcessed($member);
 		}
 	}
 }


### PR DESCRIPTION
Regression from #1641

### Before
Adding a user to a system group triggers a notification:
> You have been invited by Circles into the Circle "group1"

### After

:broom: 