### PR TITLE
Bug: Don't generate a public link token for internal circle team share

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -608,36 +608,38 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		}
 	}
 
-    /**
-     * Look up a ShareWrapper using the token in oc_circles_token
-     * (instead of oc_share.token).
-     *
-     * This makes it possible to leave oc_share.token empty whilst
-     * the circles-share remains accessible via the circles-token.
-     *
-     * @throws ShareWrapperNotFoundException
-     */
-    public function getShareByCirclesToken(string $token): ShareWrapper {
-        $qb = $this->getShareWrapperSelectSql();
 
-        // JOIN met oc_circles_token op share_id
-        $qb->innerJoin(
-            'sw',
-            'circles_token',
-            'ct',
-            $qb->expr()->eq('ct.share_id', 'sw.id')
-        );
+	/**
+	 * Look up a ShareWrapper using the token in oc_circles_token instead of oc_share.token.
+	 * Used as a fallback when oc_share.token is empty.
+	 *
+	 * @throws ShareWrapperNotFoundException
+	 */
+	public function getShareByCirclesToken(string $token): ShareWrapper {
+		$qb = $this->getShareSelectSql();
 
-        $qb->andWhere(
-            $qb->expr()->eq('ct.token', $qb->createNamedParameter($token))
-        );
+		$qb->setOptions([CoreQueryBuilder::SHARE], ['getData' => true]);
+		$qb->leftJoinCircle(CoreQueryBuilder::SHARE, null, 'share_with');
 
-        try {
-            return $this->getItemFromRequest($qb);
-        } catch (\Exception $e) {
-            throw new ShareWrapperNotFoundException(
-                'Share not found for circles token: ' . $token
-            );
-        }
-    }
+		$qb->innerJoin(
+			CoreQueryBuilder::SHARE,
+			'circles_token',
+			'ct',
+			$qb->expr()->eq('ct.share_id', CoreQueryBuilder::SHARE . '.id')
+		);
+
+		$qb->andWhere(
+			$qb->expr()->eq('ct.token', $qb->createNamedParameter($token))
+		);
+
+		try {
+			$shareWrapper = $this->getItemFromRequest($qb);
+			$shareWrapper->setToken($token);
+			return $shareWrapper;
+		} catch (\Exception $e) {
+			throw new ShareWrapperNotFoundException(
+				'Share not found for circles token: ' . $token
+			);
+		}
+	}
 }

--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -607,4 +607,37 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 			return null;
 		}
 	}
+
+    /**
+     * Look up a ShareWrapper using the token in oc_circles_token
+     * (instead of oc_share.token).
+     *
+     * This makes it possible to leave oc_share.token empty whilst
+     * the circles-share remains accessible via the circles-token.
+     *
+     * @throws ShareWrapperNotFoundException
+     */
+    public function getShareByCirclesToken(string $token): ShareWrapper {
+        $qb = $this->getShareWrapperSelectSql();
+
+        // JOIN met oc_circles_token op share_id
+        $qb->innerJoin(
+            'sw',
+            'circles_token',
+            'ct',
+            $qb->expr()->eq('ct.share_id', 'sw.id')
+        );
+
+        $qb->andWhere(
+            $qb->expr()->eq('ct.token', $qb->createNamedParameter($token))
+        );
+
+        try {
+            return $this->getItemFromRequest($qb);
+        } catch (\Exception $e) {
+            throw new ShareWrapperNotFoundException(
+                'Share not found for circles token: ' . $token
+            );
+        }
+    }
 }

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -149,15 +149,13 @@ class ShareWrapperService {
 	 * @throws ShareWrapperNotFoundException
 	 */
 	public function getShareByToken(string $token, ?FederatedUser $federatedUser = null): ShareWrapper {
-        // First try using the standard oc_share.token lookup
-        try {
-            return $this->shareWrapperRequest->getShareByToken($token);
-        } catch (ShareWrapperNotFoundException $e) {
-            // Fallback: search using oc_circles_token.token
-            // This is necessary when oc_share.token is empty or does not match,
-            // but the circles token does exist.
-            return $this->shareWrapperRequest->getShareByCirclesToken($token);
-        }
+		// First try the standard lookup via oc_share.token
+		try {
+			return $this->shareWrapperRequest->getShareByToken($token);
+		} catch (ShareWrapperNotFoundException $e) {
+			// oc_share.token is empty — fall back to oc_circles_token.token
+			return $this->shareWrapperRequest->getShareByCirclesToken($token);
+		}
 	}
 
     /**

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -149,8 +149,27 @@ class ShareWrapperService {
 	 * @throws ShareWrapperNotFoundException
 	 */
 	public function getShareByToken(string $token, ?FederatedUser $federatedUser = null): ShareWrapper {
-		return $this->shareWrapperRequest->getShareByToken($token, $federatedUser);
+        // First try using the standard oc_share.token lookup
+        try {
+            return $this->shareWrapperRequest->getShareByToken($token);
+        } catch (ShareWrapperNotFoundException $e) {
+            // Fallback: search using oc_circles_token.token
+            // This is necessary when oc_share.token is empty or does not match,
+            // but the circles token does exist.
+            return $this->shareWrapperRequest->getShareByCirclesToken($token);
+        }
 	}
+
+    /**
+     * Look up a share directly via oc_circles_token.token.
+     * Can be used as an alternative to getShareByToken when
+     * oc_share.token has been deliberately left empty.
+     *
+     * @throws ShareWrapperNotFoundException
+     */
+    public function getShareByCirclesToken(string $token): ShareWrapper {
+        return $this->shareWrapperRequest->getShareByCirclesToken($token);
+    }
 
 	/**
 	 * @return ShareWrapper[]

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -142,7 +142,6 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 			->add(DataProbe::INITIATOR, [DataProbe::BASED_ON]);
 
 		$circle = $this->circleService->probeCircle($share->getSharedWith(), $circleProbe, $dataProbe);
-		$share->setToken('');
 		$share->setMailSend(true);
 		$owner = $circle->getInitiator();
 		$this->shareWrapperService->save($share);
@@ -581,32 +580,21 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 			throw new ShareNotFound();
 		}
 
-        $shareWrapper = null;
-
-        try {
-            $shareWrapper = $this->shareWrapperService->getShareByToken($token);
-        } catch (ShareWrapperNotFoundException $e) {
-            // Not found via oc_share.token — try oc_circles_token.token
-            try {
-                $shareWrapper = $this->shareWrapperService->getShareByCirclesToken($token);
-            } catch (ShareWrapperNotFoundException $e2) {
-                throw new ShareNotFound(
-                    'Share not found for token (tried both oc_share and oc_circles_token): ' . $token
-                );
-            }
-        }
-
-        if ($shareWrapper === null) {
+		try {
+			$shareWrapper = $this->shareWrapperService->getShareByToken($token);
+		} catch (ShareWrapperNotFoundException $e) {
             throw new ShareNotFound('Share not found for token: ' . $token);
         }
 
-        // Ensure that the share object has the correct token for UI routing
-        // If oc_share.token is empty, use the provided circles token
-        if ($shareWrapper->getToken() === '' || $shareWrapper->getToken() === null) {
-            $shareWrapper->setToken($token);
-        }
-
 		$share = $shareWrapper->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
+
+		// When oc_share.token is intentionally left empty (to prevent unauthenticated public link access),
+		// the IShare object is built from raw DB data and will have an empty token.
+		// Set the circles token directly on the IShare object so the router receives a valid non-empty token.
+		if ($share->getToken() === '' || $share->getToken() === null) {
+			$share->setToken($token);
+		}
+
 		if ($share->getPassword() !== '') {
 			$this->logger->notice('share is protected by a password, hash: ' . $share->getPassword());
 		}

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -142,7 +142,7 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 			->add(DataProbe::INITIATOR, [DataProbe::BASED_ON]);
 
 		$circle = $this->circleService->probeCircle($share->getSharedWith(), $circleProbe, $dataProbe);
-		$share->setToken($this->token(15));
+		$share->setToken('');
 		$share->setMailSend(true);
 		$owner = $circle->getInitiator();
 		$this->shareWrapperService->save($share);

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -581,13 +581,32 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 			throw new ShareNotFound();
 		}
 
-		try {
-			$wrappedShare = $this->shareWrapperService->getShareByToken($token);
-		} catch (ShareWrapperNotFoundException $e) {
-			throw new ShareNotFound();
-		}
+        $shareWrapper = null;
 
-		$share = $wrappedShare->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
+        try {
+            $shareWrapper = $this->shareWrapperService->getShareByToken($token);
+        } catch (ShareWrapperNotFoundException $e) {
+            // Not found via oc_share.token — try oc_circles_token.token
+            try {
+                $shareWrapper = $this->shareWrapperService->getShareByCirclesToken($token);
+            } catch (ShareWrapperNotFoundException $e2) {
+                throw new ShareNotFound(
+                    'Share not found for token (tried both oc_share and oc_circles_token): ' . $token
+                );
+            }
+        }
+
+        if ($shareWrapper === null) {
+            throw new ShareNotFound('Share not found for token: ' . $token);
+        }
+
+        // Ensure that the share object has the correct token for UI routing
+        // If oc_share.token is empty, use the provided circles token
+        if ($shareWrapper->getToken() === '' || $shareWrapper->getToken() === null) {
+            $shareWrapper->setToken($token);
+        }
+
+		$share = $shareWrapper->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
 		if ($share->getPassword() !== '') {
 			$this->logger->notice('share is protected by a password, hash: ' . $share->getPassword());
 		}


### PR DESCRIPTION
**Issue**

When sharing data with a team, a public link token is inadvertently generated alongside the secure internal share link for authenticated users. This public link has the same access rights and, until recently, was shared with team members via email. 
Although the recipients were already authorised to access this data, recipients of the email may have forwarded it to third parties, thereby allowing them – without authorisation – to gain access with the same rights as an authorised person. Team members are no longer informed of this, but a public link token is still generated behind the scenes.
 
This public link token can easily be guessed using a randomiser, thereby allowing unauthorised access to data that should not have been publicly accessible.

**How to reproduce**
Create a team via the contacts. Then share a dataset with custom permissions with this team.

** Result **
```
MariaDB [nextcloud]> select * from oc_share where id = '16135' \G;
*************************** 1. row ***************************
                      id: 16135
              share_type: 7
              share_with: ax1Gvs4s964zpZR5z7kyXgbzd9QPXnh
               uid_owner: piet
           uid_initiator: piet
                  parent: NULL
               item_type: folder
             item_source: 6946132
             item_target: NULL
             file_source: 6946132
             file_target: /Test_Public_Link_Breach
             permissions: 31
                   stime: 1776062454
                accepted: 1
              expiration: NULL
                   token: 8ui9FePpNwznze8
               mail_send: 1
              share_name: NULL
                password:
        password_by_talk: 0
                    note: Bla
           hide_download: 0
                   label: NULL
              attributes: [["permissions","download",true]]
password_expiration_time: NULL
           reminder_sent: 0
1 row in set (0.000 sec)
```
You can view this data without authentication via the public link token (8ui9FePpNwznze8), with the assumption that it has only been shared with team members via authorised access.

