### PR TITLE
fix(population): exclude nested circles from population counts

### DIFF
--- a/lib/FederatedItems/CircleDestroy.php
+++ b/lib/FederatedItems/CircleDestroy.php
@@ -107,9 +107,15 @@ class CircleDestroy implements
 
 		$this->eventService->circleDestroying($event);
 
+		$parentCirlces = $this->membershipService->getParentCircles($circle);
+
 		$this->circleRequest->delete($circle);
 		$this->memberRequest->deleteAllFromCircle($circle);
 		$this->membershipService->onUpdate($circle->getSingleId());
+
+		foreach ($parentCirlces as $parentCircle) {
+			$this->membershipService->updatePopulation($parentCircle);
+		}
 	}
 
 

--- a/lib/Model/Circle.php
+++ b/lib/Model/Circle.php
@@ -829,6 +829,7 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 			'sanitizedName' => $this->getSanitizedName(),
 			'source' => $this->getSource(),
 			'population' => $this->getPopulation(),
+			'populationInherited' => $this->getPopulationInherited(),
 			'config' => $this->getConfig(),
 			'description' => $this->getDescription(),
 			'url' => $this->getUrl(),


### PR DESCRIPTION
* Related to: nextcloud/circles#2126

## Summary
Fixes team population calculation to exclude nested teams from member counts.

## Changes
- When a team is added as member of another team, only users within the nested team are counted (team itself and duplicates are not counted)
- When team members are added/removed, all parent circles (circles containing the updated circle) are also updated
- When a team is deleted, all teams that contained that team are updated to reflect the removal
- Added `populationInherited` field to `Circle::jsonSerialize()` alongside existing `population` for frontend usage in follow-up PR without breaking current frontend

### Frontend follow-up needed
This PR addresses only the backend part of the issue. A follow-up PR in `nextcloud/contacts` is required to fix inconsistent count display:
- Currently: uses `population` for member count on page load, but switches to member list length when clicking a team
- Expected: consistently use the same count throughout the interface (`populationInherited`, added in this PR)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
