### PR TITLE
avoid desync with memberships

### DIFF
--- a/lib/Db/CircleRequest.php
+++ b/lib/Db/CircleRequest.php
@@ -296,6 +296,7 @@ class CircleRequest extends CircleRequestBuilder {
 
 		$aliasMembership = $qb->generateAlias(CoreQueryBuilder::CIRCLE, CoreQueryBuilder::MEMBERSHIPS);
 
+		$aliasInitiator = null;
 		if (is_null($initiator)) {
 			// to get unique result, enforce a limit on level=owner
 			$limit = $qb->exprLimitInt('level', Member::LEVEL_OWNER, $aliasMembership);
@@ -305,10 +306,15 @@ class CircleRequest extends CircleRequestBuilder {
 				$initiator->getSingleId(),
 				$aliasMembership
 			);
-			$qb->completeProbeWithInitiator(CoreQueryBuilder::CIRCLE, 'single_id', $aliasMembership);
+			$aliasInitiator = $qb->completeProbeWithInitiator(CoreQueryBuilder::CIRCLE, 'single_id', $aliasMembership);
 		}
 
 		$qb->andWhere($limit);
+		if (!is_null($aliasInitiator)) {
+			// ensure initiator is not null (desync memberships/members)
+			$qb->filterNull('single_id', alias: $aliasInitiator);
+		}
+
 		$qb->resetSqlPath();
 
 		return $qb;

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1292,15 +1292,15 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 		string $alias,
 		string $field = 'single_id',
 		string $helperAlias = '',
-	): void {
+	): ?string {
 		if ($this->getType() !== QueryBuilder::SELECT) {
-			return;
+			return null;
 		}
 
 		try {
 			$aliasInitiator = $this->generateAlias($alias, self::INITIATOR);
 		} catch (RequestBuilderException $e) {
-			return;
+			return null;
 		}
 
 		$helperAlias = ($helperAlias === '') ? $alias : $helperAlias;
@@ -1314,8 +1314,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 					$expr->eq($aliasInitiator . '.' . $field, $helperAlias . '.inheritance_first'),
 				)
 			);
-		//
-		//		$this->leftJoinBasedOn($aliasInitiator);
+
+		return $aliasInitiator;
 	}
 
 	/**


### PR DESCRIPTION
when a member is removed from a team, and until the membership is rebuilt, initiator will be null; resulting in Collaboratives not able to mount its folder and therefor blocking user loading any page.

This will filters out rows with null initiator