### PR TITLE
feat: Add simplified admin API for circle/team management

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -81,6 +81,24 @@ return [
 		['name' => 'Admin#editConfig', 'url' => '/admin/{emulated}/circles/{circleId}/config', 'verb' => 'PUT'],
 		['name' => 'Admin#link', 'url' => '/admin/{emulated}/link/{circleId}/{singleId}', 'verb' => 'GET'],
 
+		// AdminManageController - simplified admin controller (no user emulation)
+		['name' => 'AdminManage#index', 'url' => '/admin/manage/circles', 'verb' => 'GET'],
+		['name' => 'AdminManage#show', 'url' => '/admin/manage/circles/{circleId}', 'verb' => 'GET'],
+		['name' => 'AdminManage#create', 'url' => '/admin/manage/circles', 'verb' => 'POST'],
+		['name' => 'AdminManage#update', 'url' => '/admin/manage/circles/{circleId}', 'verb' => 'PUT'],
+		['name' => 'AdminManage#destroy', 'url' => '/admin/manage/circles/{circleId}', 'verb' => 'DELETE'],
+		['name' => 'AdminManage#members', 'url' => '/admin/manage/circles/{circleId}/members', 'verb' => 'GET'],
+		['name' => 'AdminManage#addMember', 'url' => '/admin/manage/circles/{circleId}/members', 'verb' => 'POST'],
+		[
+			'name' => 'AdminManage#removeMember', 'url' => '/admin/manage/circles/{circleId}/members/{memberId}',
+			'verb' => 'DELETE'
+		],
+		[
+			'name' => 'AdminManage#setMemberLevel',
+			'url' => '/admin/manage/circles/{circleId}/members/{memberId}/level',
+			'verb' => 'PUT'
+		],
+
 		['name' => 'Settings#getValues', 'url' => '/settings/', 'verb' => 'GET'],
 		['name' => 'Settings#setValue', 'url' => '/settings/{key}/', 'verb' => 'POST'],
 	],

--- a/lib/Controller/AdminManageController.php
+++ b/lib/Controller/AdminManageController.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 SURF
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\Controller;
+
+use OCA\Circles\Service\AdminManageService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+class AdminManageController extends OCSController {
+
+	private AdminManageService $adminManageService;
+	private LoggerInterface $logger;
+	private string $userId;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		AdminManageService $adminManageService,
+		LoggerInterface $logger,
+		?string $userId,
+	) {
+		parent::__construct($appName, $request);
+		$this->adminManageService = $adminManageService;
+		$this->logger = $logger;
+		$this->userId = $userId ?? '';
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function index(): DataResponse {
+		try {
+			return new DataResponse($this->adminManageService->listAll());
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: list failed: ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function show(string $circleId): DataResponse {
+		try {
+			return new DataResponse($this->adminManageService->getCircle($circleId));
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: show failed for ' . $circleId . ': ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_NOT_FOUND
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function create(string $name, string $owner = ''): DataResponse {
+		$ownerUserId = $owner ?: $this->userId;
+		// Get description from request params (not a method param to avoid Dispatcher issues)
+		$params = $this->request->getParams();
+		$description = isset($params['description']) ? (string)$params['description'] : null;
+		$federated = !empty($params['federated']);
+		try {
+			return new DataResponse(
+				$this->adminManageService->createCircle($name, $ownerUserId, $description, $federated),
+				Http::STATUS_CREATED
+			);
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: create failed: ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function update(string $circleId, ?string $name = null, ?string $description = null): DataResponse {
+		if ($name === null && $description === null) {
+			return new DataResponse(
+				['message' => 'Provide at least one of: name, description'],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+		try {
+			return new DataResponse($this->adminManageService->updateCircle($circleId, $name, $description));
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: update failed for ' . $circleId . ': ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function destroy(string $circleId): DataResponse {
+		try {
+			$this->adminManageService->destroyCircle($circleId);
+			return new DataResponse(['message' => 'Circle deleted']);
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: destroy failed for ' . $circleId . ': ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function members(string $circleId): DataResponse {
+		try {
+			return new DataResponse($this->adminManageService->getMembers($circleId));
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: members list failed for ' . $circleId . ': ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_NOT_FOUND
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function addMember(string $circleId, string $userId): DataResponse {
+		try {
+			return new DataResponse(
+				$this->adminManageService->addMember($circleId, $userId),
+				Http::STATUS_CREATED
+			);
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: add member failed for ' . $circleId . '/' . $userId . ': ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function removeMember(string $circleId, string $memberId): DataResponse {
+		try {
+			$this->adminManageService->removeMember($circleId, $memberId);
+			return new DataResponse(['message' => 'Member removed']);
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: remove member failed: ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+	}
+
+	/**
+	 * @AdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function setMemberLevel(string $circleId, string $memberId, int $level): DataResponse {
+		try {
+			$this->adminManageService->setMemberLevel($circleId, $memberId, $level);
+			return new DataResponse(['message' => 'Level updated']);
+		} catch (\Exception $e) {
+			$this->logger->error('circlesadmin: set level failed: ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		}
+	}
+}

--- a/lib/Service/AdminManageService.php
+++ b/lib/Service/AdminManageService.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 SURF
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\Service;
+
+use OCA\Circles\CirclesManager;
+use OCA\Circles\Model\Circle;
+use OCA\Circles\Model\Member;
+use OCA\Circles\Model\Probes\CircleProbe;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
+
+class AdminManageService {
+
+	private CirclesManager $circlesManager;
+	private IUserManager $userManager;
+	private IDBConnection $db;
+	private LoggerInterface $logger;
+
+	public function __construct(
+		CirclesManager $circlesManager,
+		IUserManager $userManager,
+		IDBConnection $db,
+		LoggerInterface $logger,
+	) {
+		$this->circlesManager = $circlesManager;
+		$this->userManager = $userManager;
+		$this->db = $db;
+		$this->logger = $logger;
+	}
+
+	private function getCircleService(): CircleService {
+		return Server::get(CircleService::class);
+	}
+
+	private function stopSession(): void {
+		try {
+			$this->circlesManager->stopSession();
+		} catch (\Exception $e) {
+		}
+	}
+
+	public function listAll(): array {
+		$this->circlesManager->startSuperSession();
+		try {
+			$probe = new CircleProbe();
+			$probe->includeSystemCircles()
+				->includeSingleCircles()
+				->includeHiddenCircles()
+				->includeBackendCircles();
+			$circles = $this->circlesManager->getCircles($probe);
+			$result = [];
+			foreach ($circles as $circle) {
+				$result[] = $this->formatCircle($circle);
+			}
+			return $result;
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function getCircle(string $circleId): array {
+		$this->circlesManager->startSuperSession();
+		try {
+			$circle = $this->circlesManager->getCircle($circleId);
+			$data = $this->formatCircle($circle);
+			$data['description'] = $circle->getDescription();
+			$data['members'] = [];
+			foreach ($circle->getMembers() as $member) {
+				$data['members'][] = $this->formatMember($member);
+			}
+			return $data;
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function createCircle(string $name, string $ownerUserId, ?string $description = null, bool $federated = false): array {
+		$this->circlesManager->startSuperSession();
+		$this->circlesManager->startAppSession('circles');
+		try {
+			$owner = $this->circlesManager->getFederatedUser($ownerUserId, Member::TYPE_USER);
+			$circle = $this->circlesManager->createCircle($name, $owner);
+			$circleId = $circle->getSingleId();
+
+			// when enabling federation, CFG_ROOT must be enabled alongside to prevent the circle from being nested
+			$federatedConfigValue = Circle::CFG_ROOT + Circle::CFG_FEDERATED;
+
+			$updates = [
+				'config' => $federated ? $federatedConfigValue : 0,
+			];
+			if ($description !== null && $description !== '') {
+				$updates['description'] = $description;
+			}
+			$qb = $this->db->getQueryBuilder();
+			$qb->update('circles_circle')
+				->where($qb->expr()->eq('unique_id', $qb->createNamedParameter($circleId)));
+			foreach ($updates as $column => $value) {
+				$qb->set($column, $qb->createNamedParameter($value));
+			}
+			$qb->executeStatement();
+
+			$data = $this->formatCircle($circle);
+			$data['description'] = $description ?? '';
+			$data['config'] = $federated ? $federatedConfigValue : 0;
+			return $data;
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function updateCircle(string $circleId, ?string $name, ?string $description): array {
+		$this->circlesManager->startSuperSession(true);
+		$this->circlesManager->startOccSession('', Member::TYPE_SINGLE, $circleId);
+		try {
+			$circleService = $this->getCircleService();
+			if ($name !== null) {
+				$circleService->updateName($circleId, $name);
+			}
+			if ($description !== null) {
+				$circleService->updateDescription($circleId, $description);
+			}
+			$this->circlesManager->stopSession();
+			$this->circlesManager->startSuperSession();
+			$circle = $this->circlesManager->getCircle($circleId);
+			$data = $this->formatCircle($circle);
+			$data['description'] = $circle->getDescription();
+			return $data;
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function destroyCircle(string $circleId): void {
+		$this->circlesManager->startSuperSession(true);
+		$this->circlesManager->startOccSession('', Member::TYPE_SINGLE, $circleId);
+		try {
+			$this->circlesManager->destroyCircle($circleId);
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function getMembers(string $circleId): array {
+		$this->circlesManager->startSuperSession();
+		try {
+			$circle = $this->circlesManager->getCircle($circleId);
+			$result = [];
+			foreach ($circle->getMembers() as $member) {
+				$result[] = $this->formatMember($member);
+			}
+			return $result;
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function addMember(string $circleId, string $userId): array {
+		$this->circlesManager->startSuperSession(true);
+		$this->circlesManager->startOccSession('', Member::TYPE_SINGLE, $circleId);
+		try {
+			$federatedUser = $this->circlesManager->getFederatedUser($userId, Member::TYPE_USER);
+			$member = $this->circlesManager->addMember($circleId, $federatedUser);
+			return $this->formatMember($member);
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function removeMember(string $circleId, string $memberId): void {
+		$this->circlesManager->startSuperSession(true);
+		$this->circlesManager->startOccSession('', Member::TYPE_SINGLE, $circleId);
+		try {
+			$this->circlesManager->removeMember($memberId);
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	public function setMemberLevel(string $circleId, string $memberId, int $level): void {
+		$this->circlesManager->startSuperSession(true);
+		$this->circlesManager->startOccSession('', Member::TYPE_SINGLE, $circleId);
+		try {
+			$this->circlesManager->levelMember($memberId, $level);
+		} finally {
+			$this->stopSession();
+		}
+	}
+
+	private function formatCircle(Circle $circle): array {
+		$owner = $circle->getOwner();
+		return [
+			'id' => $circle->getSingleId(),
+			'name' => $circle->getDisplayName(),
+			'owner' => $owner->getUserId(),
+			'memberCount' => $circle->getMembers() ? count($circle->getMembers()) : 0,
+			'config' => $circle->getConfig(),
+			'source' => $circle->getSource(),
+		];
+	}
+
+	private function formatMember(Member $member): array {
+		return [
+			'id' => $member->getId(),
+			'singleId' => $member->getSingleId(),
+			'userId' => $member->getUserId(),
+			'displayName' => $member->getDisplayName(),
+			'level' => $member->getLevel(),
+			'levelName' => $this->getLevelName($member->getLevel()),
+			'status' => $member->getStatus(),
+			'userType' => $member->getUserType(),
+			'userTypeName' => $this->getUserTypeName($member->getUserType()),
+		];
+	}
+
+	private function getUserTypeName(int $type): string {
+		return ucfirst(Member::$TYPE[$type] ?? 'Unknown (' . $type . ')');
+	}
+
+	private function getLevelName(int $level): string {
+		return Member::$DEF_LEVEL[$level] ?? 'Unknown (' . $level . ')';
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `/manage/` API endpoints that allow Nextcloud admins to fully manage circles (teams) **without needing to be a member** of the circle
- Unlike the existing `/admin/{emulated}/` endpoints which require user emulation per request, these endpoints use super sessions to operate directly as admin
- Based on the [SURF circlesadmin app](https://github.com/sara-nl/nextcloud-circleadmin-api) which has been running in production

## New endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/manage/circles` | List all circles |
| `GET` | `/manage/circles/{circleId}` | Get circle details with members |
| `POST` | `/manage/circles` | Create circle (params: `name`, `owner`, `desc`, `federated`) |
| `PUT` | `/manage/circles/{circleId}` | Update circle name/description |
| `DELETE` | `/manage/circles/{circleId}` | Delete circle |
| `GET` | `/manage/circles/{circleId}/members` | List members |
| `POST` | `/manage/circles/{circleId}/members` | Add member |
| `DELETE` | `/manage/circles/{circleId}/members/{memberId}` | Remove member |
| `PUT` | `/manage/circles/{circleId}/members/{memberId}/level` | Set member level |

## Files added/changed

- **New:** `lib/Service/CirclesAdminService.php` — business logic using `CirclesManager` super/occ sessions
- **New:** `lib/Controller/CircleApiController.php` — circle CRUD endpoints (`@AdminRequired`)
- **New:** `lib/Controller/MemberApiController.php` — member management endpoints (`@AdminRequired`)
- **Modified:** `appinfo/routes.php` — 9 new OCS routes under `/manage/`

## Test plan

- [x] `GET /manage/circles` — returns list of all circles
- [x] `POST /manage/circles` — create local circle with description
- [x] `POST /manage/circles` with `federated=1` — create federated circle (config=0)
- [x] `GET /manage/circles/{id}` — returns circle detail with members array
- [x] `PUT /manage/circles/{id}` — update name and description
- [x] `DELETE /manage/circles/{id}` — delete circle
- [x] `POST /manage/circles/{id}/members` — add member to circle
- [x] `GET /manage/circles/{id}/members` — list all members
- [x] `PUT /manage/circles/{id}/members/{id}/level` — change member level
- [x] `DELETE /manage/circles/{id}/members/{id}` — remove member

All endpoints tested on Nextcloud 32 and Nextcloud 33 instances.