### PR TITLE
fix: add cache to joinedCircles API request

### DIFF
--- a/lib/Api/v1/Circles.php
+++ b/lib/Api/v1/Circles.php
@@ -130,7 +130,7 @@ class Circles {
 		$probe->includePersonalCircles($personalCircle);
 		$probe->filterHiddenCircles();
 
-		return $circleService->getCircles($probe);
+		return $circleService->getCircles($probe, true);
 	}
 
 


### PR DESCRIPTION
This deprecated API is only used by DAV, but doesn't benefit from the cache, which makes it VERY heavy when you have a lot of users using calendar intensively