### PR TITLE
fix(federation): Don't break when federation is disabled

### DIFF
--- a/lib/Service/TrustedServerService.php
+++ b/lib/Service/TrustedServerService.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerInterface;
  */
 class TrustedServerService {
 	public function __construct(
-		private readonly TrustedServers $trustedServers,
+		private readonly ?TrustedServers $trustedServers,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -25,6 +25,10 @@ class TrustedServerService {
 	 * @return list<array{id: int, url: string, url_hash: string, shared_secret: ?string, status: int, sync_token: ?string, address: string}>
 	 */
 	public function getTrustedServers(): array {
+		if ($this->trustedServers === null) {
+			return [];
+		}
+
 		$trustedServers = [];
 		try {
 			foreach ($this->trustedServers->getServers() as $server) {


### PR DESCRIPTION
Before:

> [!CAUTION]
> Failed to construct console command 'OCA\Circles\Command\CirclesRemote': Could not resolve OCA\Federation\TrustedServers! Class "OCA\Federation\TrustedServers" does not exist

After:
```
  - installed: true
  - version: 34.0.0.0
  - versionstring: 34.0.0 dev
  - edition: 
  - maintenance: false
  - needsDbUpgrade: false
  - productname: Nextcloud
  - extendedSupport: false
```