### PR TITLE
fix(activity): ensure absolute URL are used

### DIFF
--- a/lib/Activity/ProviderParser.php
+++ b/lib/Activity/ProviderParser.php
@@ -266,7 +266,7 @@ class ProviderParser {
 			'id' => $circle->getSingleId(),
 			'name' => $circle->getName(),
 			'_parsed' => $circle->getName(),
-			'link' => $circle->getUrl()
+			'link' => $this->url->getAbsoluteURL($circle->getUrl()),
 		];
 	}
 


### PR DESCRIPTION
Otherwise activity emails are send with `/index.php/...` URLs