### PR TITLE
feat(mount-provider): implement IPartialMountProvider

### DIFF
--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1575,6 +1575,26 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 
 
 	/**
+	 * @param string $aliasMount
+	 * @param string $path
+	 * @param bool $forChildren
+	 *
+	 * @throws RequestBuilderException
+	 */
+	public function limitToMountpoint(string $aliasMount, string $path, bool $forChildren = false): void {
+		if ($forChildren) {
+			$this->andWhere(
+				$this->expr()->like($aliasMount . '.mountpoint', $this->createNamedParameter($path . '/%'))
+			);
+		} else {
+			$this->andWhere(
+				$this->expr()->eq($aliasMount . '.mountpoint', $this->createNamedParameter($path))
+			);
+		}
+	}
+
+
+	/**
 	 * @param string $alias
 	 * @param array $default
 	 *

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1575,9 +1575,7 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 
 
 	/**
-	 * @param string $aliasMount
-	 * @param string[] $paths
-	 * @param bool $forChildren
+	 * @param list<string> $paths
 	 */
 	public function limitToMountpoints(string $aliasMount, array $paths, bool $forChildren = false): void {
 		if (count($paths) === 0) {
@@ -1589,7 +1587,7 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 
 		if ($forChildren) {
 			foreach ($paths as $path) {
-				$orX->add($expr->like($aliasMount . '.mountpoint', $this->createNamedParameter($path . '/%')));
+				$orX->add($expr->like($aliasMount . '.mountpoint', $this->createNamedParameter($path . '/_%')));
 			}
 		} else {
 			$orX->add($expr->in($aliasMount . '.mountpoint', $this->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)));

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1590,7 +1590,10 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 				$orX->add($expr->like($aliasMount . '.mountpoint', $this->createNamedParameter($path . '/_%')));
 			}
 		} else {
-			$orX->add($expr->in($aliasMount . '.mountpoint', $this->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)));
+			$pathChunks = array_chunk($paths, 1000);
+			foreach ($pathChunks as $pathChunk) {
+				$orX->add($expr->in($aliasMount . '.mountpoint', $this->createNamedParameter($pathChunk, IQueryBuilder::PARAM_STR_ARRAY)));
+			}
 		}
 
 		$this->andWhere($orX);

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -1576,21 +1576,26 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 
 	/**
 	 * @param string $aliasMount
-	 * @param string $path
+	 * @param string[] $paths
 	 * @param bool $forChildren
-	 *
-	 * @throws RequestBuilderException
 	 */
-	public function limitToMountpoint(string $aliasMount, string $path, bool $forChildren = false): void {
-		if ($forChildren) {
-			$this->andWhere(
-				$this->expr()->like($aliasMount . '.mountpoint', $this->createNamedParameter($path . '/%'))
-			);
-		} else {
-			$this->andWhere(
-				$this->expr()->eq($aliasMount . '.mountpoint', $this->createNamedParameter($path))
-			);
+	public function limitToMountpoints(string $aliasMount, array $paths, bool $forChildren = false): void {
+		if (count($paths) === 0) {
+			return;
 		}
+
+		$expr = $this->expr();
+		$orX = $expr->orX();
+
+		if ($forChildren) {
+			foreach ($paths as $path) {
+				$orX->add($expr->like($aliasMount . '.mountpoint', $this->createNamedParameter($path . '/%')));
+			}
+		} else {
+			$orX->add($expr->in($aliasMount . '.mountpoint', $this->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)));
+		}
+
+		$this->andWhere($orX);
 	}
 
 

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -58,16 +58,21 @@ class MountRequest extends MountRequestBuilder {
 
 	/**
 	 * @param IFederatedUser $federatedUser
+	 * @param string|null $path
+	 * @param bool $forChildren
 	 *
 	 * @return Mount[]
 	 * @throws RequestBuilderException
 	 */
-	public function getForUser(IFederatedUser $federatedUser): array {
+	public function getForUser(IFederatedUser $federatedUser, ?string $path = null, bool $forChildren = false): array {
 		$qb = $this->getMountSelectSql();
 		$qb->setOptions([CoreQueryBuilder::MOUNT], ['getData' => true]);
 		$qb->leftJoinMember(CoreQueryBuilder::MOUNT);
 		$qb->leftJoinMountpoint(CoreQueryBuilder::MOUNT, $federatedUser);
 		$qb->limitToInitiator(CoreQueryBuilder::MOUNT, $federatedUser, 'circle_id');
+		if ($path !== null) {
+			$qb->limitToMountpoint(CoreQueryBuilder::MOUNT, $path, $forChildren);
+		}
 
 		return $this->getItemsFromRequest($qb);
 

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -58,20 +58,20 @@ class MountRequest extends MountRequestBuilder {
 
 	/**
 	 * @param IFederatedUser $federatedUser
-	 * @param string|null $path
+	 * @param string[] $paths
 	 * @param bool $forChildren
 	 *
 	 * @return Mount[]
 	 * @throws RequestBuilderException
 	 */
-	public function getForUser(IFederatedUser $federatedUser, ?string $path = null, bool $forChildren = false): array {
+	public function getForUser(IFederatedUser $federatedUser, array $paths = [], bool $forChildren = false): array {
 		$qb = $this->getMountSelectSql();
 		$qb->setOptions([CoreQueryBuilder::MOUNT], ['getData' => true]);
 		$qb->leftJoinMember(CoreQueryBuilder::MOUNT);
 		$qb->leftJoinMountpoint(CoreQueryBuilder::MOUNT, $federatedUser);
 		$qb->limitToInitiator(CoreQueryBuilder::MOUNT, $federatedUser, 'circle_id');
-		if ($path !== null) {
-			$qb->limitToMountpoint(CoreQueryBuilder::MOUNT, $path, $forChildren);
+		if (count($paths) !== 0) {
+			$qb->limitToMountpoints(CoreQueryBuilder::MOUNT, $paths, $forChildren);
 		}
 
 		return $this->getItemsFromRequest($qb);

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -57,9 +57,7 @@ class MountRequest extends MountRequestBuilder {
 
 
 	/**
-	 * @param IFederatedUser $federatedUser
-	 * @param string[] $paths
-	 * @param bool $forChildren
+	 * @param list<string> $paths
 	 *
 	 * @return Mount[]
 	 * @throws RequestBuilderException

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -68,9 +68,7 @@ class MountRequest extends MountRequestBuilder {
 		$qb->leftJoinMember(CoreQueryBuilder::MOUNT);
 		$qb->leftJoinMountpoint(CoreQueryBuilder::MOUNT, $federatedUser);
 		$qb->limitToInitiator(CoreQueryBuilder::MOUNT, $federatedUser, 'circle_id');
-		if (count($paths) !== 0) {
-			$qb->limitToMountpoints(CoreQueryBuilder::MOUNT, $paths, $forChildren);
-		}
+		$qb->limitToMountpoints(CoreQueryBuilder::MOUNT, $paths, $forChildren);
 
 		return $this->getItemsFromRequest($qb);
 

--- a/lib/MountManager/CircleMountProvider.php
+++ b/lib/MountManager/CircleMountProvider.php
@@ -175,8 +175,8 @@ class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 
 	#[Override]
 	public function getMountsForPath(string $setupPathHint, bool $forChildren, array $mountProviderArgs, IStorageFactory $loader): array {
-		/** @var array<string, Mount[]> $userItems */
-		$userItems = [];
+		/** @var array<string, array{federatedUser: IFederatedUser, paths: string[]}> $userMountRequests */
+		$userMountRequests = [];
 		/** @var array<string, IMountPoint> $mounts */
 		$mounts = [];
 
@@ -189,24 +189,31 @@ class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 				continue;
 			}
 
-			if (!isset($userItems[$user->getUID()])) {
+			if (!isset($userMountRequests[$user->getUID()])) {
 				$federatedUser = $this->federatedUserService->getLocalFederatedUser($user->getUID());
-				$path = '/' . implode('/', array_slice($parts, 3));
-				$userItems[$user->getUID()] = $this->mountRequest->getForUser(
-					$federatedUser,
-					$path,
-					$forChildren
-				);
+				$userMountRequests[$user->getUID()] = [
+					'federatedUser' => $federatedUser,
+					'paths' => [],
+				];
 			}
 
-			foreach ($userItems[$user->getUID()] as $item) {
-				$mountPoint = '/' . $user->getUID() . '/files' . $item->getMountPoint();
+			$userMountRequests[$user->getUID()]['paths'][] = '/' . implode('/', array_slice($parts, 3));
+		}
+
+		foreach ($userMountRequests as $uid => $userMountRequest) {
+			$userItems = $this->mountRequest->getForUser(
+				$userMountRequest['federatedUser'],
+				$userMountRequest['paths'],
+				$forChildren
+			);
+
+			foreach ($userItems as $item) {
+				$mountPoint = '/' . $uid . '/files' . $item->getMountPoint();
 				if (isset($mounts[$mountPoint])) {
 					continue;
 				}
-
 				try {
-					$this->fixDuplicateFile($user->getUID(), $item);
+					$this->fixDuplicateFile($uid, $item);
 					$mounts[$mountPoint] = $this->generateCircleMount($item, $loader);
 				} catch (\Exception $e) {
 					$this->logger->warning('issue with teams\' partial mounts', ['exception' => $e]);

--- a/lib/MountManager/CircleMountProvider.php
+++ b/lib/MountManager/CircleMountProvider.php
@@ -29,6 +29,8 @@ use OCA\Files_Sharing\External\Storage as ExternalStorage;
 use OCP\DB\Exception;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\Config\IMountProvider;
+use OCP\Files\Config\IPartialMountProvider;
+use OCP\Files\Config\MountProviderArgs;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -36,9 +38,10 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\Http\Client\IClientService;
 use OCP\IUser;
+use Override;
 use Psr\Log\LoggerInterface;
 
-class CircleMountProvider implements IMountProvider {
+class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 	use TArrayTools;
 
 	/** @var class-string<ExternalStorage> */
@@ -168,5 +171,49 @@ class CircleMountProvider implements IMountProvider {
 
 			$n++;
 		}
+	}
+
+	#[Override]
+	public function getMountsForPath(string $setupPathHint, bool $forChildren, array $mountProviderArgs, IStorageFactory $loader): array {
+		/** @var array<string, Mount[]> $userItems */
+		$userItems = [];
+		/** @var array<string, IMountPoint> $mounts */
+		$mounts = [];
+
+		/** @var MountProviderArgs $mountProviderArg */
+		foreach ($mountProviderArgs as $mountProviderArg) {
+			$user = $mountProviderArg->mountInfo->getUser();
+
+			$parts = explode('/', $mountProviderArg->mountInfo->getMountPoint());
+			if ($parts[1] !== $user->getUID() || $parts[2] !== 'files') {
+				continue;
+			}
+
+			if (!isset($userItems[$user->getUID()])) {
+				$federatedUser = $this->federatedUserService->getLocalFederatedUser($user->getUID());
+				$path = '/' . implode('/', array_slice($parts, 3));
+				$userItems[$user->getUID()] = $this->mountRequest->getForUser(
+					$federatedUser,
+					$path,
+					$forChildren
+				);
+			}
+
+			foreach ($userItems[$user->getUID()] as $item) {
+				$mountPoint = '/' . $user->getUID() . '/files' . $item->getMountPoint();
+				if (isset($mounts[$mountPoint])) {
+					continue;
+				}
+
+				try {
+					$this->fixDuplicateFile($user->getUID(), $item);
+					$mounts[$mountPoint] = $this->generateCircleMount($item, $loader);
+				} catch (\Exception $e) {
+					$this->logger->warning('issue with teams\' partial mounts', ['exception' => $e]);
+				}
+			}
+		}
+
+		return $mounts;
 	}
 }

--- a/lib/MountManager/CircleMountProvider.php
+++ b/lib/MountManager/CircleMountProvider.php
@@ -189,13 +189,10 @@ class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 				continue;
 			}
 
-			if (!isset($userMountRequests[$user->getUID()])) {
-				$federatedUser = $this->federatedUserService->getLocalFederatedUser($user->getUID());
-				$userMountRequests[$user->getUID()] = [
-					'federatedUser' => $federatedUser,
-					'paths' => [],
-				];
-			}
+			$userMountRequests[$user->getUID()] ??= [
+				'federatedUser' => $this->federatedUserService->getLocalFederatedUser($user->getUID()),
+				'paths' => [],
+			];
 
 			$userMountRequests[$user->getUID()]['paths'][] = '/' . implode('/', array_slice($parts, 3));
 		}
@@ -216,7 +213,7 @@ class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 					$this->fixDuplicateFile($uid, $item);
 					$mounts[$mountPoint] = $this->generateCircleMount($item, $loader);
 				} catch (\Exception $e) {
-					$this->logger->warning('issue with teams\' partial mounts', ['exception' => $e]);
+					$this->logger->error('Failed to create Teams mount', ['exception' => $e]);
 				}
 			}
 		}


### PR DESCRIPTION
* Resolves: #2308

## Summary
Implemented `IPartialMountProvider` in `CircleMountProvider` by adding `getMountsForPath()` and added `limitToMountpoint()` to `CoreQueryBuilder` to support filtering.

## Testing

I couldn't fully test this because the code path isn't triggered without changes to `lib/AppInfo/Application::registerMountProvider()` and `lib/FederatedItems/Files/FileShare::manage()`. That said, I was able to check the behavior using step debugging as follows:

- Temporarily commented out the `if (!$this->configService->isLocalInstance($event->getOrigin()))` condition in `lib/FederatedItems/Files/FileShare::manage()` to allow mount entries to be created locally
- Created teams `mock_team_1`, `mock_team_2` and `mock_team_3`
- Created folders `mock_folder_1`, `mock_folder_2` and `mock_folder_3` and shared with their respective teams (`mock_team_1`, `mock_team_2` and `mock_team_3`)
- Temporarily commented out the early `return` in `lib/AppInfo/Application::registerMountProvider()` to force registration of `CircleMountProvider` regardless of GlobalScale availability
- Using Xdebug with a breakpoint on `circles/lib/MountManager/CircleMountProvider::getMountsForUser()`, accessed `nextcloud.local/index.php/apps/dashboard/`, triggering the `getMountsForUser()` method
- Instead of running the regular method flow, I created some mock params and called `getMountsForPath()` directly:
```php
$makeMountArg = function(string $path) use ($user): \OCP\Files\Config\MountProviderArgs {
	$mountInfo = new class($user, $path) implements \OCP\Files\Config\ICachedMountInfo {
		public function __construct(private \OCP\IUser $user, private string $path) {}
		public function getUser(): \OCP\IUser { return $this->user; }
		public function getMountPoint(): string { return '/' . $this->user->getUID() . '/files/' . $this->path; }
		public function getStorageId(): int { return 0; }
		public function getRootId(): int { return 0; }
		public function getMountPointNode(): ?\OCP\Files\Node { return null; }
		public function getMountId(): ?int { return null; }
		public function getRootInternalPath(): string { return ''; }
		public function getMountProvider(): string { return ''; }
		public function getKey(): string { return ''; }
	};
	return new \OCP\Files\Config\MountProviderArgs(
		$mountInfo,
		new \OC\Files\Cache\CacheEntry([])
	);
};

$this->getMountsForPath(
	'/' . $user->getUID() . '/files/mock_folder',
	false,
	[
		$makeMountArg('mock_folder_1'),
		$makeMountArg('mock_folder_2'),
		$makeMountArg('another_folder'),
	],
	$loader
);
```

### Results
- Path filtering worked correctly when `forChildren` was set to false. With multiple folders on my setup (`mock_team_1`, `mock_team_2` and `mock_team_3`), in the test above only the requested mounts that exist in the DB were returned for the given paths when calling `getForUser()` inside `getMountsForPath()`, confirming that `limitToMountpoints()` is filtering correctly at the database level.
- `forChildren` did not work as expected when set to true. During testing, circles always stored mountpoints relatively. For example, sharing a folder created inside `mock_folder` generated a `circles_mount` entry with mountpoint `/mock_subfolder` instead of `/mock_folder/mock_subfolder`. As a result, the `LIKE '/mock_folder/%'` filter used when `forChildren` is true will not match these entries.
- During testing, `generateCircleMount()` threw an exception in both the original `getMountsForUser()` and on new method  `getMountsForPath()`. I believe this happened because the mount entries were artificially created by bypassing the remote instance check in `FileShare::manage()`, resulting in incomplete data compared to what would be present in a real GlobalScale environment.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI