### PR TITLE
fix(FederatedUserService): Increase cache TTL for singleId to one week

### DIFF
--- a/lib/Service/FederatedUserService.php
+++ b/lib/Service/FederatedUserService.php
@@ -74,7 +74,7 @@ class FederatedUserService {
 
 
 	public const CACHE_SINGLE_CIRCLE = 'circles/singleCircle';
-	public const CACHE_SINGLE_CIRCLE_TTL = 900;
+	public const CACHE_SINGLE_CIRCLE_TTL = 604800; // one week
 
 	public const CONFLICT_001 = 1;
 	public const CONFLICT_002 = 2;


### PR DESCRIPTION
The singleId for a user doesn't change once it got generated, so no need to refresh the cache every 15 minutes. Let's cache it for one week instead.