### PR TITLE
fix: Set a token to shares retreived from the DB

### DIFF
--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -380,6 +380,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 		$share->setTarget($this->getFileTarget());
 		$share->setProviderId($this->getProviderId());
 		$share->setStatus($this->getStatus());
+		$share->setToken($this->getToken());
 		$share->setHideDownload($this->getHideDownload());
 		$share->setAttributes($this->getAttributes());
 		if ($this->hasShareToken()) {


### PR DESCRIPTION
When accessing a circle share from the public share view, the `addOpenGraphHeaders` method was erroring in `DefaultPublicShareTemplateProvider`. This is due to the fact that the `$share` object for circles share does not contain a token, so the computation of the `$shareUrl` was failing.

This commit ensures that the share has a token.

Regression introduced by https://github.com/nextcloud/server/pull/45652