### PR TITLE
fix: Get Sanitized Name

### DIFF
--- a/lib/Dashboard/TeamDashboardWidget.php
+++ b/lib/Dashboard/TeamDashboardWidget.php
@@ -66,7 +66,7 @@ class TeamDashboardWidget implements IAPIWidgetV2, IIconWidget, IButtonWidget, I
 					$circle->getDisplayName(),
 					'',
 					$this->urlGenerator->getAbsoluteURL($this->modelManager->generateLinkToCircle($circle->getSingleId())),
-					$this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('core.GuestAvatar.getAvatar', ['guestName' => $circle->getDisplayName(), 'size' => 64]))
+					$this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('core.GuestAvatar.getAvatar', ['guestName' => $circle->getSanitizedName(), 'size' => 64]))
 				);
 			}, $this->circleService->probeCircles($probe));
 		} catch (\Exception $e) {


### PR DESCRIPTION
Should fix:

```
{
  "reqId": "RS3Pk08HjqXEwfkm5UuX",
  "level": 3,
  "time": "2025-06-16T09:42:33+02:00",
  "remoteAddr": "95.182.159.42",
  "user": "WBED",
  "app": "circles",
  "method": "GET",
  "url": "/ocs/v2.php/apps/dashboard/api/v2/widget-items?widgets%5B%5D=circles",
  "message": "Parameter \"guestName\" for route \"core.guestavatar.getavatar\" must match \"[^/]++\" (\"Projet de Fusion ARC CSEM- OS/POs\" given) to generate a corresponding URL.",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
  "version": "30.0.12.2",
  "exception": {
    "Exception": "Symfony\\Component\\Routing\\Exception\\InvalidParameterException",
    "Message": "Parameter \"guestName\" for route \"core.guestavatar.getavatar\" must match \"[^/]++\" (\"Projet de Fusion ARC CSEM- OS/POs\" given) to generate a corresponding URL.",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/routing/Generator/UrlGenerator.php",
        "line": 151,
        "function": "doGenerate",
        "class": "Symfony\\Component\\Routing\\Generator\\UrlGenerator",
        "type": "->",
        "args": [
          {
            "guestName": 0,
            "size": 1
          },
          {
            "caller": [
              "core",
              "GuestAvatarController",
              "getAvatar"
            ],
            "action": null
          },
          [],
          [
            [
              "variable",
              "/",
              "[^/]++",
              "size"
            ],
            [
              "variable",
              "/",
              "[^/]++",
              "guestName"
            ],
            [
              "text",
              "/avatar/guest"
            ]
          ],
          {
            "size": 64,
            "guestName": "Projet de Fusion ARC CSEM- OS/POs"
          },
          "core.guestavatar.getavatar",
          1,
          [],
          []
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 367,
        "function": "generate",
        "class": "Symfony\\Component\\Routing\\Generator\\UrlGenerator",
        "type": "->",
        "args": [
          "core.guestavatar.getavatar",
          {
            "size": 64,
            "guestName": "Projet de Fusion ARC CSEM- OS/POs"
          },
          1
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/CachingRouter.php",
        "line": 50,
        "function": "generate",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "core.guestavatar.getavatar",
          {
            "size": 64,
            "guestName": "Projet de Fusion ARC CSEM- OS/POs"
          },
          false
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/URLGenerator.php",
        "line": 71,
        "function": "generate",
        "class": "OC\\Route\\CachingRouter",
        "type": "->",
        "args": [
          "core.GuestAvatar.getAvatar",
          {
            "size": 64,
            "guestName": "Projet de Fusion ARC CSEM- OS/POs"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/circles/lib/Dashboard/TeamDashboardWidget.php",
        "line": 68,
        "function": "linkToRoute",
        "class": "OC\\URLGenerator",
        "type": "->",
        "args": [
          "core.GuestAvatar.getAvatar",
          {
            "guestName": "Projet de Fusion ARC CSEM- OS/POs",
            "size": 64
          }
        ]
      },
      {
        "function": "OCA\\Circles\\Dashboard\\{closure}",
        "class": "OCA\\Circles\\Dashboard\\TeamDashboardWidget",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/circles/lib/Dashboard/TeamDashboardWidget.php",
        "line": 63,
        "function": "array_map",
        "args": [
          {
            "__class__": "Closure"
          },
          [
            "*** sensitive parameters replaced ***",
            "*** sensitive parameters replaced ***",
            "*** sensitive parameters replaced ***",
            "*** sensitive parameters replaced ***"
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dashboard/lib/Controller/DashboardApiController.php",
        "line": 119,
        "function": "getItemsV2",
        "class": "OCA\\Circles\\Dashboard\\TeamDashboardWidget",
        "type": "->",
        "args": [
          "WBED",
          null,
          7
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 208,
        "function": "getWidgetItemsV2",
        "class": "OCA\\Dashboard\\Controller\\DashboardApiController",
        "type": "->",
        "args": [
          [],
          7,
          {
            "circles": {
              "__class__": "OCA\\Circles\\Dashboard\\TeamDashboardWidget"
            }
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 114,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Dashboard\\Controller\\DashboardApiController"
          },
          "getWidgetItemsV2"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Dashboard\\Controller\\DashboardApiController"
          },
          "getWidgetItemsV2"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Route/Router.php",
        "line": 303,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Dashboard\\Controller\\DashboardApiController",
          "getWidgetItemsV2",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "_route": "ocs.dashboard.dashboardapi.getwidgetitemsv2"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/ocs/v1.php",
        "line": 44,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/ocsapp/apps/dashboard/api/v2/widget-items"
        ]
      },
      {
        "file": "/var/www/nextcloud/ocs/v2.php",
        "line": 8,
        "args": [
          "/var/www/nextcloud/ocs/v1.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/nextcloud/3rdparty/symfony/routing/Generator/UrlGenerator.php",
    "Line": 182,
    "message": "Parameter \"guestName\" for route \"core.guestavatar.getavatar\" must match \"[^/]++\" (\"Projet de Fusion ARC CSEM- OS/POs\" given) to generate a corresponding URL.",
    "exception": [],
    "CustomMessage": "Parameter \"guestName\" for route \"core.guestavatar.getavatar\" must match \"[^/]++\" (\"Projet de Fusion ARC CSEM- OS/POs\" given) to generate a corresponding URL."
  },
  "id": "68511fe652562"
}
```