### PR TITLE
fix: remove user part only at the beginning of path

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -24,6 +24,7 @@ use OCP\Files\NotFoundException;
 use OCP\Share\Exceptions\IllegalIDChangeException;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
+use function strlen;
 
 /**
  * Class ShareWrapperRequest
@@ -383,10 +384,14 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		$qb->limitNull('parent', false);
 		$childAlias = $qb->leftJoinShareChild(CoreQueryBuilder::SHARE);
 
+		$userId = $federatedUser->getUserId();
+		$prefix = '/' . $userId . '/files';
+		if (str_starts_with($path, $prefix)) {
+			$path = substr($path, strlen($prefix));
+		}
+		$path = rtrim($path, '/');
+
 		if ($forChildren) {
-			$userId = $federatedUser->getUserId();
-			$path = str_replace('/' . $userId . '/files', '', $path);
-			$path = rtrim($path, '/');
 			$childPathTemplate = $this->getQueryBuilder()->getConnection()->escapeLikeParameter($path) . '/_%';
 
 			$qb->limitToFileTargetLike($childPathTemplate, $childAlias);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

For [server/#58333](https://github.com/nextcloud/server/issues/58333) in circles share provider

Replaces `str_replace` with a `str_starts_with` + `substr` for stripping the user portion off the path.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
