### PR TITLE
allow admins to edit circle details

### DIFF
--- a/lib/FederatedItems/CircleEdit.php
+++ b/lib/FederatedItems/CircleEdit.php
@@ -75,7 +75,7 @@ class CircleEdit implements IFederatedItem {
 		$circle = $event->getCircle();
 
 		$initiatorHelper = new MemberHelper($circle->getInitiator());
-		$initiatorHelper->mustBeOwner();
+		$initiatorHelper->mustBeAdmin();
 
 		$data = $event->getParams();
 		$new = clone $circle;


### PR DESCRIPTION
It should be possible for admins to edit it's name, description and display name. Again this would be necessary for Collectives.

The `verify()` function is only called for editing those three properties.

fixes: #2181 