### PR TITLE
fix(ShareWrapper): Prevent attempt to access property on null

### DIFF
--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -592,7 +592,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			'shareType' => $this->getShareType(),
 			'providerId' => $this->getProviderId(),
 			'permissions' => $this->getPermissions(),
-			'attributes' => json_encode($this->getAttributes()->toArray()),
+			'attributes' => $this->getAttributes() !== null ? json_encode($this->getAttributes()->toArray()) : null,
 			'hideDownload' => $this->getHideDownload(),
 			'itemType' => $this->getItemType(),
 			'itemSource' => $this->getItemSource(),


### PR DESCRIPTION
`IShare:getAttributes()` can return null

Resolves: https://github.com/nextcloud/circles/issues/1735