### PR TITLE
feat: add endpoint to remove a team from all parent teams

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,6 +15,7 @@ return [
 		['name' => 'Local#probeCircles', 'url' => '/probecircles', 'verb' => 'GET'],
 		['name' => 'Local#create', 'url' => '/circles', 'verb' => 'POST'],
 		['name' => 'Local#destroy', 'url' => '/circles/{circleId}', 'verb' => 'DELETE'],
+		['name' => 'Local#leaveParentCircles', 'url' => '/circles/{circleId}/leave-parent-circles', 'verb' => 'PUT'],
 		['name' => 'Local#search', 'url' => '/search', 'verb' => 'GET'],
 		['name' => 'Local#circleDetails', 'url' => '/circles/{circleId}', 'verb' => 'GET'],
 		['name' => 'Local#members', 'url' => '/circles/{circleId}/members', 'verb' => 'GET'],

--- a/lib/Activity/ProviderSubjectCircle.php
+++ b/lib/Activity/ProviderSubjectCircle.php
@@ -46,4 +46,24 @@ class ProviderSubjectCircle extends ProviderParser {
 
 		throw new FakeException();
 	}
+
+	/**
+	 * @param IEvent $event
+	 * @param array $params
+	 *
+	 * @throws FakeException
+	 */
+	public function parseSubjectCircleLeavingParentCircles(IEvent $event, array $params): void {
+		if ($event->getSubject() !== 'circle_leaving_parent_circles') {
+			return;
+		}
+
+		$this->parseCircleEvent(
+			$event, $params,
+			$this->l10n->t('You removed {circle} from all teams it belonged to'),
+			$this->l10n->t('{author} removed {circle} from all teams it belonged to')
+		);
+
+		throw new FakeException();
+	}
 }

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -163,6 +163,28 @@ class LocalController extends OCSController {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * @param string $circleId
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function leaveParentCircles(string $circleId): DataResponse {
+		try {
+			$this->setCurrentFederatedUser();
+
+			$circle = $this->circleService->leaveParentCircles($circleId);
+
+			return new DataResponse($this->serializeArray($circle));
+		} catch (Exception $e) {
+			$this->e($e, ['circleId' => $circleId]);
+			throw new OCSException($e->getMessage(), (int)$e->getCode());
+		}
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 *
 	 * @param string $term
 	 *
 	 * @return DataResponse

--- a/lib/Events/LeavingParentCirclesEvent.php
+++ b/lib/Events/LeavingParentCirclesEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+namespace OCA\Circles\Events;
+
+use OCA\Circles\Model\Federated\FederatedEvent;
+
+/**
+ * Class LeavingParentCirclesEvent
+ *
+ * This event is called when a Circle is removed from all parent Circles.
+ * This event is called on every instance of Nextcloud related to the Circle.
+ *
+ * The circle member entries have already been removed from parent circles in the members table.
+ * The circle membership entries have already been removed from parent circles in the membership table.
+ *
+ * This is a good place if anything needs to be executed when a Circle has been removed from its parent Circles.
+ *
+ * If anything needs to be managed on the master instance of the Circle (ie. LeftParentCirclesEvent), please use:
+ *    $event->getFederatedEvent()->setResultEntry(string $key, array $data);
+ *
+ * @package OCA\Circles\Events
+ */
+class LeavingParentCirclesEvent extends CircleGenericEvent {
+	/**
+	 * LeavingParentCirclesEvent constructor.
+	 *
+	 * @param FederatedEvent $federatedEvent
+	 */
+	public function __construct(FederatedEvent $federatedEvent) {
+		parent::__construct($federatedEvent);
+	}
+}

--- a/lib/Events/LeftParentCirclesEvent.php
+++ b/lib/Events/LeftParentCirclesEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+namespace OCA\Circles\Events;
+
+use OCA\Circles\Model\Federated\FederatedEvent;
+
+/**
+ * Class LeftParentCirclesEvent
+ *
+ * This Event is called when it has been confirmed that the Circle has been removed from all parent Circles
+ * on all instances related to the Circle.
+ *
+ * Meaning that the event won't be triggered until each instances have been once available during the
+ * retry-on-fail initiated in a background job.
+ *
+ * WARNING: Unlike LeavingParentCirclesEvent, this Event is only called on the master instance of the Circle.
+ *
+ * @package OCA\Circles\Events
+ */
+class LeftParentCirclesEvent extends CircleResultGenericEvent {
+	/**
+	 * LeftParentCirclesEvent constructor.
+	 *
+	 * @param FederatedEvent $federatedEvent
+	 * @param array $results
+	 */
+	public function __construct(FederatedEvent $federatedEvent, array $results) {
+		parent::__construct($federatedEvent, $results);
+	}
+}

--- a/lib/FederatedItems/CircleLeaveParentCircles.php
+++ b/lib/FederatedItems/CircleLeaveParentCircles.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\FederatedItems;
+
+use OCA\Circles\AppInfo\Application;
+use OCA\Circles\Db\CircleRequest;
+use OCA\Circles\Db\MemberRequest;
+use OCA\Circles\Exceptions\MemberHelperException;
+use OCA\Circles\Exceptions\MemberLevelException;
+use OCA\Circles\Exceptions\MemberNotFoundException;
+use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\IFederatedItem;
+use OCA\Circles\IFederatedItemAsyncProcess;
+use OCA\Circles\IFederatedItemHighSeverity;
+use OCA\Circles\Model\Federated\FederatedEvent;
+use OCA\Circles\Model\Helpers\MemberHelper;
+use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\EventService;
+use OCA\Circles\Service\MembershipService;
+use OCA\Circles\Tools\Traits\TDeserialize;
+use OCA\Circles\Tools\Traits\TNCLogger;
+
+/**
+ * Class CircleLeaveParentCircles
+ *
+ * @package OCA\Circles\FederatedItems
+ */
+class CircleLeaveParentCircles implements
+	IFederatedItem,
+	IFederatedItemHighSeverity,
+	IFederatedItemAsyncProcess {
+	use TDeserialize;
+	use TNCLogger;
+
+	/** @var MemberRequest */
+	private $memberRequest;
+
+	/** @var CircleRequest */
+	private $circleRequest;
+
+	/** @var MembershipService */
+	private $membershipService;
+
+	/** @var EventService */
+	private $eventService;
+
+	/** @var ConfigService */
+	private $configService;
+
+	/**
+	 * CircleLeaveParentCircles constructor.
+	 *
+	 * @param MemberRequest $memberRequest
+	 * @param CircleRequest $circleRequest
+	 * @param MembershipService $membershipService
+	 * @param EventService $eventService
+	 * @param ConfigService $configService
+	 */
+	public function __construct(
+		MemberRequest $memberRequest,
+		CircleRequest $circleRequest,
+		MembershipService $membershipService,
+		EventService $eventService,
+		ConfigService $configService,
+	) {
+		$this->memberRequest = $memberRequest;
+		$this->circleRequest = $circleRequest;
+		$this->membershipService = $membershipService;
+		$this->eventService = $eventService;
+		$this->configService = $configService;
+
+		$this->setup('app', Application::APP_ID);
+	}
+
+	/**
+	 * @param FederatedEvent $event
+	 *
+	 * @throws RequestBuilderException
+	 * @throws MemberHelperException
+	 * @throws MemberLevelException
+	 */
+	public function verify(FederatedEvent $event): void {
+		$circle = $event->getCircle();
+		$initiator = $circle->getInitiator();
+		$initiatorHelper = new MemberHelper($initiator);
+		$initiatorHelper->mustBeOwner();
+
+		$event->setOutcome($this->serialize($circle));
+	}
+
+	/**
+	 * @param FederatedEvent $event
+	 *
+	 * @throws RequestBuilderException
+	 * @throws MemberNotFoundException
+	 */
+	public function manage(FederatedEvent $event): void {
+		$circle = $event->getCircle();
+		$parentCircles = $this->membershipService->getParentCircles($circle);
+		foreach ($parentCircles as $parentCircle) {
+			$member = $this->memberRequest->getMember(
+				$parentCircle->getSingleId(),
+				$circle->getSingleId()
+			);
+			$this->memberRequest->delete($member);
+			$this->membershipService->onUpdate($member->getSingleId());
+			$this->membershipService->updatePopulation($parentCircle);
+		}
+		$this->eventService->circleLeavingParentCircles($event);
+	}
+
+	/**
+	 * @param FederatedEvent $event
+	 * @param array $results
+	 */
+	public function result(FederatedEvent $event, array $results): void {
+		$this->eventService->circleLeftParentCircles($event, $results);
+	}
+}

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -83,6 +83,30 @@ class ActivityService {
 
 	/**
 	 * @param Circle $circle
+	 */
+	public function onCircleLeavingParentCircles(Circle $circle): void {
+		if ($circle->isConfig(Circle::CFG_PERSONAL)) {
+			return;
+		}
+
+		$event = $this->generateEvent('circles_as_member');
+		$event->setSubject(
+			'circle_leaving_parent_circles',
+			[
+				'ver' => 2,
+				'circle' => $this->shortenCircleData($circle),
+				'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+			]
+		);
+
+		$this->publishEvent(
+			$event,
+			$this->memberRequest->getInheritedMembers($circle->getSingleId(), false, Member::LEVEL_MODERATOR)
+		);
+	}
+
+	/**
+	 * @param Circle $circle
 	 * @param Member $member
 	 * @param int $eventType
 	 */

--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -33,6 +33,7 @@ use OCA\Circles\FederatedItems\CircleDestroy;
 use OCA\Circles\FederatedItems\CircleEdit;
 use OCA\Circles\FederatedItems\CircleJoin;
 use OCA\Circles\FederatedItems\CircleLeave;
+use OCA\Circles\FederatedItems\CircleLeaveParentCircles;
 use OCA\Circles\FederatedItems\CircleSetting;
 use OCA\Circles\IEntity;
 use OCA\Circles\IFederatedUser;
@@ -245,6 +246,37 @@ class CircleService {
 		$circle = $this->getCircle($circleId);
 
 		$event = new FederatedEvent(CircleDestroy::class);
+		$event->setCircle($circle);
+		$event->forceSync($forceSync);
+		$this->federatedEventService->newEvent($event);
+
+		return $event->getOutcome();
+	}
+
+
+	/**
+	 * @param string $circleId
+	 * @param bool $forceSync
+	 *
+	 * @return array
+	 * @throws CircleNotFoundException
+	 * @throws FederatedEventException
+	 * @throws FederatedItemException
+	 * @throws InitiatorNotConfirmedException
+	 * @throws InitiatorNotFoundException
+	 * @throws OwnerNotFoundException
+	 * @throws RemoteInstanceException
+	 * @throws RemoteNotFoundException
+	 * @throws RemoteResourceNotFoundException
+	 * @throws RequestBuilderException
+	 * @throws UnknownRemoteException
+	 */
+	public function leaveParentCircles(string $circleId, bool $forceSync = false): array {
+		$this->federatedUserService->mustHaveCurrentUser();
+
+		$circle = $this->getCircle($circleId);
+		
+		$event = new FederatedEvent(CircleLeaveParentCircles::class);
 		$event->setCircle($circle);
 		$event->forceSync($forceSync);
 		$this->federatedEventService->newEvent($event);

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -26,6 +26,8 @@ use OCA\Circles\Events\EditingCircleMemberEvent;
 use OCA\Circles\Events\Files\CreatingFileShareEvent;
 use OCA\Circles\Events\Files\FileShareCreatedEvent;
 use OCA\Circles\Events\Files\PreparingFileShareEvent;
+use OCA\Circles\Events\LeavingParentCirclesEvent;
+use OCA\Circles\Events\LeftParentCirclesEvent;
 use OCA\Circles\Events\MembershipsCreatedEvent;
 use OCA\Circles\Events\MembershipsRemovedEvent;
 use OCA\Circles\Events\PreparingCircleMemberEvent;
@@ -100,6 +102,23 @@ class EventService {
 		$this->eventDispatcher->dispatchTyped($event);
 	}
 
+	/**
+	 * @param FederatedEvent $federatedEvent
+	 */
+	public function circleLeavingParentCircles(FederatedEvent $federatedEvent): void {
+		$event = new LeavingParentCirclesEvent($federatedEvent);
+		$this->eventDispatcher->dispatchTyped($event);
+		$this->activityService->onCircleLeavingParentCircles($event->getCircle());
+	}
+
+	/**
+	 * @param FederatedEvent $federatedEvent
+	 * @param array $results
+	 */
+	public function circleLeftParentCircles(FederatedEvent $federatedEvent, array $results): void {
+		$event = new LeftParentCirclesEvent($federatedEvent, $results);
+		$this->eventDispatcher->dispatchTyped($event);
+	}
 
 	/**
 	 * @param FederatedEvent $federatedEvent


### PR DESCRIPTION
* Related to: nextcloud/circles#2341
* Also related to this frontend PR. nextcloud/contacts#5103

## Summary
Adds a new endpoint to enable removal of a team from all teams it belongs to.

## Changes
- Added a new route and method to `lib/Controller/LocalController.php`
- Added a new method to `lib/Service/CircleService.php`
- Created new events and triggered them when the action occurs

## Checklist
- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
