### PR TITLE
fix: do not override sharing text

### DIFF
--- a/lib/Service/SendMailService.php
+++ b/lib/Service/SendMailService.php
@@ -143,7 +143,6 @@ class SendMailService {
 			$text = $this->l10n->t('%s shared a file with "%s".', [$author, $circleName]);
 		}
 
-		$text = $this->l10n->t('%s shared multiple files with "%s".', [$author, $circleName]);
 		$emailTemplate->addBodyText(htmlspecialchars($text), $text);
 
 		return $emailTemplate;


### PR DESCRIPTION
Determined sharing text from if block above is overridden. 