### PR TITLE
fix(stubs): add missing return type to QueryBuilder::selectAlias()

### DIFF
--- a/tests/stubs/oc_db_querybuilder_querybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_querybuilder.php
@@ -321,7 +321,7 @@ class QueryBuilder implements IQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function selectAlias($select, $alias)
+	public function selectAlias($select, $alias): self
  {
  }
 


### PR DESCRIPTION
## Summary

Fixes the following psalm error:
```
Error: lib/Tools/Db/ExtendedQueryBuilder.php:30:7: MethodSignatureMismatch: Method OC\DB\QueryBuilder\QueryBuilder::selectAlias with return type '' is different to return type 'OCP\DB\QueryBuilder\IQueryBuilder' of inherited method OCP\DB\QueryBuilder\IQueryBuilder::selectAlias (see https://psalm.dev/042)
```