### PR TITLE
ignore non-circles share while extracting permissions

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -637,6 +637,10 @@ class ShareByCircleProvider implements IShareProvider {
 
 		$shareIds = $knownIds = $users = $remote = $mails = [];
 		foreach ($this->shareWrapperService->getSharesByFileIds($ids, true, true) as $share) {
+			if (!$share->hasCircle()) {
+				continue;
+			}
+
 			$shareIds[] = $share->getId();
 			$circle = $share->getCircle();
 			foreach ($circle->getInheritedMembers() as $member) {


### PR DESCRIPTION
https://github.com/nextcloud/circles/pull/1708 wasn't merged into master branch, so not available above 30.

Closes at least #2077 (maybe others)