### PR TITLE
feat: add search and limit support for team members list

### DIFF
--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -460,15 +460,17 @@ class LocalController extends OCSController {
 	 *
 	 * @param string $circleId
 	 * @param bool $fullDetails
+	 * @param int $limit
+	 * @param string $search
 	 *
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function members(string $circleId, bool $fullDetails = false): DataResponse {
+	public function members(string $circleId, bool $fullDetails = false, int $limit = 0, string $search = ''): DataResponse {
 		try {
 			$this->setCurrentFederatedUser();
 
-			return new DataResponse($this->serializeArray($this->memberService->getMembers($circleId, $fullDetails)));
+			return new DataResponse($this->serializeArray($this->memberService->getMembers($circleId, $fullDetails, $limit, $search)));
 		} catch (Exception $e) {
 			$this->e($e, ['circleId' => $circleId]);
 			throw new OCSException($e->getMessage(), (int)$e->getCode());

--- a/lib/Db/MemberRequest.php
+++ b/lib/Db/MemberRequest.php
@@ -190,6 +190,9 @@ class MemberRequest extends MemberRequestBuilder {
 	 * @param string $singleId
 	 * @param IFederatedUser|null $initiator
 	 * @param MemberProbe|null $probe
+	 * @param int $limit
+	 * @param bool $fullDetails
+	 * @param string $search
 	 *
 	 * @return Member[]
 	 * @throws RequestBuilderException
@@ -200,6 +203,7 @@ class MemberRequest extends MemberRequestBuilder {
 		?MemberProbe $probe = null,
 		int $limit = 0,
 		bool $fullDetails = false,
+		string $search = '',
 	): array {
 		if (is_null($probe)) {
 			$probe = new MemberProbe();
@@ -207,6 +211,11 @@ class MemberRequest extends MemberRequestBuilder {
 
 		$qb = $this->getMemberSelectSql($initiator);
 		$qb->limitToCircleId($singleId);
+
+		if (!empty($search)) {
+			$qb->searchInDBField('user_id', '%' . $search . '%');
+		}
+
 		if ($limit > 0) {
 			$qb->chunk(0, $limit);
 		}

--- a/lib/Service/MemberService.php
+++ b/lib/Service/MemberService.php
@@ -146,12 +146,15 @@ class MemberService {
 
 	/**
 	 * @param string $circleId
+	 * @param bool $fullDetails
+	 * @param int $limit
+	 * @param string $search
 	 *
 	 * @return Member[]
 	 * @throws InitiatorNotFoundException
 	 * @throws RequestBuilderException
 	 */
-	public function getMembers(string $circleId, bool $fullDetails = false): array {
+	public function getMembers(string $circleId, bool $fullDetails = false, int $limit = 0, string $search = ''): array {
 		$this->federatedUserService->mustHaveCurrentUser();
 
 		$probe = new MemberProbe();
@@ -165,7 +168,9 @@ class MemberService {
 			$circleId,
 			$this->federatedUserService->getCurrentUser(),
 			$probe,
-			fullDetails: $fullDetails
+			$limit,
+			$fullDetails,
+			$search
 		);
 	}
 


### PR DESCRIPTION
This will enable us to optimize the retrieval of participant lists for large teams in the Contacts and Collectives apps.

This PR extends the API. Therefore, please backport it to 32, 31 so that it can be used for other modules that still support version 32, 31.