### PR TITLE
refactor(QueryBuilder): Migrate away from deprecated execute method

### DIFF
--- a/lib/Command/CirclesTest.php
+++ b/lib/Command/CirclesTest.php
@@ -286,7 +286,7 @@ class CirclesTest extends Base {
 		//		$circlesQueryHelper->addCircleDetails('test', 'shared_to');
 		//
 		//		$items = [];
-		//		$cursor = $qb->execute();
+		//		$cursor = $qb->executeQuery();
 		//		while ($row = $cursor->fetch()) {
 		//			try {
 		//				$items[] = [

--- a/lib/Command/MigrateCustomGroups.php
+++ b/lib/Command/MigrateCustomGroups.php
@@ -231,7 +231,7 @@ class MigrateCustomGroups extends Base {
 			->where($select->expr()->eq('share_type', $select->createNamedParameter(IShare::TYPE_GROUP)));
 
 		$shareIds = [];
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		while ($row = $result->fetch()) {
 			$with = $row['share_with'];
 			if (!str_starts_with($with, 'customgroup_')

--- a/lib/Db/AccountsRequest.php
+++ b/lib/Db/AccountsRequest.php
@@ -21,7 +21,7 @@ class AccountsRequest extends AccountsRequestBuilder {
 
 		$this->limitToDBField($qb, 'uid', $userId);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -46,7 +46,7 @@ class AccountsRequest extends AccountsRequestBuilder {
 
 		$this->limitToDBField($qb, 'uid', $userId);
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -66,7 +66,7 @@ class AccountsRequest extends AccountsRequestBuilder {
 		$qb = $this->getAccountsSelectSql();
 
 		$accounts = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			$account = $this->parseAccountsSelectSql($data);
 			$accounts[$account['userId']] = $account;

--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -51,7 +51,7 @@ class CircleRequest extends CircleRequestBuilder {
 			->setValue('settings', $qb->createNamedParameter(json_encode($circle->getSettings())))
 			->setValue('config', $qb->createNamedParameter($circle->getConfig()));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -67,7 +67,7 @@ class CircleRequest extends CircleRequestBuilder {
 
 		$qb->limitToUniqueId($circle->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -83,7 +83,7 @@ class CircleRequest extends CircleRequestBuilder {
 
 		$qb->limitToUniqueId($circle->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -112,7 +112,7 @@ class CircleRequest extends CircleRequestBuilder {
 
 		$qb->limitToUniqueId($singleId);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -125,7 +125,7 @@ class CircleRequest extends CircleRequestBuilder {
 
 		$qb->limitToUniqueId($circle->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -137,7 +137,7 @@ class CircleRequest extends CircleRequestBuilder {
 		$qb->set('settings', $qb->createNamedParameter(json_encode($circle->getSettings())));
 		$qb->limitToUniqueId($circle->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -513,7 +513,7 @@ class CircleRequest extends CircleRequestBuilder {
 		$qb = $this->getCircleDeleteSql();
 		$qb->limitToUniqueId($circle->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -524,6 +524,6 @@ class CircleRequest extends CircleRequestBuilder {
 		$qb = $this->getCircleDeleteSql();
 		$qb->limitToUniqueId($federatedUser->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -244,7 +244,7 @@ class CoreRequestBuilder {
 			$qb = $this->getQueryBuilder();
 			try {
 				$qb->delete($table);
-				$qb->execute();
+				$qb->executeStatement();
 			} catch (Exception $e) {
 			}
 		}
@@ -254,7 +254,7 @@ class CoreRequestBuilder {
 			$expr = $qb->expr();
 			$qb->delete(self::TABLE_SHARE);
 			$qb->where($expr->eq('share_type', $qb->createNamedParameter(IShare::TYPE_CIRCLE)));
-			$qb->execute();
+			$qb->executeStatement();
 		}
 	}
 
@@ -292,7 +292,7 @@ class CoreRequestBuilder {
 		$qb->limit('app', 'circles');
 		$qb->unlike('version', '001%');
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -302,6 +302,6 @@ class CoreRequestBuilder {
 		$qb = $this->getQueryBuilder();
 		//		$qb->delete('jobs');
 		//		$qb->where($this->exprLimitToDBField($qb, 'class', 'OCA\Circles\', true, true));
-		//		$qb->execute();
+		//		$qb->executeStatement();
 	}
 }

--- a/lib/Db/FileSharesRequest.php
+++ b/lib/Db/FileSharesRequest.php
@@ -32,7 +32,7 @@ class FileSharesRequest extends FileSharesRequestBuilder {
 			$expr->eq('uid_initiator', $qb->createNamedParameter($member->getUserId())),
 		));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -48,7 +48,7 @@ class FileSharesRequest extends FileSharesRequestBuilder {
 			$expr->eq('share_with', $qb->createNamedParameter($circleId)),
 		));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -64,7 +64,7 @@ class FileSharesRequest extends FileSharesRequestBuilder {
 		$this->limitToShareType($qb, self::SHARE_TYPE);
 
 		$shares = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			$shares[] = $data;
 		}
@@ -86,7 +86,7 @@ class FileSharesRequest extends FileSharesRequestBuilder {
 		$qb->andWhere($expr->isNull($this->default_select_alias . '.parent'));
 
 		$shares = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			$shares[] = $data;
 		}

--- a/lib/Db/GSSharesRequest.php
+++ b/lib/Db/GSSharesRequest.php
@@ -38,7 +38,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 			->setValue('parent', $qb->createNamedParameter($gsShare->getParent()))
 			->setValue('mountpoint', $qb->createNamedParameter($gsShare->getMountPoint()))
 			->setValue('mountpoint_hash', $qb->createNamedParameter($hash));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -54,7 +54,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 		$this->leftJoinMountPoint($qb, $userId);
 
 		$shares = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			$shares[] = $this->parseGSSharesSelectSql($data);
 		}
@@ -73,7 +73,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 		$this->limitToInstance($qb, $member->getInstance());
 		$this->limitToOwner($qb, $member->getUserId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -126,7 +126,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 		$this->limitToMountpointHash($qb, $targetHash);
 
 		$shares = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 
 		if ($data === false) {
@@ -151,7 +151,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 		$this->limitToUserId($qb, $userId);
 
 		$shares = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetch();
 		if ($data === false) {
 			throw new ShareNotFound();
@@ -173,7 +173,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 			->setValue('share_id', $qb->createNamedParameter($mountpoint->getShareId()))
 			->setValue('mountpoint', $qb->createNamedParameter($mountpoint->getMountPoint()))
 			->setValue('mountpoint_hash', $qb->createNamedParameter($hash));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -192,7 +192,7 @@ class GSSharesRequest extends GSSharesRequestBuilder {
 
 		$this->limitToShareId($qb, $mountpoint->getShareId());
 		$this->limitToUserId($qb, $mountpoint->getUserId());
-		$nb = $qb->execute();
+		$nb = $qb->executeStatement();
 
 		return ($nb === 1);
 	}

--- a/lib/Db/MemberRequest.php
+++ b/lib/Db/MemberRequest.php
@@ -53,7 +53,7 @@ class MemberRequest extends MemberRequestBuilder {
 			$qb->setValue('invited_by', $qb->createNamedParameter($member->getInvitedBy()->getSingleId()));
 		}
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -77,7 +77,7 @@ class MemberRequest extends MemberRequestBuilder {
 		$qb->limitToCircleId($member->getCircleId());
 		$qb->limitToSingleId($member->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -112,7 +112,7 @@ class MemberRequest extends MemberRequestBuilder {
 			$qb->limitToCircleId($circleId);
 		}
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -124,7 +124,7 @@ class MemberRequest extends MemberRequestBuilder {
 		$qb->limitToCircleId($member->getCircleId());
 		$qb->limitToSingleId($member->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -137,7 +137,7 @@ class MemberRequest extends MemberRequestBuilder {
 		$qb->limitToMemberId($federatedUser->getSingleId());
 		$qb->limitToCircleId($federatedUser->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -150,7 +150,7 @@ class MemberRequest extends MemberRequestBuilder {
 		$qb->limitToSingleId($federatedUser->getSingleId());
 		$qb->limitToCircleId($circle->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -167,7 +167,7 @@ class MemberRequest extends MemberRequestBuilder {
 			)
 		);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -182,7 +182,7 @@ class MemberRequest extends MemberRequestBuilder {
 		$qb->limitToCircleId($member->getCircleId());
 		$qb->limitToSingleId($member->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 

--- a/lib/Db/MembershipRequest.php
+++ b/lib/Db/MembershipRequest.php
@@ -38,7 +38,7 @@ class MembershipRequest extends MembershipRequestBuilder {
 		);
 		$qb->setValue('inheritance_depth', $qb->createNamedParameter($membership->getInheritanceDepth()));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -59,7 +59,7 @@ class MembershipRequest extends MembershipRequestBuilder {
 		$qb->limitToSingleId($membership->getSingleId());
 		$qb->limitToCircleId($membership->getCircleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -127,7 +127,7 @@ class MembershipRequest extends MembershipRequestBuilder {
 			$qb->limitToSingleId($singleId);
 		}
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -139,7 +139,7 @@ class MembershipRequest extends MembershipRequestBuilder {
 		$qb->limitToSingleId($membership->getSingleId());
 		$qb->limitToCircleId($membership->getCircleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -150,6 +150,6 @@ class MembershipRequest extends MembershipRequestBuilder {
 		$qb = $this->getMembershipDeleteSql();
 		$qb->limitToSingleId($federatedUser->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -41,7 +41,7 @@ class MountRequest extends MountRequestBuilder {
 			->setValue('remote', $qb->createNamedParameter($mount->getRemote()))
 			->setValue('remote_id', $qb->createNamedParameter($mount->getRemoteShareId(), IQueryBuilder::PARAM_INT));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -52,7 +52,7 @@ class MountRequest extends MountRequestBuilder {
 		$qb = $this->getMountDeleteSql();
 		$qb->limitToToken($token);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -101,7 +101,7 @@ class MountRequest extends MountRequestBuilder {
 		//		$this->leftJoinMountPoint($qb, $userId);
 
 		//		$shares = [];
-		//		$cursor = $qb->execute();
+		//		$cursor = $qb->executeQuery();
 		//		while ($data = $cursor->fetch()) {
 		//			$shares[] = $this->parseGSSharesSelectSql($data);
 		//		}
@@ -122,7 +122,7 @@ class MountRequest extends MountRequestBuilder {
 	//		$this->leftJoinMountPoint($qb, $userId);
 	//
 	//		$shares = [];
-	//		$cursor = $qb->execute();
+	//		$cursor = $qb->executeQuery();
 	//		while ($data = $cursor->fetch()) {
 	//			$shares[] = $this->parseGSSharesSelectSql($data);
 	//		}
@@ -141,7 +141,7 @@ class MountRequest extends MountRequestBuilder {
 	//		$this->limitToInstance($qb, $member->getInstance());
 	//		$this->limitToOwner($qb, $member->getUserId());
 	//
-	//		$qb->execute();
+	//		$qb->executeStatement();
 	//	}
 	//
 	//
@@ -194,7 +194,7 @@ class MountRequest extends MountRequestBuilder {
 	//		$this->limitToMountpointHash($qb, $targetHash);
 	//
 	//		$shares = [];
-	//		$cursor = $qb->execute();
+	//		$cursor = $qb->executeQuery();
 	//		$data = $cursor->fetch();
 	//
 	//		if ($data === false) {
@@ -219,7 +219,7 @@ class MountRequest extends MountRequestBuilder {
 	//		$this->limitToUserId($qb, $userId);
 	//
 	//		$shares = [];
-	//		$cursor = $qb->execute();
+	//		$cursor = $qb->executeQuery();
 	//		$data = $cursor->fetch();
 	//		if ($data === false) {
 	//			throw new ShareNotFound();
@@ -241,7 +241,7 @@ class MountRequest extends MountRequestBuilder {
 	//		   ->setValue('share_id', $qb->createNamedParameter($mountpoint->getShareId()))
 	//		   ->setValue('mountpoint', $qb->createNamedParameter($mountpoint->getMountPoint()))
 	//		   ->setValue('mountpoint_hash', $qb->createNamedParameter($hash));
-	//		$qb->execute();
+	//		$qb->executeStatement();
 	//	}
 	//
 	//
@@ -260,7 +260,7 @@ class MountRequest extends MountRequestBuilder {
 	//
 	//		$this->limitToShareId($qb, $mountpoint->getShareId());
 	//		$this->limitToUserId($qb, $mountpoint->getUserId());
-	//		$nb = $qb->execute();
+	//		$nb = $qb->executeStatement();
 	//
 	//		return ($nb === 1);
 	//	}

--- a/lib/Db/RemoteRequest.php
+++ b/lib/Db/RemoteRequest.php
@@ -40,7 +40,7 @@ class RemoteRequest extends RemoteRequestBuilder {
 			->setValue('interface', $qb->createNamedParameter($remote->getInterface()))
 			->setValue('item', $qb->createNamedParameter(json_encode($remote->getOrigData())));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -59,7 +59,7 @@ class RemoteRequest extends RemoteRequestBuilder {
 
 		$qb->limitToInstance($remote->getInstance());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -75,7 +75,7 @@ class RemoteRequest extends RemoteRequestBuilder {
 
 		$qb->limit('uid', $remote->getUid(true), '', false);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -91,7 +91,7 @@ class RemoteRequest extends RemoteRequestBuilder {
 
 		$qb->limit('uid', $remote->getUid(true), '', false);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -107,7 +107,7 @@ class RemoteRequest extends RemoteRequestBuilder {
 
 		$qb->limit('uid', $remote->getUid(true), '', false);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -123,7 +123,7 @@ class RemoteRequest extends RemoteRequestBuilder {
 
 		$qb->limit('uid', $remote->getUid(true), '', false);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -259,6 +259,6 @@ class RemoteRequest extends RemoteRequestBuilder {
 	public function deleteById(RemoteInstance $remoteInstance) {
 		$qb = $this->getRemoteDeleteSql();
 		$qb->limitToId($remoteInstance->getDbId());
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/lib/Db/ShareLockRequest.php
+++ b/lib/Db/ShareLockRequest.php
@@ -34,7 +34,7 @@ class ShareLockRequest extends ShareLockRequestBuilder {
 			->setValue('circle_id', $qb->createNamedParameter($share->getCircleId()))
 			->setValue('instance', $qb->createNamedParameter($qb->getInstance($share)));
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 

--- a/lib/Db/ShareTokenRequest.php
+++ b/lib/Db/ShareTokenRequest.php
@@ -36,7 +36,7 @@ class ShareTokenRequest extends ShareTokenRequestBuilder {
 			->setValue('password', $qb->createNamedParameter($token->getPassword()))
 			->setValue('accepted', $qb->createNamedParameter($token->getAccepted()));
 
-		$qb->execute();
+		$qb->executeStatement();
 		$id = $qb->getLastInsertId();
 		$token->setDbId($id);
 	}
@@ -95,7 +95,7 @@ class ShareTokenRequest extends ShareTokenRequestBuilder {
 		$qb->limitToSingleId($singleId);
 		$qb->limitToCircleId($circleId);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**

--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -62,7 +62,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 			$qb->setValue('parent', $qb->createNamedParameter($parentId));
 		}
 
-		$qb->execute();
+		$qb->executeStatement();
 		$id = $qb->getLastInsertId();
 		try {
 			$share->setId((string)$id);
@@ -92,7 +92,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 
 		$qb->limitToId((int)$shareWrapper->getId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -108,7 +108,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		$qb->limitToShareParent((int)$shareWrapper->getId());
 		$qb->gt('permissions', 0);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -120,7 +120,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		$qb->limitToShareWith($membership->getCircleId());
 		$qb->limit('uid_initiator', $membership->getSingleId());
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 
@@ -475,7 +475,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 			)
 		);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -512,7 +512,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		$qb->limitNull('id', false, 'p');
 
 		$ids = [];
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($data = $cursor->fetch()) {
 			$ids[] = $data['id'];
 		}
@@ -534,7 +534,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 			)
 		);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -791,7 +791,7 @@ class ShareByCircleProvider implements IShareProvider {
 		//				  )
 		//		   );
 		//
-		//		$cursor = $qb->execute();
+		//		$cursor = $qb->executeQuery();
 		//		while ($data = $cursor->fetch()) {
 		//			try {
 		//				yield $this->createShareObject($data);

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -995,7 +995,7 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws RowNotFoundException
 	 */
 	public function getRow(callable $method, string $object = '', array $params = []): IQueryRow {
-		$cursor = $this->execute();
+		$cursor = $this->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -1016,7 +1016,7 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 */
 	public function getRows(callable $method, string $object = '', array $params = []): array {
 		$rows = [];
-		$cursor = $this->execute();
+		$cursor = $this->executeQuery();
 		while ($data = $cursor->fetch()) {
 			try {
 				$rows[] = $method($data, $this, $object, $params);


### PR DESCRIPTION
Required due to https://github.com/nextcloud/server/pull/55720