### PR TITLE
fix(ShareWrapperRequest): Save share attributes on creation

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -40,7 +40,8 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 	 */
 	public function save(IShare $share, int $parentId = 0): int {
 		$qb = $this->getShareInsertSql();
-		$qb->setValue('share_type', $qb->createNamedParameter($share->getShareType()))
+		$qb->setValue('attributes', $qb->createNamedParameter($this->formatShareAttributes($share->getAttributes())))
+			->setValue('share_type', $qb->createNamedParameter($share->getShareType()))
 			->setValue('item_type', $qb->createNamedParameter($share->getNodeType()))
 			->setValue('item_source', $qb->createNamedParameter($share->getNodeId()))
 			->setValue('file_source', $qb->createNamedParameter($share->getNodeId()))
@@ -514,7 +515,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 			$compressedAttributes[] = [
 				$attribute['scope'],
 				$attribute['key'],
-				$attribute['enabled']
+				$attribute['value']
 			];
 		}
 

--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -478,6 +478,8 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			->setToken($this->get('token', $data))
 			->setShareTime($shareTime);
 
+		$this->importAttributesFromDatabase($this->get('attributes', $data));
+
 		try {
 			$this->setExpirationDate(new DateTime($this->get('expiration', $data)));
 		} catch (\Exception $e) {
@@ -590,7 +592,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			'shareType' => $this->getShareType(),
 			'providerId' => $this->getProviderId(),
 			'permissions' => $this->getPermissions(),
-			'attributes' => $this->getAttributes(),
+			'attributes' => json_encode($this->getAttributes()->toArray()),
 			'hideDownload' => $this->getHideDownload(),
 			'itemType' => $this->getItemType(),
 			'itemSource' => $this->getItemSource(),


### PR DESCRIPTION
- Before this commit, attributes added to a share were ignored when the share type was team/circles (share type `7`).

- Share attributes are not expected to contain any key or property named `enabled`.

Partial resolution of: https://github.com/nextcloud/server/issues/46920

This is a partial resolution because setting the `download` attribute may not fully enforce the correct download permissions. A follow-up PR in the server may be needed to update the `hideDownload` property of the share based on the value of `download` in the share attributes.