### PR TITLE
fix(groups): add repair step for group circles sync and adjust 'circles:sync --groups' command

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -41,6 +41,7 @@ Those groups of people can then be used by any other app for sharing purpose.
 	<repair-steps>
 		<post-migration>
 			<step>OCA\Circles\Migration\Migration</step>
+			<step>OCA\Circles\Migration\SyncGroupCircles</step>
 		</post-migration>
 	</repair-steps>
 

--- a/lib/BackgroundJob/SyncGroupCirclesJob.php
+++ b/lib/BackgroundJob/SyncGroupCirclesJob.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\BackgroundJob;
+
+use OCA\Circles\Service\SyncService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+
+class SyncGroupCirclesJob extends QueuedJob {
+
+	public function __construct(
+		ITimeFactory $time,
+		private SyncService $syncService,
+	) {
+		parent::__construct($time);
+	}
+
+	public function run($argument) {
+		$this->syncService->syncNextcloudGroups();
+	}
+}

--- a/lib/Migration/SyncGroupCircles.php
+++ b/lib/Migration/SyncGroupCircles.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\Migration;
+
+use OCA\Circles\BackgroundJob\SyncGroupCirclesJob;
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Class SyncGroupCircles
+ *
+ * @package OCA\Circles\Migration
+ */
+class SyncGroupCircles implements IRepairStep {
+
+	public function __construct(
+		private IJobList $jobList,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Sync groups with their circles';
+	}
+
+	public function run(IOutput $output): void {
+		$this->jobList->add(SyncGroupCirclesJob::class);
+	}
+}

--- a/lib/Service/SyncService.php
+++ b/lib/Service/SyncService.php
@@ -282,10 +282,6 @@ class SyncService {
 		}, $this->memberRequest->getMembers($circle->getSingleId()));
 
 		$group = $this->groupManager->get($groupId);
-		if ($group->count() <= count($members)) {
-			return $circle;
-		}
-
 		foreach ($group->getUsers() as $user) {
 			$member = $this->generateGroupMember($circle, $user->getUID());
 			if (in_array($member->getSingleId(), $members)) {


### PR DESCRIPTION
* Resolves: #2291

## Summary

Fixes group to circle sync for groups created while Circles (teams) app was disabled. When such groups are added to teams, their members now correctly appear as team members.

## Problem

When a group is created and populated while the Circles app is disabled and later added to a team, the group members are not synced to the team, so users don't see themselves as team members.

As reported in issue #2291, removing/adding a user from a group again while Circles is enabled and then adding that group to a team would correctly sync the users.

Also reported that running `circles:sync --groups` should fix this situation, but in my case that did not work. I had to adjust the sync method to not rely on member count to sync (removed the count if statment), as it was counting app type as a member and entering here and returning earlier without actually updating the memberships of a circle:
```php
if ($group->count() <= count($members)) {
    return $circle;
}
```
With this adjustment I was able to correctly sync groups created before circles was enabled.

Also, as requested on the issue, a repair step was added, and basically what it does is trigger a single background job that runs the same method as `circles:sync --groups`, resulting in the same behaviour.

## Testing

To test this, I did the reproduction steps described on the issue:

1. Disable circles
2. Create a group "TestGroup" and add "TestUser" to it
3. Enable circles
4. As "SomeoneElse" create team "TestTeam" and add "TestGroup"
5. As "TestUser" look in the contacts app what teams you're part of
6. Result: "TestTeam" does not appear as a team "TestUser" is part of

To fix that the following can be done (this is what this PR implements):
```bash
occ maintenance:repair
occ background-job:list
```

Get the id from `OCA\Circles\BackgroundJob\SyncGroupCirclesJob` job
```bash
occ background-job:execute <sync-group-circles-job-id>
```

After execute runs, if you refresh the "TestUser" contacts page you should see that now the "TestTeam" appears as a team where "TestUser" belongs.

Instead of executing the repair step, `circles:sync --groups` can also be runned to test and achieve the same result.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)