### PR TITLE
refactor: Migrate away from deprecated `ILogger` to PSR-3

### DIFF
--- a/lib/Circles/FileSharingBroadcaster.php
+++ b/lib/Circles/FileSharingBroadcaster.php
@@ -28,7 +28,6 @@ use OCP\Federation\ICloudIdManager;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -37,6 +36,7 @@ use OCP\Mail\IMailer;
 use OCP\Share\Exceptions\IllegalIDChangeException;
 use OCP\Share\IShare;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class FileSharingBroadcaster
@@ -65,7 +65,7 @@ class FileSharingBroadcaster implements IBroadcaster {
 	/** @var Notifications */
 	private $federationNotifications;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var Defaults */
@@ -104,7 +104,7 @@ class FileSharingBroadcaster implements IBroadcaster {
 		$this->rootFolder = OC::$server->getLazyRootFolder();
 		$this->userManager = OC::$server->getUserManager();
 		$this->federationCloudIdManager = OC::$server->getCloudIdManager();
-		$this->logger = OC::$server->getLogger();
+		$this->logger = \OCP\Server::get(LoggerInterface::class);
 		$this->urlGenerator = OC::$server->getURLGenerator();
 		try {
 			$this->defaults = OC::$server->query(Defaults::class);
@@ -356,12 +356,12 @@ class FileSharingBroadcaster implements IBroadcaster {
 				IShare::TYPE_USER
 			);
 		} catch (\Exception $e) {
-			$this->logger->logException(
-				$e, [
-					'message' => 'Failed to notify remote server of circles-federated share',
-					'level' => ILogger::ERROR,
+			$this->logger->error(
+				'Failed to notify remote server of circles-federated share',
+				[
 					'app' => 'circles',
-				]
+					'exception' => $e,
+				],
 			);
 		}
 

--- a/lib/Service/MiscService.php
+++ b/lib/Service/MiscService.php
@@ -16,32 +16,18 @@ use OCA\Circles\Tools\Traits\TArrayTools;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Contacts\ContactsMenu\IContactsStore;
-use OCP\ILogger;
 use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
 
 class MiscService {
 	use TArrayTools;
 
-
-	/** @var ILogger */
-	private $logger;
-
-	/** @var IContactsStore */
-	private $contactsStore;
-
-	/** @var string */
-	private $appName;
-
-	/** @var IUserManager */
-	private $userManager;
-
 	public function __construct(
-		ILogger $logger, IContactsStore $contactsStore, $appName, IUserManager $userManager
+		private LoggerInterface $logger,
+		private IContactsStore $contactsStore,
+		private string $appName,
+		private IUserManager $userManager,
 	) {
-		$this->logger = $logger;
-		$this->contactsStore = $contactsStore;
-		$this->appName = $appName;
-		$this->userManager = $userManager;
 	}
 
 	public function log($message, $level = 4) {
@@ -58,13 +44,13 @@ class MiscService {
 	 * @param Exception $e
 	 */
 	public function e(Exception $e) {
-		$this->logger->logException($e, ['app' => 'circles']);
+		$this->logger->error($e->getMessage(), ['app' => 'circles', 'exception' => $e]);
 	}
 
 
 	/**
-	 * @param $arr
-	 * @param $k
+	 * @param array $arr
+	 * @param int|string $k
 	 *
 	 * @param string $default
 	 *

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -55,7 +55,6 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
@@ -98,7 +97,7 @@ class ShareByCircleProvider implements IShareProvider {
 		IUserManager $userManager,
 		IRootFolder $rootFolder,
 		IL10N $l10n,
-		ILogger $logger,
+		mixed $logger, // unused, only kept for compatibility with server
 		IURLGenerator $urlGenerator
 	) {
 		$this->userManager = $userManager;


### PR DESCRIPTION
Mostly replace `ILogger` with `LoggerInterface` and some minor cleanup (constructor property promotion).

Some places used the deprecated `logException`, this is easy to migrate: Simply use the appropriate log level on the logger and place the exception under the `exception` key in the context.