### PR TITLE
fix(shareprovider): fill details on getChildren()

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -244,6 +244,15 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		return $this->getItemFromRequest($qb);
 	}
 
+	/**
+	 * @return ShareWrapper[]
+	 */
+	public function getChildren(int $shareId): array {
+		$qb = $this->getShareSelectSql();
+		$qb->limitToShareParent($shareId);
+
+		return $this->getItemsFromRequest($qb);
+	}
 
 	/**
 	 * @param int $fileId

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -292,6 +292,12 @@ class ShareWrapperService {
 		return $this->createChild($share, $federatedUser);
 	}
 
+	/**
+	 * @return ShareWrapper[]
+	 */
+	public function getChildren(IShare $parent): array {
+		return $this->shareWrapperRequest->getChildren((int)$parent->getId());
+	}
 
 	public function clearCache(string $singleId): void {
 		$this->cache->clear($singleId);

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -757,19 +757,15 @@ class ShareByCircleProvider implements IShareProvider {
 		return $result;
 	}
 
-	/**
-	 * We don't return a thing about children.
-	 * The call to this function is deprecated and should be removed in next release of NC.
-	 * Also, we get the children in the delete() method.
-	 *
-	 * @param IShare $parent
-	 *
-	 * @return array
-	 */
 	public function getChildren(IShare $parent): array {
-		return [];
+		return array_filter(
+			array_map(
+				function (ShareWrapper $wrapper) {
+					return $wrapper->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
+				}, $this->shareWrapperService->getChildren($parent)
+			)
+		);
 	}
-
 
 	/**
 	 * @return iterable


### PR DESCRIPTION
while not needed today, now provide the correct result for `getChildren()`