### PR TITLE
force delete old events

### DIFF
--- a/lib/Db/EventWrapperRequest.php
+++ b/lib/Db/EventWrapperRequest.php
@@ -122,19 +122,18 @@ class EventWrapperRequest extends EventWrapperRequestBuilder {
 	}
 
 	/**
-	 * delete completed entries older than a month
-	 *
-	 * @param bool $allOldEntries delete also not-completed entries
+	 * delete completed entries older than a week,
+	 * delete all entries older than a month
 	 */
-	public function deleteOldEntries(bool $allOldEntries = false): void {
+	public function deleteOldEntries(): void {
 		$qb = $this->getEventWrapperDeleteSql();
-		$qb->where(
-			$qb->exprLimitInt('status', EventWrapper::STATUS_OVER),
-			$qb->exprLt('creation', time() - 30 * 86400)
-		);
-		if (!$allOldEntries) {
-			$qb->andWhere($qb->exprLimitInt('status', EventWrapper::STATUS_OVER));
-		}
+		$qb->where($qb->expr()->orX(
+			$qb->expr()->andX(
+				$qb->exprLimitInt('status', EventWrapper::STATUS_OVER),
+				$qb->exprLt('creation', time() - 604800)
+			),
+			$qb->exprLt('creation', time() - (4 * 604800)),
+		));
 
 		$qb->executeStatement();
 	}

--- a/lib/Service/MaintenanceService.php
+++ b/lib/Service/MaintenanceService.php
@@ -209,7 +209,7 @@ class MaintenanceService {
 
 		try {
 			$this->output('Delete old and terminated FederatedEvents');
-			$this->eventWrapperRequest->deleteOldEntries(false);
+			$this->eventWrapperRequest->deleteOldEntries();
 		} catch (Exception $e) {
 			$this->logger->warning('issue while deleting old events', ['exception' => $e]);
 		}


### PR DESCRIPTION
modification of the logic to clean the events table, will generate this kind of request:

```
DELETE
FROM
    `oc_circles_event`
WHERE
    ((`status` = 9) AND(`creation` < 1771240913)) 
  OR
     (`creation` < 1769426513)
```

this delete:
- successful event old that 1 week,
- every events older than 4 weeks