### PR TITLE
feat: add option to fix display names for LDAP users

### DIFF
--- a/lib/Command/CirclesMaintenance.php
+++ b/lib/Command/CirclesMaintenance.php
@@ -15,7 +15,10 @@ use OCA\Circles\Exceptions\MaintenanceException;
 use OCA\Circles\Service\FederatedUserService;
 use OCA\Circles\Service\MaintenanceService;
 use OCA\Circles\Service\OutputService;
+use OCA\User_LDAP\Mapping\UserMapping;
+use OCP\App\IAppManager;
 use OCP\IDBConnection;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -37,6 +40,7 @@ class CirclesMaintenance extends Base {
 		private OutputService $outputService,
 		private IDBConnection $dbConnection,
 		private LoggerInterface $logger,
+		private IAppManager $appManager,
 	) {
 		parent::__construct();
 	}
@@ -48,6 +52,8 @@ class CirclesMaintenance extends Base {
 			->setDescription('Clean stuff, keeps the app running')
 			->addOption('refresh-display-name', '', InputOption::VALUE_REQUIRED, 'refresh single user display name', '')
 			->addOption('fix-saml-users-display-name', '', InputOption::VALUE_NONE, 'retrieve users from the db table \'user_saml_users\' to fix their display-name')
+			->addOption('fix-ldap-users-display-name', '',
+				InputOption::VALUE_NONE, 'retrieve users from the db table \'user_ldap_users\' to fix their display-name')
 			->addOption('level', '', InputOption::VALUE_REQUIRED, 'level of maintenance', '3')
 			->addOption(
 				'reset', '', InputOption::VALUE_NONE, 'reset Circles; remove all data related to the App'
@@ -75,6 +81,15 @@ class CirclesMaintenance extends Base {
 
 		if ($input->getOption('fix-saml-users-display-name')) {
 			$this->fixSamlDisplayName($output);
+			return 0;
+		}
+
+		if ($input->getOption('fix-ldap-users-display-name')) {
+			if (!$this->appManager->isEnabledForAnyone('user_ldap')) {
+				$output->writeln('The "user_ldap" app is not enabled');
+				return 1;
+			}
+			$this->fixLdapUsersDisplayName($output);
 			return 0;
 		}
 
@@ -174,6 +189,19 @@ class CirclesMaintenance extends Base {
 				$this->refreshSingleDisplayName($row['uid'], $output);
 			} catch (Exception $e) {
 				$output->writeln(get_class($e) . ' while trying to update display name of ' . $row['uid']);
+			}
+		}
+	}
+
+	public function fixLdapUsersDisplayName(OutputInterface $output): void {
+		$ldapUserMapping = Server::get(UserMapping::class);
+		/** @var array<int, array{dn: string, name: string, uuid: string}> $list */
+		$list = $ldapUserMapping->getList();
+		foreach ($list as $user) {
+			try {
+				$this->refreshSingleDisplayName($user['name'], $output);
+			} catch (Exception $e) {
+				$output->writeln(get_class($e) . ' while trying to update display name of ' . $user['name']);
 			}
 		}
 	}


### PR DESCRIPTION
In some cases users which have an LDAP backend on an instance may be displayed on teams with their UUID instead of their display names. Like in the [case for the SAML backend](https://github.com/nextcloud/circles/pull/1584/files), we need a fix command for users with an LDAP backend.