### PR TITLE
bypass user condition on cli

### DIFF
--- a/lib/Api/v1/Circles.php
+++ b/lib/Api/v1/Circles.php
@@ -163,8 +163,8 @@ class Circles {
 	public static function detailsCircle(string $circleUniqueId, bool $forceAll = false): Circle {
 		/** @var FederatedUserService $federatedUserService */
 		$federatedUserService = \OC::$server->get(FederatedUserService::class);
-		if ($forceAll) {
-			$federatedUserService->bypassCurrentUserCondition($forceAll);
+		if ($forceAll || \OC::$CLI) {
+			$federatedUserService->bypassCurrentUserCondition(true);
 		} else {
 			$federatedUserService->initCurrentUser();
 		}


### PR DESCRIPTION
bypass initiator check when ran from CLI. this would fix an issue when running `./occ files:transfer-ownership`

~~~
```
Could not restore share with id 1:Invalid initiator : #0 /home/maxence/sites/nc30/nextcloud/apps/circles/lib/Service/CircleService.php(489): OCA\Circles\Service\FederatedUserService->mustHaveCurrentUser()
#1 /home/maxence/sites/nc30/nextcloud/apps/circles/lib/Api/v1/Circles.php(177): OCA\Circles\Service\CircleService->getCircle()
#2 /home/maxence/sites/nc30/nextcloud/lib/private/Share20/Manager.php(158): OCA\Circles\Api\v1\Circles::detailsCircle()
#3 /home/maxence/sites/nc30/nextcloud/lib/private/Share20/Manager.php(792): OC\Share20\Manager->generalCreateChecks()
#4 /home/maxence/sites/nc30/nextcloud/apps/files/lib/Service/OwnershipTransferService.php(463): OC\Share20\Manager->updateShare()
```