### PR TITLE
fix(sharing): Handle share notes

### DIFF
--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -151,6 +151,7 @@ class CoreRequestBuilder {
 			'file_target',
 			'permissions',
 			'attributes',
+			'note',
 			'stime',
 			'accepted',
 			'expiration',

--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -84,6 +84,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 			->set('uid_initiator', $qb->createNamedParameter($shareWrapper->getSharedBy()))
 			->set('accepted', $qb->createNamedParameter(IShare::STATUS_ACCEPTED))
 			->set('permissions', $qb->createNamedParameter($shareWrapper->getPermissions()))
+			->set('note', $qb->createNamedParameter($shareWrapper->getShareNote()))
 			->set('expiration', $qb->createNamedParameter($shareWrapper->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 			->set('attributes', $qb->createNamedParameter($shareAttributes));
 

--- a/lib/Model/ShareWrapper.php
+++ b/lib/Model/ShareWrapper.php
@@ -52,6 +52,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 	private int $status = 0;
 	private string $providerId = '';
 	private DateTime $shareTime;
+	private string $note = '';
 	private string $sharedWith = '';
 	private string $sharedBy = '';
 	private ?DateTime $expirationDate = null;
@@ -181,6 +182,16 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 
 	public function getShareTime(): DateTime {
 		return $this->shareTime;
+	}
+
+	public function setShareNote(string $note): self {
+		$this->note = $note;
+
+		return $this;
+	}
+
+	public function getShareNote(): string {
+		return $this->note;
 	}
 
 	public function setSharedWith(string $sharedWith): self {
@@ -383,6 +394,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 		$share->setToken($this->getToken());
 		$share->setHideDownload($this->getHideDownload());
 		$share->setAttributes($this->getAttributes());
+		$share->setNote($this->getShareNote());
 		if ($this->hasShareToken()) {
 			$password = $this->getShareToken()->getPassword();
 			if ($password !== '') {
@@ -477,7 +489,8 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			->setSharedBy($this->get('sharedBy', $data))
 			->setShareOwner($this->get('shareOwner', $data))
 			->setToken($this->get('token', $data))
-			->setShareTime($shareTime);
+			->setShareTime($shareTime)
+			->setShareNote($this->get('note', $data));
 
 		$this->importAttributesFromDatabase($this->get('attributes', $data));
 
@@ -541,7 +554,8 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			->setSharedBy($this->get($prefix . 'uid_initiator', $data))
 			->setShareOwner($this->get($prefix . 'uid_owner', $data))
 			->setToken($this->get($prefix . 'token', $data))
-			->setShareTime($shareTime);
+			->setShareTime($shareTime)
+			->setShareNote($this->get($prefix . 'note', $data));
 
 		$this->importAttributesFromDatabase($this->get('attributes', $data));
 
@@ -602,6 +616,7 @@ class ShareWrapper extends ManagedModel implements IDeserializable, IQueryRow, J
 			'fileTarget' => $this->getFileTarget(),
 			'status' => $this->getStatus(),
 			'shareTime' => $this->getShareTime()->getTimestamp(),
+			'note' => $this->getShareNote(),
 			'sharedWith' => $this->getSharedWith(),
 			'sharedBy' => $this->getSharedBy(),
 			'shareOwner' => $this->getShareOwner(),

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -208,7 +208,8 @@ class ShareByCircleProvider implements IShareProvider {
 			->setShareOwner($share->getShareOwner())
 			->setAttributes($share->getAttributes())
 			->setSharedBy($share->getSharedBy())
-			->setExpirationDate($share->getExpirationDate());
+			->setExpirationDate($share->getExpirationDate())
+			->setShareNote($share->getNote());
 
 		$this->shareWrapperService->update($wrappedShare);
 


### PR DESCRIPTION
This will first properly save the note in the DB, and then properly retrieve it.

Without it, we cannot display the share note to the user.

Before | After
-- | --
![Screenshot 2025-04-08 at 17-15-28 A - All files - Nextcloud](https://github.com/user-attachments/assets/6d14b6c0-db36-4c48-bc97-1acdbde391ca) | ![Screenshot 2025-04-08 at 17-15-00 A - All files - Nextcloud](https://github.com/user-attachments/assets/6878634e-1317-4b8a-b7d2-e596e643c8c6)
