### PR TITLE
perf: use getExistingUser for getUsersForShare

### DIFF
--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -52,7 +52,6 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\AlreadySharedException;
 use OCP\Share\Exceptions\IllegalIDChangeException;
@@ -852,9 +851,7 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 		$members = $this->shareWrapperService->getShareById((int)$share->getId())->getCircle()->getInheritedMembers();
 		foreach ($members as $member) {
 			if ($member->getUserType() === Member::TYPE_USER) {
-				/** @var IUser $user */
-				$user = $this->userManager->get($member->getUserId());
-				yield $user;
+				yield $this->userManager->getExistingUser($member->getUserId());
 			}
 		}
 	}


### PR DESCRIPTION
We already know the user id is valid (not user provided), so we don't need to check the existence and can use the more performant option.