### PR TITLE
switch to probeCircles

### DIFF
--- a/lib/Api/v1/Circles.php
+++ b/lib/Api/v1/Circles.php
@@ -131,7 +131,7 @@ class Circles {
 		$probe->includePersonalCircles($personalCircle);
 		$probe->filterHiddenCircles();
 
-		return $circleService->getCircles($probe);
+		return $circleService->probeCircles($probe);
 	}
 
 


### PR DESCRIPTION
no need for `joinedCircles()` to use `getCircles()`.

- `probeCircles()` ignore circles user is not a member of,
- `getCircles()` is heavier.
