### PR TITLE
fix(LocalController): Allow to still get full details of members

### DIFF
--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -459,15 +459,16 @@ class LocalController extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @param string $circleId
+	 * @param bool $fullDetails
 	 *
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function members(string $circleId): DataResponse {
+	public function members(string $circleId, bool $fullDetails = false): DataResponse {
 		try {
 			$this->setCurrentFederatedUser();
 
-			return new DataResponse($this->serializeArray($this->memberService->getMembers($circleId)));
+			return new DataResponse($this->serializeArray($this->memberService->getMembers($circleId, $fullDetails)));
 		} catch (Exception $e) {
 			$this->e($e, ['circleId' => $circleId]);
 			throw new OCSException($e->getMessage(), (int)$e->getCode());


### PR DESCRIPTION
PR #1969 broke members management in Collectives.

Collectives needs the initiator of a request to check if the current user is an (inherited) member of non-user members (like circles and groups).