### PR TITLE
fix(dashboard): enable rounded item icons

### DIFF
--- a/lib/Dashboard/TeamDashboardWidget.php
+++ b/lib/Dashboard/TeamDashboardWidget.php
@@ -19,15 +19,17 @@ use OCP\Dashboard\IAPIWidgetV2;
 use OCP\Dashboard\IButtonWidget;
 use OCP\Dashboard\IConditionalWidget;
 use OCP\Dashboard\IIconWidget;
+use OCP\Dashboard\IOptionWidget;
 use OCP\Dashboard\Model\WidgetButton;
 use OCP\Dashboard\Model\WidgetItem;
 use OCP\Dashboard\Model\WidgetItems;
+use OCP\Dashboard\Model\WidgetOptions;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
-class TeamDashboardWidget implements IAPIWidgetV2, IIconWidget, IButtonWidget, IConditionalWidget {
+class TeamDashboardWidget implements IAPIWidgetV2, IIconWidget, IButtonWidget, IConditionalWidget, IOptionWidget {
 	public function __construct(
 		private IURLGenerator $urlGenerator,
 		private IL10N $l10n,
@@ -144,5 +146,11 @@ class TeamDashboardWidget implements IAPIWidgetV2, IIconWidget, IButtonWidget, I
 	public function isEnabled(): bool {
 		return $this->appManager->isEnabledForUser('contacts') &&
 			$this->configService->getAppValueBool(ConfigService::FRONTEND_ENABLED);
+	}
+
+	public function getWidgetOptions(): WidgetOptions {
+		return new WidgetOptions(
+			roundItemIcons: true,
+		);
 	}
 }


### PR DESCRIPTION
Similar to https://github.com/nextcloud/activity/pull/2097

| Before | After |
| --- | --- |
| <img width="263" height="704" alt="Bildschirmfoto vom 2025-08-13 10-25-22" src="https://github.com/user-attachments/assets/6585e23b-1ed3-4d75-a939-58becb19f26e" /> | <img width="267" height="734" alt="Bildschirmfoto vom 2025-08-13 10-25-08" src="https://github.com/user-attachments/assets/b0633f0c-c122-4a7a-939a-7df908ef17ea" /> |
