### PR TITLE
[stable29] ignore non-circles share while extracting permissions

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -691,6 +691,10 @@ class ShareByCircleProvider implements IShareProvider {
 
 		$shareIds = $knownIds = $users = $remote = $mails = [];
 		foreach ($this->shareWrapperService->getSharesByFileIds($ids, true, true) as $share) {
+			if (!$share->hasCircle()) {
+				continue;
+			}
+
 			$shareIds[] = $share->getId();
 			$circle = $share->getCircle();
 			foreach ($circle->getInheritedMembers() as $member) {


### PR DESCRIPTION
backport of #1708