### PR TITLE
ignore eventual duplicate entries

### DIFF
--- a/lib/Db/EventWrapperRequest.php
+++ b/lib/Db/EventWrapperRequest.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace OCA\Circles\Db;
 
 use OCA\Circles\Model\Federated\EventWrapper;
+use OCP\DB\Exception;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class EventWrapperRequest
@@ -38,7 +40,12 @@ class EventWrapperRequest extends EventWrapperRequestBuilder {
 			->setValue('status', $qb->createNamedParameter($wrapper->getStatus()))
 			->setValue('creation', $qb->createNamedParameter($wrapper->getCreation()));
 
-		$qb->execute();
+		try {
+			$qb->execute();
+		} catch (Exception $e) {
+			$logger = \OCP\Server::get(LoggerInterface::class);
+			$logger->warning('issue while storing event', ['exception' => $e]);
+		}
 	}
 
 	/**


### PR DESCRIPTION
On miss-configured federated teams  It can happens that same entry is generated twice. Not an issue to ignore it but we keep a trace in logs.