### PR TITLE
Fix display name of new users

### DIFF
--- a/lib/Listeners/AccountUpdated.php
+++ b/lib/Listeners/AccountUpdated.php
@@ -11,6 +11,7 @@ namespace OCA\Circles\Listeners;
 
 use Exception;
 use OCA\Circles\Db\CircleRequest;
+use OCA\Circles\Db\MemberRequest;
 use OCA\Circles\FederatedItems\MemberDisplayName;
 use OCA\Circles\Model\Federated\FederatedEvent;
 use OCA\Circles\Model\Probes\CircleProbe;
@@ -30,7 +31,8 @@ class AccountUpdated implements IEventListener {
 		private CircleService $circleService,
 		private FederatedEventService $federatedEventService,
 		private FederatedUserService $federatedUserService,
-		private LoggerInterface $logger
+		private LoggerInterface $logger,
+		private MemberRequest $memberRequest
 	) {
 	}
 
@@ -47,6 +49,7 @@ class AccountUpdated implements IEventListener {
 			$user = $event->getUser();
 			$federatedUser = $this->federatedUserService->getLocalFederatedUser($user->getUID());
 
+			$this->memberRequest->updateDisplayName($federatedUser->getSingleId(), $user->getDisplayName());
 			$this->circleRequest->updateDisplayName($federatedUser->getSingleId(), $user->getDisplayName());
 			$this->federatedUserService->setCurrentUser($federatedUser);
 


### PR DESCRIPTION
Fixes nextcloud/contacts#3646

Although since https://github.com/nextcloud/circles/pull/1648 the display name of users is updated in a circle when it is changed in the user settings, the new display name was not shown if the user was then added to a circle; when the display name is changed it needs to be updated both for the circles and the members, similarly to how it is done [when updating the display name in the `MaintenanceService`](https://github.com/nextcloud/circles/blob/f725ecaffbfae29a98ef0eea745d5bcf6e64b90c/lib/Service/MaintenanceService.php#L432-L433).

Originally this pull request had an additional commit to set the display name of the associated member based on the `IUser` API instead of the account data when a user was created; this was done on the basis that the user was updated after being created due to the avatar being generated, but that it was just a happy coincidence and the user should be properly set up from the beginning. But that was wrong :facepalm: When [the `UserCreated` event is triggered](https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/lib/private/User/Manager.php#L448) the user does not even have a display name set, and [the `UserChanged` event is then triggered](https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/lib/private/User/User.php#L148) not only when the avatar is generated, but when the display name [is actually set in the newly created user](https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/apps/provisioning_api/lib/Controller/UsersController.php#L547). Due to that the extra commit was dropped.

## How to test (scenario 1)

- Create a user with a display name
- Open the Contacts app
- Create a circle
- Add the user

### Result with this pull request

The display name of the user is shown in the circle

### Result without this pull request

The id of the user is shown in the circle

## How to test (scenario 2)

- Create a user
- Set a display name for the user
- Open the Contacts app
- Create a circle
- Add the user

### Result with this pull request

The display name of the user is shown in the circle

### Result without this pull request

The id of the user is shown in the circle
