### PR TITLE
fix(CoreQueryBuilder): Use shorter prefixes to stay below 30 characters for Oracle <12.2

### DIFF
--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -36,29 +36,29 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	use TArrayTools;
 
 
-	public const SINGLE = 'cs';
-	public const CIRCLE = 'cc';
-	public const MEMBER = 'mm';
-	public const OWNER = 'wn';
-	public const FEDERATED_EVENT = 'ev';
-	public const REMOTE = 'rm';
-	public const BASED_ON = 'on';
-	public const INITIATOR = 'in';
-	public const DIRECT_INITIATOR = 'di';
-	public const MEMBERSHIPS = 'ms';
-	public const CONFIG = 'cf';
-	public const UPSTREAM_MEMBERSHIPS = 'up';
-	public const INHERITANCE_FROM = 'ih';
-	public const INHERITED_BY = 'by';
-	public const INVITED_BY = 'nv';
-	public const MOUNT = 'mo';
-	public const MOUNTPOINT = 'mp';
-	public const SHARE = 'sh';
-	public const FILE_CACHE = 'fc';
-	public const STORAGES = 'st';
-	public const TOKEN = 'tk';
-	public const OPTIONS = 'pt';
-	public const HELPER = 'hp';
+	public const SINGLE = 'a';
+	public const CIRCLE = 'b';
+	public const MEMBER = 'c';
+	public const OWNER = 'd';
+	public const FEDERATED_EVENT = 'e';
+	public const REMOTE = 'f';
+	public const BASED_ON = 'g';
+	public const INITIATOR = 'h';
+	public const DIRECT_INITIATOR = 'i';
+	public const MEMBERSHIPS = 'j';
+	public const CONFIG = 'k';
+	public const UPSTREAM_MEMBERSHIPS = 'l';
+	public const INHERITANCE_FROM = 'm';
+	public const INHERITED_BY = 'n';
+	public const INVITED_BY = 'o';
+	public const MOUNT = 'p';
+	public const MOUNTPOINT = 'q';
+	public const SHARE = 'r';
+	public const FILE_CACHE = 's';
+	public const STORAGES = 't';
+	public const TOKEN = 'u';
+	public const OPTIONS = 'v';
+	public const HELPER = 'w';
 
 
 	public static $SQL_PATH = [


### PR DESCRIPTION
Fixes https://github.com/nextcloud/circles/issues/1697