### PR TITLE
fix(sharing): Don't crash when loading shares for unknown user

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -498,7 +498,12 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider {
 			return [];
 		}
 
-		$federatedUser = $this->federatedUserService->getLocalFederatedUser($userId);
+		try {
+			$federatedUser = $this->federatedUserService->getLocalFederatedUser($userId);
+		} catch (FederatedUserNotFoundException) {
+			return [];
+		}
+
 		$probe = new CircleProbe();
 		$probe->includePersonalCircles()
 			->includeSystemCircles()


### PR DESCRIPTION
- Since https://github.com/nextcloud/circles/pull/2275 the share provider crashes when loading shares of a deleted user
- This is triggered via the new `UserShareAccessUpdatedEvent` even that apps are supposed to trigger when access changes.
- The event is dispatched by Talk when removing a user from the one-to-one chats and migrating them to former-one-to-one chats
- Failure visible before in https://github.com/nextcloud/spreed/actions/runs/20985168552/job/60317795918?pr=16713