### PR TITLE
improve action on multi-teams 

### DIFF
--- a/lib/CirclesManager.php
+++ b/lib/CirclesManager.php
@@ -344,6 +344,24 @@ class CirclesManager {
 		return $this->circleService->getCircle($singleId, $probe);
 	}
 
+	/**
+	 * better than using getCircle() if only interested in teams current user is member of
+	 *
+	 * @since 33.0.0
+	 */
+	public function probeCircle(string $singleId, ?CircleProbe $probe = null, ?DataProbe $dataProbe = null): Circle {
+		return $this->circleService->probeCircle($singleId, $probe, $dataProbe);
+	}
+
+	/**
+	 * get details from a list of circles the current user is a member of
+	 *
+	 * @since 33.0.0
+	 */
+	public function getCirclesByIds(array $ids, ?DataProbe $dataProbe = null): array {
+		return $this->circleService->probeCirclesByIds($ids, $dataProbe);
+	}
+
 
 	/**
 	 * @param Circle $circle

--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -236,6 +236,36 @@ class CircleRequest extends CircleRequestBuilder {
 	}
 
 	/**
+	 * returns details about circles using a list of ids.
+	 * initiator permissions are respected
+	 */
+	public function probeCirclesByIds(
+		IFederatedUser $initiator,
+		array $ids,
+		DataProbe $dataProbe,
+	): array {
+		$qb = $this->getCircleSelectSql();
+		if (!$dataProbe->has(DataProbe::MEMBERSHIPS)) {
+			$dataProbe->add(DataProbe::MEMBERSHIPS);
+		}
+
+		$qb->setSqlPath(CoreQueryBuilder::CIRCLE, $dataProbe->getPath());
+		$qb->leftJoinOwner(CoreQueryBuilder::CIRCLE);
+		$qb->innerJoinMembership(null, CoreQueryBuilder::CIRCLE);
+
+		$aliasMembership = $qb->generateAlias(CoreQueryBuilder::CIRCLE, CoreQueryBuilder::MEMBERSHIPS);
+		$limit = $qb->exprLimit('single_id', $initiator->getSingleId(), $aliasMembership);
+		$qb->completeProbeWithInitiator(CoreQueryBuilder::CIRCLE, 'single_id', $aliasMembership);
+		$qb->andWhere(
+			$limit,
+			$qb->expr()->in(CoreQueryBuilder::CIRCLE . '.unique_id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_STR_ARRAY))
+		);
+		$qb->resetSqlPath();
+
+		return $this->getItemsFromRequest($qb);
+	}
+
+	/**
 	 * @param IFederatedUser|null $initiator
 	 * @param CircleProbe $circleProbe
 	 * @param DataProbe $dataProbe

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -843,7 +843,7 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param string $field
 	 */
 	public function innerJoinMembership(
-		CircleProbe $probe,
+		?CircleProbe $probe,
 		string $alias,
 		string $field = 'unique_id',
 	): void {
@@ -862,7 +862,7 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		$on = $expr->andX($expr->eq($aliasMembership . '.circle_id', $alias . '.' . $field));
 
 		// limit on membership level if requested
-		$minLevel = $probe->getMinimumLevel();
+		$minLevel = $probe?->getMinimumLevel() ?? 0;
 		if ($minLevel > Member::LEVEL_MEMBER) {
 			$on->add($this->exprGt('level', $minLevel, true, $aliasMembership));
 		}

--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -182,6 +182,24 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 
 
 	/**
+	 * @param string $circleId
+	 * @param FederatedUser|null $shareRecipient
+	 * @param FederatedUser|null $shareInitiator
+	 * @param bool $completeDetails
+	 *
+	 * @return ShareWrapper[]
+	 * @throws RequestBuilderException
+	 */
+	public function getSharesToCircles(array $circleIds): array {
+		$qb = $this->getShareSelectSql();
+		$qb->limitNull('parent', false);
+		$qb->expr()->in('share_with', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY));
+		return $this->getItemsFromRequest($qb);
+	}
+
+
+
+	/**
 	 * @param int $shareId
 	 * @param FederatedUser|null $federatedUser
 	 *

--- a/lib/FileSharingTeamResourceProvider.php
+++ b/lib/FileSharingTeamResourceProvider.php
@@ -43,6 +43,35 @@ class FileSharingTeamResourceProvider implements ITeamResourceProvider {
 		}
 
 		$shares = $this->shareByCircleProvider->getSharesToCircle($teamId);
+		return $this->convertWrappedShareToResource($shares);
+	}
+
+	/**
+	 * @return array<string, TeamResource[]>
+	 */
+	public function getSharedWithList(array $teams): array {
+		$data = $shares = [];
+		foreach ($this->shareByCircleProvider->getSharesToCircles($teams) as $share) {
+			if (!array_key_exists($share->getId(), $shares)) {
+				$shares[$share->getSharedWith()] = [];
+			}
+			$shares[$share->getSharedWith()][] = $share;
+		}
+
+		foreach ($teams as $teamId) {
+			$data[$teamId] = $this->convertWrappedShareToResource($shares[$teamId]);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * convert list of ShareWrapper to TeamResource
+	 *
+	 * @param ShareWrapper[] $shares
+	 * @return TeamResource[]
+	 */
+	private function convertWrappedShareToResource(array $shares): array {
 		usort($shares, function ($a, $b) {
 			return (int)($b->getItemType() === 'folder') - (int)($a->getItemType() === 'folder');
 		});

--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -811,4 +811,19 @@ class CircleService {
 			$dataProbe
 		);
 	}
+
+	/**
+	 * @return Circle[]
+	 */
+	public function probeCirclesByIds(array $ids, ?DataProbe $dataProbe = null): array {
+		if (empty($ids)) {
+			return [];
+		}
+		$this->federatedUserService->mustHaveCurrentUser();
+		return $this->circleRequest->probeCirclesByIds(
+			$this->federatedUserService->getCurrentUser(),
+			$ids,
+			$dataProbe ?? new DataProbe()
+		);
+	}
 }

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -152,6 +152,13 @@ class ShareWrapperService {
 		);
 	}
 
+	/**
+	 * @return ShareWrapper[]
+	 */
+	public function getSharesToCircles(array $circleIds): array {
+		return $this->shareWrapperRequest->getSharesToCircles($circleIds);
+	}
+
 
 	/**
 	 * @param int $shareId


### PR DESCRIPTION

- (CirclesManager) add `probeCircle()` as a lighter alternative to `getCircle()`,
- (CirclesManager) add `getCirclesByIds()` that returns details about multiple teams,
- (ITeamResourceProvider) adding `getSharedWithList()` that returns all shares from a list of team ids,
