### PR TITLE
fix(federated-teams): ignore duplicate instance and generate logs

### DIFF
--- a/lib/Db/EventWrapperRequest.php
+++ b/lib/Db/EventWrapperRequest.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Db;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OCA\Circles\Model\Federated\EventWrapper;
-use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -42,7 +42,7 @@ class EventWrapperRequest extends EventWrapperRequestBuilder {
 
 		try {
 			$qb->execute();
-		} catch (Exception $e) {
+		} catch (UniqueConstraintViolationException $e) {
 			$logger = \OCP\Server::get(LoggerInterface::class);
 			$logger->warning('issue while storing event', ['exception' => $e]);
 		}

--- a/lib/Service/FederatedEventService.php
+++ b/lib/Service/FederatedEventService.php
@@ -395,9 +395,11 @@ class FederatedEventService extends NCSignature {
 		$wrapper->setCreation(time());
 		$wrapper->setSeverity($event->getSeverity());
 
+		$avoidDuplicate = [];
 		if ($event->isAsync()) {
 			$wrapper->setInstance($this->configService->getLoopbackInstance());
 			$this->eventWrapperRequest->save($wrapper);
+			$avoidDuplicate[] = $this->configService->getLoopbackInstance();
 		}
 
 		foreach ($instances as $instance) {
@@ -405,9 +407,15 @@ class FederatedEventService extends NCSignature {
 				break;
 			}
 
+			if (in_array($instance->getInstance(), $avoidDuplicate, true)) {
+				Server::get(\Psr\Log\LoggerInterface::class)->warning('duplicate instance, please verify the setup of Federated Teams', ['duplicate' => $avoidDuplicate, 'loopback' => $this->configService->getLoopbackInstance(), 'instance' => $instance->getInstance(), 'interface' => $instance->getInterface()]);
+				continue;
+			}
+
 			$wrapper->setInstance($instance->getInstance());
 			$wrapper->setInterface($instance->getInterface());
 			$this->eventWrapperRequest->save($wrapper);
+			$avoidDuplicate[] = $wrapper->getInstance();
 		}
 
 		$request = new NCRequest('', Request::TYPE_POST);


### PR DESCRIPTION
- There is no reason for a duplicate instance, unless faulty configuration of federated teams.
- The generated logs should help fixing it
- catch duplicate exception only