### PR TITLE
fix(stubs): update test stubs

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -41,6 +41,7 @@
 		<file name="tests/stubs/oc_db_connection.php" />
 		<file name="tests/stubs/oc_db_connectionadapter.php" />
 		<file name="tests/stubs/oc_db_querybuilder_querybuilder.php" />
+		<file name="tests/stubs/oc_db_querybuilder_typedquerybuilder.php" />
 		<file name="tests/stubs/oc_db_schemawrapper.php" />
 		<file name="tests/stubs/oc_files_cache_cache.php" />
 		<file name="tests/stubs/oc_files_cache_cacheentry.php" />

--- a/tests/stubs/oc.php
+++ b/tests/stubs/oc.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 
 use OC\Profiler\BuiltInProfiler;
+use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OC\Share20\GroupDeletedListener;
 use OC\Share20\Hooks;
 use OC\Share20\UserDeletedListener;
@@ -22,6 +23,7 @@ use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\ILogger;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Security\Bruteforce\IThrottler;
@@ -75,78 +77,78 @@ class OC {
 	 *                           the app path list is empty or contains an invalid path
 	 */
 	public static function initPaths(): void
- {
- }
+    {
+    }
 
 	public static function checkConfig(): void
- {
- }
+    {
+    }
 
 	public static function checkInstalled(\OC\SystemConfig $systemConfig): void
- {
- }
+    {
+    }
 
 	public static function checkMaintenanceMode(\OC\SystemConfig $systemConfig): void
- {
- }
+    {
+    }
 
 	public static function initSession(): void
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool true if the session expiry should only be done by gc instead of an explicit timeout
 	 */
 	public static function hasSessionRelaxedExpiry(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Try to set some values to the required Nextcloud default
 	 */
 	public static function setRequiredIniValues(): void
- {
- }
+    {
+    }
 
 	public static function init(): void
- {
- }
+    {
+    }
 
 	/**
 	 * register hooks for the cleanup of cache and bruteforce protection
 	 */
 	public static function registerCleanupHooks(\OC\SystemConfig $systemConfig): void
- {
- }
+    {
+    }
 
 	/**
 	 * register hooks for sharing
 	 */
 	public static function registerShareHooks(\OC\SystemConfig $systemConfig): void
- {
- }
+    {
+    }
 
 	/**
 	 * Handle the request
 	 */
 	public static function handleRequest(): void
- {
- }
+    {
+    }
 
 	/**
 	 * Check login: apache auth, auth token, basic auth
 	 */
 	public static function handleLogin(OCP\IRequest $request): bool
- {
- }
+    {
+    }
 
 	protected static function handleAuthHeaders(): void
- {
- }
+    {
+    }
 
 	protected static function tryAppAPILogin(OCP\IRequest $request): bool
- {
- }
+    {
+    }
 }
 
 OC::init();

--- a/tests/stubs/oc_appframework_bootstrap_aregistration.php
+++ b/tests/stubs/oc_appframework_bootstrap_aregistration.php
@@ -12,14 +12,15 @@ namespace OC\AppFramework\Bootstrap;
  * @psalm-immutable
  */
 abstract class ARegistration {
-	public function __construct(string $appId)
- {
- }
+	public function __construct(
+		private string $appId,
+	) {
+	}
 
 	/**
 	 * @return string
 	 */
 	public function getAppId(): string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_bootstrap_coordinator.php
+++ b/tests/stubs/oc_appframework_bootstrap_coordinator.php
@@ -40,22 +40,22 @@ class Coordinator {
 	}
 
 	public function runInitialRegistration(): void
- {
- }
+    {
+    }
 
 	public function runLazyRegistration(string $appId): void
- {
- }
+    {
+    }
 
 	public function getRegistrationContext(): ?RegistrationContext
- {
- }
+    {
+    }
 
 	public function bootApp(string $appId): void
- {
- }
+    {
+    }
 
 	public function isBootable(string $appId)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_bootstrap_registrationcontext.php
+++ b/tests/stubs/oc_appframework_bootstrap_registrationcontext.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\Services\InitialStateProvider;
 use OCP\Authentication\IAlternativeLogin;
+use OCP\Authentication\IAlternativeLoginProvider;
 use OCP\Calendar\ICalendarProvider;
 use OCP\Calendar\Resource\IBackend as IResourceBackend;
 use OCP\Calendar\Room\IBackend as IRoomBackend;
@@ -25,463 +26,479 @@ use OCP\Config\Lexicon\ILexicon;
 use OCP\Dashboard\IManager;
 use OCP\Dashboard\IWidget;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Conversion\IConversionProvider;
 use OCP\Files\Template\ICustomTemplateProvider;
 use OCP\Http\WellKnown\IHandler;
 use OCP\Mail\Provider\IProvider as IMailProvider;
 use OCP\Notification\INotifier;
 use OCP\Profile\ILinkAction;
 use OCP\Search\IProvider;
+use OCP\Server;
 use OCP\Settings\IDeclarativeSettingsForm;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\Share\IPublicShareTemplateProvider;
 use OCP\SpeechToText\ISpeechToTextProvider;
 use OCP\Support\CrashReport\IReporter;
 use OCP\Talk\ITalkBackend;
+use OCP\TaskProcessing\ITaskType;
 use OCP\Teams\ITeamResourceProvider;
 use OCP\TextProcessing\IProvider as ITextProcessingProvider;
 use OCP\Translation\ITranslationProvider;
 use OCP\UserMigration\IMigrator as IUserMigrator;
+use Override;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
 use function array_shift;
 
 class RegistrationContext {
-	public function __construct(LoggerInterface $logger)
- {
- }
+	public function __construct(
+		private LoggerInterface $logger,
+	) {
+	}
 
 	public function for(string $appId): IRegistrationContext
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<ICapability> $capability
 	 */
 	public function registerCapability(string $appId, string $capability): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<IReporter> $reporterClass
 	 */
 	public function registerCrashReporter(string $appId, string $reporterClass): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<IWidget> $panelClass
 	 */
 	public function registerDashboardPanel(string $appId, string $panelClass): void
- {
- }
+    {
+    }
 
 	public function registerService(string $appId, string $name, callable $factory, bool $shared = true): void
- {
- }
+    {
+    }
 
 	public function registerServiceAlias(string $appId, string $alias, string $target): void
- {
- }
+    {
+    }
 
 	public function registerParameter(string $appId, string $name, $value): void
- {
- }
+    {
+    }
 
 	public function registerEventListener(string $appId, string $event, string $listener, int $priority = 0): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<Middleware> $class
 	 */
 	public function registerMiddleware(string $appId, string $class, bool $global): void
- {
- }
+    {
+    }
 
 	public function registerSearchProvider(string $appId, string $class)
- {
- }
+    {
+    }
 
 	public function registerAlternativeLogin(string $appId, string $class): void
- {
- }
+    {
+    }
+
+	public function registerAlternativeLoginProvider(string $appId, string $class): void
+    {
+    }
 
 	public function registerInitialState(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerWellKnown(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerSpeechToTextProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerTextProcessingProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerTextToImageProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerTemplateProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerTranslationProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerNotifierService(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerTwoFactorProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerPreviewProvider(string $appId, string $class, string $mimeTypeRegex): void
- {
- }
+    {
+    }
 
 	public function registerCalendarProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	public function registerReferenceProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<ILinkAction> $actionClass
 	 */
 	public function registerProfileLinkAction(string $appId, string $actionClass): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<ITalkBackend> $backend
 	 */
 	public function registerTalkBackend(string $appId, string $backend)
- {
- }
+    {
+    }
 
 	public function registerCalendarResourceBackend(string $appId, string $class)
- {
- }
+    {
+    }
 
 	public function registerCalendarRoomBackend(string $appId, string $class)
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<ITeamResourceProvider> $class
 	 */
 	public function registerTeamResourceProvider(string $appId, string $class)
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<IUserMigrator> $migratorClass
 	 */
 	public function registerUserMigrator(string $appId, string $migratorClass): void
- {
- }
+    {
+    }
 
 	public function registerSensitiveMethods(string $appId, string $class, array $methods): void
- {
- }
+    {
+    }
 
 	public function registerPublicShareTemplateProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<ISetupCheck> $setupCheckClass
 	 */
 	public function registerSetupCheck(string $appId, string $setupCheckClass): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<IDeclarativeSettingsForm> $declarativeSettingsClass
 	 */
 	public function registerDeclarativeSettings(string $appId, string $declarativeSettingsClass): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<\OCP\TaskProcessing\IProvider> $declarativeSettingsClass
 	 */
 	public function registerTaskProcessingProvider(string $appId, string $taskProcessingProviderClass): void
- {
- }
+    {
+    }
 
 	/**
-	 * @psalm-param class-string<\OCP\TaskProcessing\ITaskType> $declarativeSettingsClass
+	 * @psalm-param class-string<ITaskType> $declarativeSettingsClass
 	 */
 	public function registerTaskProcessingTaskType(string $appId, string $taskProcessingTaskTypeClass)
- {
- }
+    {
+    }
 
 	/**
-	 * @psalm-param class-string<\OCP\Files\Conversion\IConversionProvider> $class
+	 * @psalm-param class-string<IConversionProvider> $class
 	 */
 	public function registerFileConversionProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<IMailProvider> $migratorClass
 	 */
 	public function registerMailProvider(string $appId, string $class): void
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-param class-string<ILexicon> $configLexiconClass
 	 */
 	public function registerConfigLexicon(string $appId, string $configLexiconClass): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param App[] $apps
 	 */
 	public function delegateCapabilityRegistrations(array $apps): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param App[] $apps
 	 */
 	public function delegateCrashReporterRegistrations(array $apps, Registry $registry): void
- {
- }
+    {
+    }
 
 	public function delegateDashboardPanelRegistrations(IManager $dashboardManager): void
- {
- }
+    {
+    }
 
 	public function delegateEventListenerRegistrations(IEventDispatcher $eventDispatcher): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param App[] $apps
 	 */
 	public function delegateContainerRegistrations(array $apps): void
- {
- }
+    {
+    }
 
 	/**
 	 * @return MiddlewareRegistration[]
 	 */
 	public function getMiddlewareRegistrations(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IProvider>[]
 	 */
 	public function getSearchProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IAlternativeLogin>[]
 	 */
 	public function getAlternativeLogins(): array
- {
- }
+    {
+    }
+
+	/**
+	 * @return ServiceRegistration<IAlternativeLoginProvider>[]
+	 */
+	public function getAlternativeLoginProviders(): array
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<InitialStateProvider>[]
 	 */
 	public function getInitialStates(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IHandler>[]
 	 */
 	public function getWellKnownHandlers(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ISpeechToTextProvider>[]
 	 */
 	public function getSpeechToTextProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ITextProcessingProvider>[]
 	 */
 	public function getTextProcessingProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<\OCP\TextToImage\IProvider>[]
 	 */
 	public function getTextToImageProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ICustomTemplateProvider>[]
 	 */
 	public function getTemplateProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ITranslationProvider>[]
 	 */
 	public function getTranslationProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<INotifier>[]
 	 */
 	public function getNotifierServices(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<\OCP\Authentication\TwoFactorAuth\IProvider>[]
 	 */
 	public function getTwoFactorProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return PreviewProviderRegistration[]
 	 */
 	public function getPreviewProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ICalendarProvider>[]
 	 */
 	public function getCalendarProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IReferenceProvider>[]
 	 */
 	public function getReferenceProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ILinkAction>[]
 	 */
 	public function getProfileLinkActions(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration|null
 	 * @psalm-return ServiceRegistration<ITalkBackend>|null
 	 */
 	public function getTalkBackendRegistration(): ?ServiceRegistration
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration[]
 	 * @psalm-return ServiceRegistration<IResourceBackend>[]
 	 */
 	public function getCalendarResourceBackendRegistrations(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration[]
 	 * @psalm-return ServiceRegistration<IRoomBackend>[]
 	 */
 	public function getCalendarRoomBackendRegistrations(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IUserMigrator>[]
 	 */
 	public function getUserMigrators(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ParameterRegistration[]
 	 */
 	public function getSensitiveMethods(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IPublicShareTemplateProvider>[]
 	 */
 	public function getPublicShareTemplateProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ISetupCheck>[]
 	 */
 	public function getSetupChecks(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<ITeamResourceProvider>[]
 	 */
 	public function getTeamResourceProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IDeclarativeSettingsForm>[]
 	 */
 	public function getDeclarativeSettings(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<\OCP\TaskProcessing\IProvider>[]
 	 */
 	public function getTaskProcessingProviders(): array
- {
- }
+    {
+    }
 
 	/**
-	 * @return ServiceRegistration<\OCP\TaskProcessing\ITaskType>[]
+	 * @return ServiceRegistration<ITaskType>[]
 	 */
 	public function getTaskProcessingTaskTypes(): array
- {
- }
+    {
+    }
 
 	/**
-	 * @return ServiceRegistration<\OCP\Files\Conversion\IConversionProvider>[]
+	 * @return ServiceRegistration<IConversionProvider>[]
 	 */
 	public function getFileConversionProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ServiceRegistration<IMailProvider>[]
 	 */
 	public function getMailProviders(): array
- {
- }
+    {
+    }
 
 	/**
 	 * returns IConfigLexicon registered by the app.
@@ -492,6 +509,6 @@ class RegistrationContext {
 	 * @return ILexicon|null
 	 */
 	public function getConfigLexicon(string $appId): ?ILexicon
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_bootstrap_serviceregistration.php
+++ b/tests/stubs/oc_appframework_bootstrap_serviceregistration.php
@@ -16,14 +16,14 @@ class ServiceRegistration extends ARegistration {
 	/**
 	 * @psalm-param class-string<T> $service
 	 */
-	public function __construct(string $appId, string $service)
- {
- }
+	public function __construct(string $appId, private string $service)
+    {
+    }
 
 	/**
 	 * @psalm-return class-string<T>
 	 */
 	public function getService(): string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_middleware_security_exceptions_notloggedinexception.php
+++ b/tests/stubs/oc_appframework_middleware_security_exceptions_notloggedinexception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -17,6 +19,6 @@ use OCP\AppFramework\Http;
  */
 class NotLoggedInException extends SecurityException {
 	public function __construct()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_utility_simplecontainer.php
+++ b/tests/stubs/oc_appframework_utility_simplecontainer.php
@@ -29,61 +29,45 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	public static bool $useLazyObjects = false;
 
 	public function __construct()
- {
- }
+    {
+    }
 
 	/**
 	 * @template T
 	 * @param class-string<T>|string $id
-	 * @return T|mixed
-	 * @psalm-template S as class-string<T>|string
-	 * @psalm-param S $id
-	 * @psalm-return (S is class-string<T> ? T : mixed)
+	 * @return ($id is class-string<T> ? T : mixed)
 	 */
 	public function get(string $id): mixed
- {
- }
+    {
+    }
 
 	public function has(string $id): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @param list<class-string> $chain
 	 */
-	public function resolve($name, array $chain = [])
- {
- }
+	public function resolve(string $name, array $chain = []): mixed
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @param list<class-string> $chain
 	 */
-	public function query(string $name, bool $autoload = true, array $chain = [])
- {
- }
+	public function query(string $name, bool $autoload = true, array $chain = []): mixed
+    {
+    }
 
-	/**
-	 * @param string $name
-	 * @param mixed $value
-	 */
-	public function registerParameter($name, $value)
- {
- }
+	public function registerParameter(string $name, mixed $value): void
+    {
+    }
 
-	/**
-	 * The given closure is call the first time the given service is queried.
-	 * The closure has to return the instance for the given service.
-	 * Created instance will be cached in case $shared is true.
-	 *
-	 * @param string $name name of the service to register another backend for
-	 * @param Closure $closure the closure to be called on service creation
-	 * @param bool $shared
-	 */
-	public function registerService($name, Closure $closure, $shared = true)
- {
- }
+	public function registerService(string $name, Closure $closure, bool $shared = true): void
+    {
+    }
 
 	/**
 	 * Shortcut for returning a service from a service under a different key,
@@ -92,49 +76,49 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	 * @param string $alias the alias that should be registered
 	 * @param string $target the target that should be resolved instead
 	 */
-	public function registerAlias($alias, $target): void
- {
- }
+	public function registerAlias(string $alias, string $target): void
+    {
+    }
 
 	protected function registerDeprecatedAlias(string $alias, string $target): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $name
 	 * @return string
 	 */
 	protected function sanitizeName($name)
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::has
 	 */
 	public function offsetExists($id): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 * @return mixed
 	 */
 	#[\ReturnTypeWillChange]
- public function offsetGet($id)
- {
- }
+    public function offsetGet($id)
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 use \OCP\IContainer::registerService
 	 */
 	public function offsetSet($offset, $value): void
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0
 	 */
 	public function offsetUnset($offset): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_core_command_base.php
+++ b/tests/stubs/oc_core_command_base.php
@@ -26,40 +26,40 @@ class Base extends Command implements CompletionAwareInterface {
 	protected string $defaultOutputFormat = self::OUTPUT_FORMAT_PLAIN;
 
 	protected function configure()
- {
- }
+    {
+    }
 
 	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, iterable $items, string $prefix = '  - '): void
- {
- }
+    {
+    }
 
 	protected function writeTableInOutputFormat(InputInterface $input, OutputInterface $output, array $items): void
- {
- }
+    {
+    }
 
 	protected function writeStreamingTableInOutputFormat(InputInterface $input, OutputInterface $output, \Iterator $items, int $tableGroupSize): void
- {
- }
+    {
+    }
 
 	protected function writeStreamingJsonArray(InputInterface $input, OutputInterface $output, \Iterator $items): void
- {
- }
+    {
+    }
 
 	public function chunkIterator(\Iterator $iterator, int $count): \Iterator
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param mixed $item
 	 */
 	protected function writeMixedInOutputFormat(InputInterface $input, OutputInterface $output, $item)
- {
- }
+    {
+    }
 
 	protected function valueToString($value, bool $returnNull = true): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * Throw InterruptedException when interrupted by user
@@ -67,8 +67,8 @@ class Base extends Command implements CompletionAwareInterface {
 	 * @throws InterruptedException
 	 */
 	protected function abortIfInterrupted()
- {
- }
+    {
+    }
 
 	/**
 	 * Changes the status of the command to "interrupted" if ctrl-c has been pressed
@@ -76,12 +76,12 @@ class Base extends Command implements CompletionAwareInterface {
 	 * Gives a chance to the command to properly terminate what it's doing
 	 */
 	public function cancelOperation(): void
- {
- }
+    {
+    }
 
 	public function run(InputInterface $input, OutputInterface $output): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $optionName
@@ -89,8 +89,8 @@ class Base extends Command implements CompletionAwareInterface {
 	 * @return string[]
 	 */
 	public function completeOptionValues($optionName, CompletionContext $context)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $argumentName
@@ -98,6 +98,6 @@ class Base extends Command implements CompletionAwareInterface {
 	 * @return string[]
 	 */
 	public function completeArgumentValues($argumentName, CompletionContext $context)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_db_connection.php
+++ b/tests/stubs/oc_db_connection.php
@@ -34,9 +34,12 @@ use OC\DB\QueryBuilder\Sharded\ShardConnectionManager;
 use OC\DB\QueryBuilder\Sharded\ShardDefinition;
 use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\ITypedQueryBuilder;
 use OCP\DB\QueryBuilder\Sharded\IShardMapper;
 use OCP\Diagnostics\IEventLogger;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\IRequestId;
@@ -50,27 +53,17 @@ use function count;
 use function in_array;
 
 class Connection extends PrimaryReadReplicaConnection {
-	/** @var string */
-	protected $tablePrefix;
-
-	/** @var \OC\DB\Adapter $adapter */
-	protected $adapter;
-
+	protected string $tablePrefix;
+	protected Adapter $adapter;
 	protected $lockedTable = null;
-
-	/** @var int */
-	protected $queriesBuilt = 0;
-
-	/** @var int */
-	protected $queriesExecuted = 0;
-
-	/** @var DbDataCollector|null */
-	protected $dbDataCollector = null;
+	protected int $queriesBuilt = 0;
+	protected int $queriesExecuted = 0;
+	protected ?DbDataCollector $dbDataCollector = null;
 
 	protected ?float $transactionActiveSince = null;
 
 	/** @var array<string, int> */
-	protected $tableDirtyWrites = [];
+	protected array $tableDirtyWrites = [];
 
 	protected bool $logDbException = false;
 
@@ -106,37 +99,41 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws \Exception
 	 */
 	public function __construct(private array $params, Driver $driver, ?Configuration $config = null, ?EventManager $eventManager = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @return IDBConnection[]
 	 */
 	public function getShardConnections(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @throws Exception
 	 */
 	public function connect($connectionName = null)
- {
- }
+    {
+    }
 
 	protected function performConnect(?string $connectionName = null): bool
- {
- }
+    {
+    }
 
 	public function getStats(): array
- {
- }
+    {
+    }
 
 	/**
 	 * Returns a QueryBuilder for the connection.
 	 */
 	public function getQueryBuilder(): IQueryBuilder
- {
- }
+    {
+    }
+
+	public function getTypedQueryBuilder(): ITypedQueryBuilder
+    {
+    }
 
 	/**
 	 * Gets the QueryBuilder for the connection.
@@ -145,8 +142,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @deprecated 8.0.0 please use $this->getQueryBuilder() instead
 	 */
 	public function createQueryBuilder()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the ExpressionBuilder for the connection.
@@ -155,8 +152,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @deprecated 8.0.0 please use $this->getQueryBuilder()->expr() instead
 	 */
 	public function getExpressionBuilder()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the file and line that called the method where `getCallerBacktrace()` was used
@@ -164,15 +161,12 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @return string
 	 */
 	protected function getCallerBacktrace()
- {
- }
+    {
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getPrefix()
- {
- }
+	public function getPrefix(): string
+    {
+    }
 
 	/**
 	 * Prepares an SQL statement.
@@ -185,8 +179,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws Exception
 	 */
 	public function prepare($sql, $limit = null, $offset = null): Statement
- {
- }
+    {
+    }
 
 	/**
 	 * Executes an, optionally parametrized, SQL query.
@@ -204,15 +198,15 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws \Doctrine\DBAL\Exception
 	 */
 	public function executeQuery(string $sql, array $params = [], $types = [], ?QueryCacheProfile $qcp = null): Result
- {
- }
+    {
+    }
 
 	/**
 	 * @throws Exception
 	 */
 	public function executeUpdate(string $sql, array $params = [], array $types = []): int
- {
- }
+    {
+    }
 
 	/**
 	 * Executes an SQL INSERT/UPDATE/DELETE query with the given parameters
@@ -229,12 +223,12 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws \Doctrine\DBAL\Exception
 	 */
 	public function executeStatement($sql, array $params = [], array $types = []): int
- {
- }
+    {
+    }
 
 	protected function logQueryToFile(string $sql, array $params): void
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the ID of the last inserted row, or the last value from a sequence object,
@@ -250,16 +244,16 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws Exception
 	 */
 	public function lastInsertId($name = null): int
- {
- }
+    {
+    }
 
 	/**
 	 * @internal
 	 * @throws Exception
 	 */
 	public function realLastInsertId($seqName = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Insert a row if the matching row does not exists. To accomplish proper race condition avoidance
@@ -276,12 +270,12 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (UniqueConstraintViolationException $e) {}" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
 	 */
 	public function insertIfNotExist($table, $input, ?array $compare = null)
- {
- }
+    {
+    }
 
 	public function insertIgnoreConflict(string $table, array $values): int
- {
- }
+    {
+    }
 
 	/**
 	 * Insert or update a row value
@@ -295,8 +289,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws PreConditionNotMetException
 	 */
 	public function setValues(string $table, array $keys, array $values, array $updatePreconditionValues = []): int
- {
- }
+    {
+    }
 
 	/**
 	 * Create an exclusive read+write lock on a table
@@ -308,8 +302,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @since 9.1.0
 	 */
 	public function lockTable($tableName)
- {
- }
+    {
+    }
 
 	/**
 	 * Release a previous acquired lock again
@@ -318,8 +312,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @since 9.1.0
 	 */
 	public function unlockTable()
- {
- }
+    {
+    }
 
 	/**
 	 * returns the error code and message as a string for logging
@@ -327,16 +321,16 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @return string
 	 */
 	public function getError()
- {
- }
+    {
+    }
 
 	public function errorCode()
- {
- }
+    {
+    }
 
 	public function errorInfo()
- {
- }
+    {
+    }
 
 	/**
 	 * Drop a table from the database if it exists
@@ -346,8 +340,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws Exception
 	 */
 	public function dropTable($table)
- {
- }
+    {
+    }
 
 	/**
 	 * Truncate a table data if it exists
@@ -358,8 +352,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws Exception
 	 */
 	public function truncateTable(string $table, bool $cascade)
- {
- }
+    {
+    }
 
 	/**
 	 * Check if a table exists
@@ -370,12 +364,12 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws Exception
 	 */
 	public function tableExists($table)
- {
- }
+    {
+    }
 
 	protected function finishQuery(string $statement): string
- {
- }
+    {
+    }
 
 	// internal use
 	/**
@@ -383,8 +377,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @return string
 	 */
 	protected function replaceTablePrefix($statement)
- {
- }
+    {
+    }
 
 	/**
 	 * Check if a transaction is active
@@ -393,8 +387,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @since 8.2.0
 	 */
 	public function inTransaction()
- {
- }
+    {
+    }
 
 	/**
 	 * Escape a parameter to be used in a LIKE query
@@ -403,8 +397,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @return string
 	 */
 	public function escapeLikeParameter($param)
- {
- }
+    {
+    }
 
 	/**
 	 * Check whether or not the current database support 4byte wide unicode
@@ -413,8 +407,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @since 11.0.0
 	 */
 	public function supports4ByteText()
- {
- }
+    {
+    }
 
 
 	/**
@@ -424,8 +418,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @throws Exception
 	 */
 	public function createSchema()
- {
- }
+    {
+    }
 
 	/**
 	 * Migrate the database to the given schema
@@ -438,35 +432,35 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @return string|null Returns a string only if $dryRun is true.
 	 */
 	public function migrateToSchema(Schema $toSchema, bool $dryRun = false)
- {
- }
+    {
+    }
 
 	public function beginTransaction()
- {
- }
+    {
+    }
 
 	public function commit()
- {
- }
+    {
+    }
 
 	public function rollBack()
- {
- }
+    {
+    }
 
 	/**
 	 * @return IDBConnection::PLATFORM_MYSQL|IDBConnection::PLATFORM_ORACLE|IDBConnection::PLATFORM_POSTGRES|IDBConnection::PLATFORM_SQLITE|IDBConnection::PLATFORM_MARIADB
 	 */
 	public function getDatabaseProvider(bool $strict = false): string
- {
- }
+    {
+    }
 
 	/**
 	 * @internal Should only be used inside the QueryBuilder, ExpressionBuilder and FunctionBuilder
 	 * All apps and API code should not need this and instead use provided functionality from the above.
 	 */
 	public function getServerVersion(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Log a database exception if enabled
@@ -475,14 +469,14 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @return void
 	 */
 	public function logDatabaseException(\Exception $exception): void
- {
- }
+    {
+    }
 
 	public function getShardDefinition(string $name): ?ShardDefinition
- {
- }
+    {
+    }
 
 	public function getCrossShardMoveHelper(): CrossShardMoveHelper
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_db_connectionadapter.php
+++ b/tests/stubs/oc_db_connectionadapter.php
@@ -17,166 +17,172 @@ use OC\DB\QueryBuilder\Sharded\ShardDefinition;
 use OCP\DB\IPreparedStatement;
 use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\ITypedQueryBuilder;
 use OCP\IDBConnection;
 
 /**
  * Adapts the public API to our internal DBAL connection wrapper
  */
 class ConnectionAdapter implements IDBConnection {
-	public function __construct(Connection $inner)
- {
- }
+	public function __construct(
+		private Connection $inner,
+	) {
+	}
 
 	public function getQueryBuilder(): IQueryBuilder
- {
- }
+    {
+    }
+
+	public function getTypedQueryBuilder(): ITypedQueryBuilder
+    {
+    }
 
 	public function prepare($sql, $limit = null, $offset = null): IPreparedStatement
- {
- }
+    {
+    }
 
 	public function executeQuery(string $sql, array $params = [], $types = []): IResult
- {
- }
+    {
+    }
 
 	public function executeUpdate(string $sql, array $params = [], array $types = []): int
- {
- }
+    {
+    }
 
 	public function executeStatement($sql, array $params = [], array $types = []): int
- {
- }
+    {
+    }
 
 	public function lastInsertId(string $table): int
- {
- }
+    {
+    }
 
 	public function insertIfNotExist(string $table, array $input, ?array $compare = null)
- {
- }
+    {
+    }
 
 	public function insertIgnoreConflict(string $table, array $values): int
- {
- }
+    {
+    }
 
 	public function setValues($table, array $keys, array $values, array $updatePreconditionValues = []): int
- {
- }
+    {
+    }
 
 	public function lockTable($tableName): void
- {
- }
+    {
+    }
 
 	public function unlockTable(): void
- {
- }
+    {
+    }
 
 	public function beginTransaction(): void
- {
- }
+    {
+    }
 
 	public function inTransaction(): bool
- {
- }
+    {
+    }
 
 	public function commit(): void
- {
- }
+    {
+    }
 
 	public function rollBack(): void
- {
- }
+    {
+    }
 
 	public function getError(): string
- {
- }
+    {
+    }
 
 	public function errorCode()
- {
- }
+    {
+    }
 
 	public function errorInfo()
- {
- }
+    {
+    }
 
 	public function connect(): bool
- {
- }
+    {
+    }
 
 	public function close(): void
- {
- }
+    {
+    }
 
 	public function quote($input, $type = IQueryBuilder::PARAM_STR)
- {
- }
+    {
+    }
 
 	/**
 	 * @todo we are leaking a 3rdparty type here
 	 */
 	public function getDatabasePlatform(): AbstractPlatform
- {
- }
+    {
+    }
 
 	public function dropTable(string $table): void
- {
- }
+    {
+    }
 
 	public function truncateTable(string $table, bool $cascade): void
- {
- }
+    {
+    }
 
 	public function tableExists(string $table): bool
- {
- }
+    {
+    }
 
 	public function escapeLikeParameter(string $param): string
- {
- }
+    {
+    }
 
 	public function supports4ByteText(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @todo leaks a 3rdparty type
 	 */
 	public function createSchema(): Schema
- {
- }
+    {
+    }
 
 	public function migrateToSchema(Schema $toSchema): void
- {
- }
+    {
+    }
 
 	public function getInner(): Connection
- {
- }
+    {
+    }
 
 	/**
 	 * @return self::PLATFORM_MYSQL|self::PLATFORM_ORACLE|self::PLATFORM_POSTGRES|self::PLATFORM_SQLITE|self::PLATFORM_MARIADB
 	 */
 	public function getDatabaseProvider(bool $strict = false): string
- {
- }
+    {
+    }
 
 	/**
 	 * @internal Should only be used inside the QueryBuilder, ExpressionBuilder and FunctionBuilder
 	 * All apps and API code should not need this and instead use provided functionality from the above.
 	 */
 	public function getServerVersion(): string
- {
- }
+    {
+    }
 
 	public function logDatabaseException(\Exception $exception)
- {
- }
+    {
+    }
 
 	public function getShardDefinition(string $name): ?ShardDefinition
- {
- }
+    {
+    }
 
 	public function getCrossShardMoveHelper(): CrossShardMoveHelper
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_db_querybuilder_querybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_querybuilder.php
@@ -19,38 +19,28 @@ use OC\DB\QueryBuilder\FunctionBuilder\PgSqlFunctionBuilder;
 use OC\DB\QueryBuilder\FunctionBuilder\SqliteFunctionBuilder;
 use OC\SystemConfig;
 use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\ConflictResolutionMode;
 use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IFunctionBuilder;
 use OCP\DB\QueryBuilder\ILiteral;
 use OCP\DB\QueryBuilder\IParameter;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\IDBConnection;
+use Override;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
-enum ConflictResolutionMode {
-	/**
-	 * Wait for the row to be unlocked.
-	 */
-	case Ordinary;
-	/**
-	 * Skip the row if it is locked.
-	 */
-	case SkipLocked;
-}
-
-class QueryBuilder implements IQueryBuilder {
-	/** @var string */
-	protected $lastInsertedTable;
+class QueryBuilder extends TypedQueryBuilder {
+	protected ?string $lastInsertedTable = null;
 
 	/**
 	 * Initializes a new QueryBuilder.
-	 *
-	 * @param ConnectionAdapter $connection
-	 * @param SystemConfig $systemConfig
 	 */
-	public function __construct(ConnectionAdapter $connection, SystemConfig $systemConfig, LoggerInterface $logger)
- {
- }
+	public function __construct(private ConnectionAdapter $connection, private SystemConfig $systemConfig, private LoggerInterface $logger)
+    {
+    }
 
 	/**
 	 * Enable/disable automatic prefixing of table names with the oc_ prefix
@@ -60,8 +50,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @since 8.2.0
 	 */
 	public function automaticTablePrefix($enabled)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets an ExpressionBuilder used for object-oriented construction of query expressions.
@@ -77,11 +67,11 @@ class QueryBuilder implements IQueryBuilder {
 	 * For more complex expression construction, consider storing the expression
 	 * builder object in a local variable.
 	 *
-	 * @return \OCP\DB\QueryBuilder\IExpressionBuilder
+	 * @return IExpressionBuilder
 	 */
 	public function expr()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets an FunctionBuilder used for object-oriented construction of query functions.
@@ -97,11 +87,11 @@ class QueryBuilder implements IQueryBuilder {
 	 * For more complex function construction, consider storing the function
 	 * builder object in a local variable.
 	 *
-	 * @return \OCP\DB\QueryBuilder\IFunctionBuilder
+	 * @return IFunctionBuilder
 	 */
 	public function func()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the type of the currently built query.
@@ -109,17 +99,17 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return integer
 	 */
 	public function getType()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the associated DBAL Connection for this query builder.
 	 *
-	 * @return \OCP\IDBConnection
+	 * @return IDBConnection
 	 */
 	public function getConnection()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the state of this query builder instance.
@@ -129,16 +119,16 @@ class QueryBuilder implements IQueryBuilder {
 	 *    and we can not fix this in our wrapper.
 	 */
 	public function getState()
- {
- }
+    {
+    }
 
 	public function executeQuery(?IDBConnection $connection = null): IResult
- {
- }
+    {
+    }
 
 	public function executeStatement(?IDBConnection $connection = null): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -154,8 +144,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return string The SQL query string.
 	 */
 	public function getSQL()
- {
- }
+    {
+    }
 
 	/**
 	 * Sets a query parameter for the query being constructed.
@@ -175,8 +165,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function setParameter($key, $value, $type = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Sets a collection of query parameters for the query being constructed.
@@ -198,8 +188,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function setParameters(array $params, array $types = [])
- {
- }
+    {
+    }
 
 	/**
 	 * Gets all defined query parameters for the query being constructed indexed by parameter index or name.
@@ -207,8 +197,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return array The currently defined query parameters indexed by parameter index or name.
 	 */
 	public function getParameters()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets a (previously set) query parameter of the query being constructed.
@@ -218,8 +208,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return mixed The value of the bound parameter.
 	 */
 	public function getParameter($key)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets all defined query parameter types for the query being constructed indexed by parameter index or name.
@@ -227,8 +217,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return array The currently defined query parameter types indexed by parameter index or name.
 	 */
 	public function getParameterTypes()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets a (previously set) query parameter type of the query being constructed.
@@ -238,8 +228,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return mixed The value of the bound parameter type.
 	 */
 	public function getParameterType($key)
- {
- }
+    {
+    }
 
 	/**
 	 * Sets the position of the first result to retrieve (the "offset").
@@ -249,8 +239,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function setFirstResult($firstResult)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the position of the first result the query object was set to retrieve (the "offset").
@@ -259,8 +249,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return int The position of the first result.
 	 */
 	public function getFirstResult()
- {
- }
+    {
+    }
 
 	/**
 	 * Sets the maximum number of results to retrieve (the "limit").
@@ -274,8 +264,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function setMaxResults($maxResults)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the maximum number of results the query object was set to retrieve (the "limit").
@@ -284,8 +274,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return int|null The maximum number of results.
 	 */
 	public function getMaxResults()
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies an item that is to be returned in the query result.
@@ -303,8 +293,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * '@return $this This QueryBuilder instance.
 	 */
 	public function select(...$selects)
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies an item that is to be returned with a different name in the query result.
@@ -321,9 +311,9 @@ class QueryBuilder implements IQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function selectAlias($select, $alias)
- {
- }
+	public function selectAlias($select, $alias): self
+    {
+    }
 
 	/**
 	 * Specifies an item that is to be returned uniquely in the query result.
@@ -339,8 +329,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function selectDistinct($select)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds an item that is to be returned in the query result.
@@ -353,17 +343,17 @@ class QueryBuilder implements IQueryBuilder {
 	 *         ->leftJoin('u', 'phonenumbers', 'u.id = p.user_id');
 	 * </code>
 	 *
-	 * @param mixed ...$selects The selection expression.
+	 * @param mixed ...$select The selection expression.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function addSelect(...$selects)
- {
- }
+	public function addSelect(...$select)
+    {
+    }
 
 	public function getOutputColumns(): array
- {
- }
+    {
+    }
 
 	/**
 	 * Turns the query being built into a bulk delete query that ranges over
@@ -383,8 +373,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @since 30.0.0 Alias is deprecated and will no longer be used with the next Doctrine/DBAL update
 	 */
 	public function delete($delete = null, $alias = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Turns the query being built into a bulk update query that ranges over
@@ -404,8 +394,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @since 30.0.0 Alias is deprecated and will no longer be used with the next Doctrine/DBAL update
 	 */
 	public function update($update = null, $alias = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Turns the query being built into an insert query that inserts into
@@ -427,8 +417,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function insert($insert = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates and adds a query root corresponding to the table identified by the
@@ -446,8 +436,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function from($from, $alias = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates and adds a join to the query.
@@ -467,8 +457,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function join($fromAlias, $join, $alias, $condition = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates and adds a join to the query.
@@ -488,8 +478,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function innerJoin($fromAlias, $join, $alias, $condition = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates and adds a left join to the query.
@@ -509,8 +499,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function leftJoin($fromAlias, $join, $alias, $condition = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates and adds a right join to the query.
@@ -530,8 +520,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function rightJoin($fromAlias, $join, $alias, $condition = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Sets a new value for a column in a bulk update query.
@@ -549,8 +539,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function set($key, $value)
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies one or more restrictions to the query result.
@@ -580,8 +570,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function where(...$predicates)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds one or more restrictions to the query results, forming a logical
@@ -602,8 +592,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @see where()
 	 */
 	public function andWhere(...$where)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds one or more restrictions to the query results, forming a logical
@@ -624,8 +614,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @see where()
 	 */
 	public function orWhere(...$where)
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies a grouping over the results of the query.
@@ -643,8 +633,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function groupBy(...$groupBys)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds a grouping expression to the query.
@@ -662,8 +652,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function addGroupBy(...$groupBy)
- {
- }
+    {
+    }
 
 	/**
 	 * Sets a value for a column in an insert query.
@@ -680,13 +670,13 @@ class QueryBuilder implements IQueryBuilder {
 	 * </code>
 	 *
 	 * @param string $column The column into which the value should be inserted.
-	 * @param IParameter|string $value The value that should be inserted into the column.
+	 * @param IParameter|IQueryFunction|string $value The value that should be inserted into the column.
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function setValue($column, $value)
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies values for an insert query indexed by column names.
@@ -708,8 +698,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function values(array $values)
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies a restriction over the groups of the query.
@@ -720,8 +710,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function having(...$having)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds a restriction over the groups of the query, forming a logical
@@ -732,8 +722,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function andHaving(...$having)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds a restriction over the groups of the query, forming a logical
@@ -744,8 +734,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function orHaving(...$having)
- {
- }
+    {
+    }
 
 	/**
 	 * Specifies an ordering for the query results.
@@ -757,8 +747,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function orderBy($sort, $order = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Adds an ordering to the query results.
@@ -769,8 +759,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 */
 	public function addOrderBy($sort, $order = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets a query part by its name.
@@ -782,8 +772,8 @@ class QueryBuilder implements IQueryBuilder {
 	 *   and we can not fix this in our wrapper. Please track the details you need, outside the object.
 	 */
 	public function getQueryPart($queryPartName)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets all query parts.
@@ -793,8 +783,8 @@ class QueryBuilder implements IQueryBuilder {
 	 *   and we can not fix this in our wrapper. Please track the details you need, outside the object.
 	 */
 	public function getQueryParts()
- {
- }
+    {
+    }
 
 	/**
 	 * Resets SQL parts.
@@ -806,8 +796,8 @@ class QueryBuilder implements IQueryBuilder {
 	 *  and we can not fix this in our wrapper. Please create a new IQueryBuilder instead.
 	 */
 	public function resetQueryParts($queryPartNames = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Resets a single SQL part.
@@ -819,8 +809,8 @@ class QueryBuilder implements IQueryBuilder {
 	 *  and we can not fix this in our wrapper. Please create a new IQueryBuilder instead.
 	 */
 	public function resetQueryPart($queryPartName)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a new named parameter and bind the value $value to it.
@@ -852,8 +842,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return IParameter the placeholder name used.
 	 */
 	public function createNamedParameter($value, $type = IQueryBuilder::PARAM_STR, $placeHolder = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a new positional parameter and bind the given value to it.
@@ -878,8 +868,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return IParameter
 	 */
 	public function createPositionalParameter($value, $type = IQueryBuilder::PARAM_STR)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a new parameter
@@ -898,8 +888,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return IParameter
 	 */
 	public function createParameter($name)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a new function
@@ -925,8 +915,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return IQueryFunction
 	 */
 	public function createFunction($call)
- {
- }
+    {
+    }
 
 	/**
 	 * Used to get the id of the last inserted element
@@ -934,8 +924,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @throws \BadMethodCallException When being called before an insert query has been run.
 	 */
 	public function getLastInsertId(): int
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the table name quoted and with database prefix as needed by the implementation
@@ -944,8 +934,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return string
 	 */
 	public function getTableName($table)
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the table name with database prefix as needed by the implementation
@@ -956,8 +946,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return string
 	 */
 	public function prefixTableName(string $table): string
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the column name quoted and with table alias prefix as needed by the implementation
@@ -967,8 +957,8 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return string
 	 */
 	public function getColumnName($column, $tableAlias = '')
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the column name quoted and with table alias prefix as needed by the implementation
@@ -977,21 +967,23 @@ class QueryBuilder implements IQueryBuilder {
 	 * @return string
 	 */
 	public function quoteAlias($alias)
- {
- }
+    {
+    }
 
 	public function escapeLikeParameter(string $parameter): string
- {
- }
+    {
+    }
 
 	public function hintShardKey(string $column, mixed $value, bool $overwrite = false): self
- {
- }
+    {
+    }
 
 	public function runAcrossAllShards(): self
- {
- }
+    {
+    }
 
-
-public function forUpdate(ConflictResolutionMode $conflictResolutionMode = ConflictResolutionMode::Ordinary): self {}
+	#[Override]
+    public function forUpdate(ConflictResolutionMode $conflictResolutionMode = ConflictResolutionMode::Ordinary): self
+    {
+    }
 }

--- a/tests/stubs/oc_db_querybuilder_typedquerybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_typedquerybuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\DB\QueryBuilder;
+
+use OCP\DB\QueryBuilder\ITypedQueryBuilder;
+use RuntimeException;
+
+/**
+ * @psalm-suppress InvalidTemplateParam
+ * @template-implements ITypedQueryBuilder<string>
+ */
+abstract class TypedQueryBuilder implements ITypedQueryBuilder {
+	public function selectColumns(string ...$columns): static
+    {
+    }
+
+	public function selectColumnsDistinct(string ...$columns): static
+    {
+    }
+}

--- a/tests/stubs/oc_db_schemawrapper.php
+++ b/tests/stubs/oc_db_schemawrapper.php
@@ -15,26 +15,22 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class SchemaWrapper implements ISchemaWrapper {
-	/** @var Connection */
-	protected $connection;
+	protected Schema $schema;
 
-	/** @var Schema */
-	protected $schema;
+	/** @var array<string, true> */
+	protected array $tablesToDelete = [];
 
-	/** @var array */
-	protected $tablesToDelete = [];
-
-	public function __construct(Connection $connection, ?Schema $schema = null)
- {
- }
+	public function __construct(protected Connection $connection, ?Schema $schema = null)
+    {
+    }
 
 	public function getWrappedSchema()
- {
- }
+    {
+    }
 
-	public function performDropTableCalls()
- {
- }
+	public function performDropTableCalls(): void
+    {
+    }
 
 	/**
 	 * Gets all table names
@@ -42,8 +38,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return array
 	 */
 	public function getTableNamesWithoutPrefix()
- {
- }
+    {
+    }
 
 	// Overwritten methods
 
@@ -51,8 +47,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return array
 	 */
 	public function getTableNames()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $tableName
@@ -61,8 +57,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @throws \Doctrine\DBAL\Schema\SchemaException
 	 */
 	public function getTable($tableName)
- {
- }
+    {
+    }
 
 	/**
 	 * Does this schema have a table with the given name?
@@ -72,8 +68,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return boolean
 	 */
 	public function hasTable($tableName)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a new table.
@@ -82,8 +78,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return \Doctrine\DBAL\Schema\Table
 	 */
 	public function createTable($tableName)
- {
- }
+    {
+    }
 
 	/**
 	 * Drops a table from the schema.
@@ -92,8 +88,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return \Doctrine\DBAL\Schema\Schema
 	 */
 	public function dropTable($tableName)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets all tables of this schema.
@@ -101,8 +97,8 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @return \Doctrine\DBAL\Schema\Table[]
 	 */
 	public function getTables()
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the DatabasePlatform for the database.
@@ -112,10 +108,10 @@ class SchemaWrapper implements ISchemaWrapper {
 	 * @throws Exception
 	 */
 	public function getDatabasePlatform()
- {
- }
+    {
+    }
 
 	public function dropAutoincrementColumn(string $table, string $column): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_cache.php
+++ b/tests/stubs/oc_files_cache_cache.php
@@ -7,6 +7,7 @@
  */
 namespace OC\Files\Cache;
 
+use OC\DatabaseException;
 use OC\DB\Exceptions\DbalException;
 use OC\DB\QueryBuilder\Sharded\ShardDefinition;
 use OC\Files\Cache\Wrapper\CacheJail;
@@ -15,9 +16,11 @@ use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\SystemConfig;
+use OCP\Constants;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\CacheEntriesRemovedEvent;
 use OCP\Files\Cache\CacheEntryInsertedEvent;
 use OCP\Files\Cache\CacheEntryRemovedEvent;
 use OCP\Files\Cache\CacheEntryUpdatedEvent;
@@ -25,6 +28,7 @@ use OCP\Files\Cache\CacheInsertEvent;
 use OCP\Files\Cache\CacheUpdateEvent;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\Search\ISearchComparison;
@@ -33,7 +37,9 @@ use OCP\Files\Search\ISearchQuery;
 use OCP\Files\Storage\IStorage;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IDBConnection;
+use OCP\Server;
 use OCP\Util;
+use Override;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -66,21 +72,21 @@ class Cache implements ICache {
 	protected IFilesMetadataManager $metadataManager;
 
 	public function __construct(
-     private IStorage $storage,
-     // this constructor is used in to many pleases to easily do proper di
-     // so instead we group it all together
-     ?CacheDependencies $dependencies = null
- )
- {
- }
+        private IStorage $storage,
+        // this constructor is used in to many pleases to easily do proper di
+        // so instead we group it all together
+        ?CacheDependencies $dependencies = null
+    )
+    {
+    }
 
 	protected function getQueryBuilder()
- {
- }
+    {
+    }
 
 	public function getStorageCache(): Storage
- {
- }
+    {
+    }
 
 	/**
 	 * Get the numeric storage id for this cache's storage
@@ -88,8 +94,8 @@ class Cache implements ICache {
 	 * @return int
 	 */
 	public function getNumericStorageId()
- {
- }
+    {
+    }
 
 	/**
 	 * get the stored metadata of a file or folder
@@ -98,35 +104,25 @@ class Cache implements ICache {
 	 * @return ICacheEntry|false the cache entry as array or false if the file is not found in the cache
 	 */
 	public function get($file)
- {
- }
+    {
+    }
 
 	/**
 	 * Create a CacheEntry from database row
 	 */
 	public static function cacheEntryFromData(array $data, IMimeTypeLoader $mimetypeLoader): CacheEntry
- {
- }
+    {
+    }
 
-	/**
-	 * get the metadata of all files stored in $folder
-	 *
-	 * @param string $folder
-	 * @return ICacheEntry[]
-	 */
-	public function getFolderContents($folder)
- {
- }
+	#[Override]
+    public function getFolderContents(string $folder, ?string $mimeTypeFilter = null)
+    {
+    }
 
-	/**
-	 * get the metadata of all files stored in $folder
-	 *
-	 * @param int $fileId the file id of the folder
-	 * @return ICacheEntry[]
-	 */
-	public function getFolderContentsById($fileId)
- {
- }
+	#[Override]
+    public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null)
+    {
+    }
 
 	/**
 	 * insert or update meta data for a file or folder
@@ -138,8 +134,8 @@ class Cache implements ICache {
 	 * @throws \RuntimeException
 	 */
 	public function put($file, array $data)
- {
- }
+    {
+    }
 
 	/**
 	 * insert meta data for a new file or folder
@@ -151,8 +147,8 @@ class Cache implements ICache {
 	 * @throws \RuntimeException|Exception
 	 */
 	public function insert($file, array $data)
- {
- }
+    {
+    }
 
 	/**
 	 * update the metadata of an existing file or folder in the cache
@@ -161,8 +157,8 @@ class Cache implements ICache {
 	 * @param array $data [$key => $value] the metadata to update, only the fields provided in the array will be updated, non-provided values will remain unchanged
 	 */
 	public function update($id, array $data)
- {
- }
+    {
+    }
 
 	/**
 	 * extract query parts and params array from data array
@@ -171,8 +167,8 @@ class Cache implements ICache {
 	 * @return array
 	 */
 	protected function normalizeData(array $data): array
- {
- }
+    {
+    }
 
 	/**
 	 * get the file id for a file
@@ -185,8 +181,8 @@ class Cache implements ICache {
 	 * @return int
 	 */
 	public function getId($file)
- {
- }
+    {
+    }
 
 	/**
 	 * get the id of the parent folder of a file
@@ -195,8 +191,8 @@ class Cache implements ICache {
 	 * @return int
 	 */
 	public function getParentId($file)
- {
- }
+    {
+    }
 
 	/**
 	 * check if a file is available in the cache
@@ -205,8 +201,8 @@ class Cache implements ICache {
 	 * @return bool
 	 */
 	public function inCache($file)
- {
- }
+    {
+    }
 
 	/**
 	 * remove a file or folder from the cache
@@ -216,8 +212,8 @@ class Cache implements ICache {
 	 * @param string $file
 	 */
 	public function remove($file)
- {
- }
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -226,8 +222,8 @@ class Cache implements ICache {
 	 * @param string $target
 	 */
 	public function move($source, $target)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the storage id and path needed for a move
@@ -236,16 +232,16 @@ class Cache implements ICache {
 	 * @return array [$storageId, $internalPath]
 	 */
 	protected function getMoveInfo($path)
- {
- }
+    {
+    }
 
 	protected function hasEncryptionWrapper(): bool
- {
- }
+    {
+    }
 
 	protected function shouldEncrypt(string $targetPath): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -253,19 +249,19 @@ class Cache implements ICache {
 	 * @param ICache $sourceCache
 	 * @param string $sourcePath
 	 * @param string $targetPath
-	 * @throws \OC\DatabaseException
+	 * @throws DatabaseException
 	 * @throws \Exception if the given storages have an invalid id
 	 */
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
- {
- }
+    {
+    }
 
 	/**
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
 	public function clear()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the scan status of a file
@@ -280,8 +276,8 @@ class Cache implements ICache {
 	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
 	public function getStatus($file)
- {
- }
+    {
+    }
 
 	/**
 	 * search for files matching $pattern
@@ -290,8 +286,8 @@ class Cache implements ICache {
 	 * @return ICacheEntry[] an array of cache entries where the name matches the search pattern
 	 */
 	public function search($pattern)
- {
- }
+    {
+    }
 
 	/**
 	 * search for files by mimetype
@@ -301,12 +297,12 @@ class Cache implements ICache {
 	 * @return ICacheEntry[] an array of cache entries where the mimetype matches the search
 	 */
 	public function searchByMime($mimetype)
- {
- }
+    {
+    }
 
 	public function searchQuery(ISearchQuery $query)
- {
- }
+    {
+    }
 
 	/**
 	 * Re-calculate the folder size and the size of all parent folders
@@ -314,8 +310,8 @@ class Cache implements ICache {
 	 * @param array|ICacheEntry|null $data (optional) meta data of the folder
 	 */
 	public function correctFolderSize(string $path, $data = null, bool $isBackgroundScan = false): void
- {
- }
+    {
+    }
 
 	/**
 	 * get the incomplete count that shares parent $folder
@@ -324,8 +320,8 @@ class Cache implements ICache {
 	 * @return int
 	 */
 	public function getIncompleteChildrenCount($fileId)
- {
- }
+    {
+    }
 
 	/**
 	 * calculate the size of a folder and set it in the cache
@@ -335,8 +331,8 @@ class Cache implements ICache {
 	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null)
- {
- }
+    {
+    }
 
 
 	/**
@@ -348,8 +344,8 @@ class Cache implements ICache {
 	 * @return int|float
 	 */
 	protected function calculateFolderSizeInner(string $path, $entry = null, bool $ignoreUnknown = false)
- {
- }
+    {
+    }
 
 	/**
 	 * get all file ids on the files on the storage
@@ -357,8 +353,8 @@ class Cache implements ICache {
 	 * @return int[]
 	 */
 	public function getAll()
- {
- }
+    {
+    }
 
 	/**
 	 * find a folder in the cache which has not been fully scanned
@@ -370,8 +366,8 @@ class Cache implements ICache {
 	 * @return string|false the path of the folder or false when no folder matched
 	 */
 	public function getIncomplete()
- {
- }
+    {
+    }
 
 	/**
 	 * get the path of a file on this storage by it's file id
@@ -380,8 +376,8 @@ class Cache implements ICache {
 	 * @return string|null the path of the file (relative to the storage) or null if a file with the given id does not exists within this cache
 	 */
 	public function getPathById($id)
- {
- }
+    {
+    }
 
 	/**
 	 * get the storage id of the storage for a file and the internal path of the file
@@ -393,8 +389,8 @@ class Cache implements ICache {
 	 * @deprecated 17.0.0 use getPathById() instead
 	 */
 	public static function getById($id)
- {
- }
+    {
+    }
 
 	/**
 	 * normalize the given path
@@ -403,8 +399,8 @@ class Cache implements ICache {
 	 * @return string
 	 */
 	public function normalize($path)
- {
- }
+    {
+    }
 
 	/**
 	 * Copy a file or folder in the cache
@@ -415,14 +411,14 @@ class Cache implements ICache {
 	 * @return int fileId of copied entry
 	 */
 	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int
- {
- }
+    {
+    }
 
 	public function getQueryFilterForStorage(): ISearchOperator
- {
- }
+    {
+    }
 
 	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_cacheentry.php
+++ b/tests/stubs/oc_files_cache_cacheentry.php
@@ -19,102 +19,102 @@ class CacheEntry implements ICacheEntry {
 	}
 
 	public function offsetSet($offset, $value): void
- {
- }
+    {
+    }
 
 	public function offsetExists($offset): bool
- {
- }
+    {
+    }
 
 	public function offsetUnset($offset): void
- {
- }
+    {
+    }
 
 	/**
 	 * @return mixed
 	 */
 	#[\ReturnTypeWillChange]
- public function offsetGet($offset)
- {
- }
+    public function offsetGet($offset)
+    {
+    }
 
 	public function getId()
- {
- }
+    {
+    }
 
 	public function getStorageId()
- {
- }
+    {
+    }
 
 
 	public function getPath()
- {
- }
+    {
+    }
 
 
 	public function getName()
- {
- }
+    {
+    }
 
 
 	public function getMimeType(): string
- {
- }
+    {
+    }
 
 
 	public function getMimePart()
- {
- }
+    {
+    }
 
 	public function getSize()
- {
- }
+    {
+    }
 
 	public function getMTime()
- {
- }
+    {
+    }
 
 	public function getStorageMTime()
- {
- }
+    {
+    }
 
 	public function getEtag()
- {
- }
+    {
+    }
 
 	public function getPermissions(): int
- {
- }
+    {
+    }
 
 	public function isEncrypted()
- {
- }
+    {
+    }
 
 	public function getMetadataEtag(): ?string
- {
- }
+    {
+    }
 
 	public function getCreationTime(): ?int
- {
- }
+    {
+    }
 
 	public function getUploadTime(): ?int
- {
- }
+    {
+    }
 
 	public function getParentId(): int
- {
- }
+    {
+    }
 
 	public function getData()
- {
- }
+    {
+    }
 
 	public function __clone()
- {
- }
+    {
+    }
 
 	public function getUnencryptedSize(): int
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_mount_manager.php
+++ b/tests/stubs/oc_files_mount_manager.php
@@ -19,40 +19,27 @@ use OCP\Files\NotFoundException;
 
 class Manager implements IMountManager {
 	public function __construct(SetupManagerFactory $setupManagerFactory)
- {
- }
+    {
+    }
 
-	/**
-	 * @param IMountPoint $mount
-	 */
-	public function addMount(IMountPoint $mount)
- {
- }
+	public function addMount(IMountPoint $mount): void
+    {
+    }
 
-	/**
-	 * @param string $mountPoint
-	 */
-	public function removeMount(string $mountPoint)
- {
- }
+	public function removeMount(string $mountPoint): void
+    {
+    }
 
-	/**
-	 * @param string $mountPoint
-	 * @param string $target
-	 */
-	public function moveMount(string $mountPoint, string $target)
- {
- }
+	public function moveMount(string $mountPoint, string $target): void
+    {
+    }
 
 	/**
 	 * Find the mount for $path
-	 *
-	 * @param string $path
-	 * @return IMountPoint
 	 */
 	public function find(string $path): IMountPoint
- {
- }
+    {
+    }
 
 	/**
 	 * Find all mounts in $path
@@ -60,12 +47,12 @@ class Manager implements IMountManager {
 	 * @return IMountPoint[]
 	 */
 	public function findIn(string $path): array
- {
- }
+    {
+    }
 
 	public function clear(): void
- {
- }
+    {
+    }
 
 	/**
 	 * Find mounts by storage id
@@ -74,15 +61,15 @@ class Manager implements IMountManager {
 	 * @return IMountPoint[]
 	 */
 	public function findByStorageId(string $id): array
- {
- }
+    {
+    }
 
 	/**
 	 * @return IMountPoint[]
 	 */
 	public function getAll(): array
- {
- }
+    {
+    }
 
 	/**
 	 * Find mounts by numeric storage id
@@ -91,23 +78,23 @@ class Manager implements IMountManager {
 	 * @return IMountPoint[]
 	 */
 	public function findByNumericId(int $id): array
- {
- }
+    {
+    }
 
 	public function getSetupManager(): SetupManager
- {
- }
+    {
+    }
 
 	/**
-	 * Return all mounts in a path from a specific mount provider
+	 * Return all mounts in a path from a specific mount provider, indexed by mount point
 	 *
 	 * @param string $path
 	 * @param string[] $mountProviders
-	 * @return MountPoint[]
+	 * @return array<string, IMountPoint>
 	 */
-	public function getMountsByMountProvider(string $path, array $mountProviders)
- {
- }
+	public function getMountsByMountProvider(string $path, array $mountProviders): array
+    {
+    }
 
 	/**
 	 * Return the mount matching a cached mount info (or mount file info)
@@ -117,6 +104,6 @@ class Manager implements IMountManager {
 	 * @return IMountPoint|null
 	 */
 	public function getMountFromMountInfo(ICachedMountInfo $info): ?IMountPoint
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_mount_mountpoint.php
+++ b/tests/stubs/oc_files_mount_mountpoint.php
@@ -11,53 +11,43 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\StorageFactory;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class MountPoint implements IMountPoint {
-	/**
-	 * @var \OC\Files\Storage\Storage|null $storage
-	 */
+	/** @var IStorage|null $storage */
 	protected $storage = null;
-	protected $class;
-	protected $storageId;
-	protected $numericStorageId = null;
-	protected $rootId = null;
+	/** @var class-string<IStorage> */
+	protected string $class;
+	protected ?string $storageId = null;
+	protected ?int $numericStorageId = null;
+	protected ?int $rootId = null;
 
 	/**
 	 * Configuration options for the storage backend
-	 *
-	 * @var array
 	 */
-	protected $arguments = [];
-	protected $mountPoint;
+	protected array $arguments = [];
+	protected string $mountPoint;
 
 	/**
 	 * Mount specific options
-	 *
-	 * @var array
 	 */
-	protected $mountOptions = [];
-
-	/** @var int|null */
-	protected $mountId;
-
-	/** @var string */
-	protected $mountProvider;
+	protected array $mountOptions = [];
+	protected string $mountProvider;
 
 	/**
-	 * @param string|\OC\Files\Storage\Storage $storage
-	 * @param string $mountpoint
+	 * @param IStorage|class-string<IStorage> $storage
 	 * @param array $arguments (optional) configuration for the storage backend
-	 * @param \OCP\Files\Storage\IStorageFactory $loader
-	 * @param array $mountOptions mount specific options
-	 * @param int|null $mountId
-	 * @param string|null $mountProvider
+	 * @param ?array $mountOptions mount specific options
+	 * @param ?int $mountId
+	 * @param ?string $mountProvider
 	 * @throws \Exception
 	 */
-	public function __construct($storage, string $mountpoint, ?array $arguments = null, ?IStorageFactory $loader = null, ?array $mountOptions = null, ?int $mountId = null, ?string $mountProvider = null)
- {
- }
+	public function __construct(string|IStorage $storage, string $mountpoint, ?array $arguments = null, ?IStorageFactory $loader = null, ?array $mountOptions = null, protected ?int $mountId = null, ?string $mountProvider = null)
+    {
+    }
 
 	/**
 	 * get complete path to the mount point, relative to data/
@@ -65,8 +55,8 @@ class MountPoint implements IMountPoint {
 	 * @return string
 	 */
 	public function getMountPoint()
- {
- }
+    {
+    }
 
 	/**
 	 * Sets the mount point path, relative to data/
@@ -74,44 +64,44 @@ class MountPoint implements IMountPoint {
 	 * @param string $mountPoint new mount point
 	 */
 	public function setMountPoint($mountPoint)
- {
- }
+    {
+    }
 
 	/**
-	 * @return \OC\Files\Storage\Storage|null
+	 * @return IStorage|null
 	 */
 	public function getStorage()
- {
- }
+    {
+    }
 
 	/**
 	 * @return string|null
 	 */
 	public function getStorageId()
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getNumericStorageId()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return string
 	 */
 	public function getInternalPath($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param callable $wrapper
 	 */
 	public function wrapStorage($wrapper)
- {
- }
+    {
+    }
 
 	/**
 	 * Get a mount option
@@ -121,8 +111,8 @@ class MountPoint implements IMountPoint {
 	 * @return mixed
 	 */
 	public function getOption($name, $default)
- {
- }
+    {
+    }
 
 	/**
 	 * Get all options for the mount
@@ -130,8 +120,8 @@ class MountPoint implements IMountPoint {
 	 * @return array
 	 */
 	public function getOptions()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the file id of the root of the storage
@@ -139,18 +129,18 @@ class MountPoint implements IMountPoint {
 	 * @return int
 	 */
 	public function getStorageRootId()
- {
- }
+    {
+    }
 
 	public function getMountId()
- {
- }
+    {
+    }
 
 	public function getMountType()
- {
- }
+    {
+    }
 
 	public function getMountProvider(): string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_group_group.php
+++ b/tests/stubs/oc_group_group.php
@@ -9,11 +9,16 @@ namespace OC\Group;
 
 use OC\Hooks\PublicEmitter;
 use OC\User\LazyUser;
+use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Group\Backend\IAddToGroupBackend;
 use OCP\Group\Backend\ICountDisabledInGroup;
+use OCP\Group\Backend\ICountUsersBackend;
+use OCP\Group\Backend\IDeleteGroupBackend;
 use OCP\Group\Backend\IGetDisplayNameBackend;
 use OCP\Group\Backend\IHideFromCollaborationBackend;
 use OCP\Group\Backend\INamedBackend;
+use OCP\Group\Backend\IRemoveFromGroupBackend;
 use OCP\Group\Backend\ISearchableGroupBackend;
 use OCP\Group\Backend\ISetDisplayNameBackend;
 use OCP\Group\Events\BeforeGroupChangedEvent;
@@ -28,35 +33,40 @@ use OCP\GroupInterface;
 use OCP\IGroup;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 
 class Group implements IGroup {
-	/** @var null|string */
-	protected $displayName;
-
-	public function __construct(string $gid, array $backends, IEventDispatcher $dispatcher, IUserManager $userManager, ?PublicEmitter $emitter = null, ?string $displayName = null)
- {
- }
+	public function __construct(
+		private string $gid,
+		/** @var list<GroupInterface> */
+		private array $backends,
+		private IEventDispatcher $dispatcher,
+		private IUserManager $userManager,
+		private ?PublicEmitter $emitter = null,
+		protected ?string $displayName = null,
+	) {
+	}
 
 	public function getGID(): string
- {
- }
+    {
+    }
 
 	public function getDisplayName(): string
- {
- }
+    {
+    }
 
 	public function setDisplayName(string $displayName): bool
- {
- }
+    {
+    }
 
 	/**
 	 * get all users in the group
 	 *
-	 * @return \OC\User\User[]
+	 * @return array<string, IUser>
 	 */
 	public function getUsers(): array
- {
- }
+    {
+    }
 
 	/**
 	 * check if a user is in the group
@@ -65,8 +75,8 @@ class Group implements IGroup {
 	 * @return bool
 	 */
 	public function inGroup(IUser $user): bool
- {
- }
+    {
+    }
 
 	/**
 	 * add a user to the group
@@ -74,23 +84,23 @@ class Group implements IGroup {
 	 * @param IUser $user
 	 */
 	public function addUser(IUser $user): void
- {
- }
+    {
+    }
 
 	/**
 	 * remove a user from the group
 	 */
 	public function removeUser(IUser $user): void
- {
- }
+    {
+    }
 
 	/**
 	 * Search for users in the group by userid or display name
 	 * @return IUser[]
 	 */
 	public function searchUsers(string $search, ?int $limit = null, ?int $offset = null): array
- {
- }
+    {
+    }
 
 	/**
 	 * returns the number of users matching the search string
@@ -99,8 +109,8 @@ class Group implements IGroup {
 	 * @return int|bool
 	 */
 	public function count($search = ''): int|bool
- {
- }
+    {
+    }
 
 	/**
 	 * returns the number of disabled users
@@ -108,8 +118,8 @@ class Group implements IGroup {
 	 * @return int|bool
 	 */
 	public function countDisabled(): int|bool
- {
- }
+    {
+    }
 
 	/**
 	 * search for users in the group by displayname
@@ -121,8 +131,8 @@ class Group implements IGroup {
 	 * @deprecated 27.0.0 Use searchUsers instead (same implementation)
 	 */
 	public function searchDisplayName(string $search, ?int $limit = null, ?int $offset = null): array
- {
- }
+    {
+    }
 
 	/**
 	 * Get the names of the backend classes the group is connected to
@@ -130,8 +140,8 @@ class Group implements IGroup {
 	 * @return string[]
 	 */
 	public function getBackendNames(): array
- {
- }
+    {
+    }
 
 	/**
 	 * Delete the group
@@ -139,30 +149,30 @@ class Group implements IGroup {
 	 * @return bool
 	 */
 	public function delete(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @since 14.0.0
 	 */
 	public function canRemoveUser(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @since 14.0.0
 	 */
 	public function canAddUser(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @since 16.0.0
 	 */
 	public function hideFromCollaboration(): bool
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_group_manager.php
+++ b/tests/stubs/oc_group_manager.php
@@ -9,6 +9,8 @@ namespace OC\Group;
 
 use OC\Hooks\PublicEmitter;
 use OC\Settings\AuthorizedGroupMapper;
+use OC\SubAdmin;
+use OCA\Settings\Settings\Admin\Users;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Backend\IBatchMethodsBackend;
 use OCP\Group\Backend\ICreateNamedGroupBackend;
@@ -17,10 +19,12 @@ use OCP\Group\Events\BeforeGroupCreatedEvent;
 use OCP\Group\Events\GroupCreatedEvent;
 use OCP\GroupInterface;
 use OCP\ICacheFactory;
+use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Security\Ip\IRemoteAddress;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use function is_string;
 
@@ -43,8 +47,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 	private const MAX_GROUP_LENGTH = 255;
 
 	public function __construct(private \OC\User\Manager $userManager, private IEventDispatcher $dispatcher, private LoggerInterface $logger, ICacheFactory $cacheFactory, private IRemoteAddress $remoteAddress)
- {
- }
+    {
+    }
 
 	/**
 	 * Checks whether a given backend is used
@@ -53,50 +57,50 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return bool
 	 */
 	public function isBackendUsed($backendClass)
- {
- }
+    {
+    }
 
 	/**
-	 * @param \OCP\GroupInterface $backend
+	 * @param GroupInterface $backend
 	 */
 	public function addBackend($backend)
- {
- }
+    {
+    }
 
 	public function clearBackends()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the active backends
 	 *
-	 * @return \OCP\GroupInterface[]
+	 * @return GroupInterface[]
 	 */
 	public function getBackends()
- {
- }
+    {
+    }
 
 
 	protected function clearCaches()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @return IGroup|null
 	 */
 	public function get($gid)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @param string $displayName
-	 * @return \OCP\IGroup|null
+	 * @return IGroup|null
 	 */
 	protected function getGroupObject($gid, $displayName = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @brief Batch method to create group objects
@@ -106,44 +110,44 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return array<string, IGroup>
 	 */
 	protected function getGroupsObjects(array $gids, array $displayNames = []): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @return bool
 	 */
 	public function groupExists($gid)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @return IGroup|null
 	 */
 	public function createGroup($gid)
- {
- }
+    {
+    }
 
 	public function search(string $search, ?int $limit = null, ?int $offset = 0)
- {
- }
+    {
+    }
 
 	/**
 	 * @param IUser|null $user
-	 * @return \OC\Group\Group[]
+	 * @return array<string, IGroup>
 	 */
-	public function getUserGroups(?IUser $user = null)
- {
- }
+	public function getUserGroups(?IUser $user = null): array
+    {
+    }
 
 	/**
 	 * @param string $uid the user id
-	 * @return \OC\Group\Group[]
+	 * @return array<string, IGroup>
 	 */
 	public function getUserIdGroups(string $uid): array
- {
- }
+    {
+    }
 
 	/**
 	 * Checks if a userId is in the admin group
@@ -152,12 +156,12 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return bool if admin
 	 */
 	public function isAdmin($userId)
- {
- }
+    {
+    }
 
 	public function isDelegatedAdmin(string $userId): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Checks if a userId is in a group
@@ -167,20 +171,20 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return bool if in group
 	 */
 	public function isInGroup($userId, $group)
- {
- }
+    {
+    }
 
 	public function getUserGroupIds(IUser $user): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $groupId
 	 * @return ?string
 	 */
 	public function getDisplayName(string $groupId): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * get an array of groupid and displayName for a user
@@ -189,26 +193,17 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return array ['displayName' => displayname]
 	 */
 	public function getUserGroupNames(IUser $user)
- {
- }
+    {
+    }
 
-	/**
-	 * get a list of all display names in a group
-	 *
-	 * @param string $gid
-	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
-	 * @return array an array of display names (value) and user ids (key)
-	 */
 	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0)
- {
- }
+    {
+    }
 
 	/**
-	 * @return \OC\SubAdmin
+	 * @return SubAdmin
 	 */
 	public function getSubAdmin()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_hooks_basicemitter.php
+++ b/tests/stubs/oc_hooks_basicemitter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/tests/stubs/oc_hooks_emitter.php
+++ b/tests/stubs/oc_hooks_emitter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -24,8 +26,8 @@ interface Emitter {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */
 	public function listen($scope, $method, callable $callback)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $scope optional
@@ -35,6 +37,6 @@ interface Emitter {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::removeListener
 	 */
 	public function removeListener($scope = null, $method = null, ?callable $callback = null)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_hooks_publicemitter.php
+++ b/tests/stubs/oc_hooks_publicemitter.php
@@ -20,6 +20,6 @@ class PublicEmitter extends BasicEmitter {
 	 * @suppress PhanAccessMethodProtected
 	 */
 	public function emit($scope, $method, array $arguments = [])
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_server.php
+++ b/tests/stubs/oc_server.php
@@ -9,35 +9,48 @@ namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
 use OC\Accounts\AccountManager;
+use OC\Activity\EventMerger;
 use OC\App\AppManager;
 use OC\App\AppStore\Bundles\BundleFetcher;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Http\RequestId;
 use OC\AppFramework\Services\AppConfig;
+use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Authentication\Events\LoginFailed;
 use OC\Authentication\Listeners\LoginFailedListener;
 use OC\Authentication\Listeners\UserLoggedInListener;
 use OC\Authentication\LoginCredentials\Store;
 use OC\Authentication\Token\IProvider;
+use OC\Authentication\TwoFactorAuth\Registry;
 use OC\Avatar\AvatarManager;
+use OC\BackgroundJob\JobList;
 use OC\Blurhash\Listener\GenerateBlurhashMetadata;
 use OC\Collaboration\Collaborators\GroupPlugin;
 use OC\Collaboration\Collaborators\MailByMailPlugin;
 use OC\Collaboration\Collaborators\RemoteGroupPlugin;
 use OC\Collaboration\Collaborators\RemotePlugin;
+use OC\Collaboration\Collaborators\Search;
+use OC\Collaboration\Collaborators\SearchResult;
 use OC\Collaboration\Collaborators\UserByMailPlugin;
 use OC\Collaboration\Collaborators\UserPlugin;
 use OC\Collaboration\Reference\ReferenceManager;
+use OC\Collaboration\Resources\ProviderManager;
 use OC\Command\CronBus;
 use OC\Comments\ManagerFactory as CommentsManagerFactory;
+use OC\Config\UserConfig;
 use OC\Contacts\ContactsMenu\ActionFactory;
 use OC\Contacts\ContactsMenu\ContactsStore;
+use OC\ContextChat\ContentManager;
 use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
+use OC\DB\ConnectionFactory;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\QueryLogger;
+use OC\Encryption\File;
+use OC\Encryption\Keys\Storage;
+use OC\EventDispatcher\EventDispatcher;
 use OC\Federation\CloudFederationFactory;
 use OC\Federation\CloudFederationProviderManager;
 use OC\Federation\CloudIdManager;
@@ -46,6 +59,7 @@ use OC\Files\Config\MountProviderCollection;
 use OC\Files\Config\UserMountCache;
 use OC\Files\Config\UserMountCacheListener;
 use OC\Files\Conversion\ConversionManager;
+use OC\Files\FilenameValidator;
 use OC\Files\Lock\LockManager;
 use OC\Files\Mount\CacheMountProvider;
 use OC\Files\Mount\LocalHomeMountProvider;
@@ -58,6 +72,7 @@ use OC\Files\ObjectStore\PrimaryObjectStoreConfig;
 use OC\Files\SetupManager;
 use OC\Files\Storage\StorageFactory;
 use OC\Files\Template\TemplateManager;
+use OC\Files\Type\Detection;
 use OC\Files\Type\Loader;
 use OC\Files\View;
 use OC\FilesMetadata\FilesMetadataManager;
@@ -79,41 +94,52 @@ use OC\Mail\EmailValidator;
 use OC\Mail\Mailer;
 use OC\Memcache\ArrayCache;
 use OC\Memcache\Factory;
+use OC\Memcache\NullCache;
+use OC\Memcache\Redis;
 use OC\Notification\Manager;
 use OC\OCM\Model\OCMProvider;
 use OC\OCM\OCMDiscoveryService;
+use OC\OCS\CoreCapabilities;
 use OC\OCS\DiscoveryService;
 use OC\Preview\Db\PreviewMapper;
 use OC\Preview\GeneratorHelper;
 use OC\Preview\IMagickSupport;
 use OC\Preview\MimeIconProvider;
 use OC\Preview\Watcher;
+use OC\Preview\WatcherConnector;
 use OC\Profile\ProfileManager;
 use OC\Profiler\Profiler;
 use OC\Remote\Api\ApiFactory;
 use OC\Remote\InstanceFactory;
+use OC\RichObjectStrings\RichTextFormatter;
 use OC\RichObjectStrings\Validator;
 use OC\Route\CachingRouter;
 use OC\Route\Router;
+use OC\Security\Bruteforce\Capabilities;
 use OC\Security\Bruteforce\Throttler;
 use OC\Security\CertificateManager;
 use OC\Security\CredentialsManager;
 use OC\Security\Crypto;
 use OC\Security\CSP\ContentSecurityPolicyManager;
-use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OC\Security\CSRF\CsrfTokenManager;
 use OC\Security\CSRF\TokenStorage\SessionStorage;
 use OC\Security\Hasher;
 use OC\Security\Ip\RemoteAddress;
+use OC\Security\RateLimiting\Backend\DatabaseBackend;
+use OC\Security\RateLimiting\Backend\IBackend;
+use OC\Security\RateLimiting\Backend\MemoryCacheBackend;
 use OC\Security\RateLimiting\Limiter;
+use OC\Security\RemoteHostValidator;
 use OC\Security\SecureRandom;
 use OC\Security\Signature\SignatureManager;
 use OC\Security\TrustedDomainHelper;
 use OC\Security\VerificationToken\VerificationToken;
 use OC\Session\CryptoWrapper;
+use OC\Session\Memory;
 use OC\Settings\DeclarativeManager;
 use OC\SetupCheck\SetupCheckManager;
 use OC\Share20\ProviderFactory;
+use OC\Share20\PublicShareTemplateFactory;
 use OC\Share20\ShareHelper;
 use OC\Snowflake\APCuSequence;
 use OC\Snowflake\FileSequence;
@@ -121,6 +147,7 @@ use OC\Snowflake\ISequence;
 use OC\Snowflake\SnowflakeDecoder;
 use OC\Snowflake\SnowflakeGenerator;
 use OC\SpeechToText\SpeechToTextManager;
+use OC\Support\Subscription\Assertion;
 use OC\SystemTag\ManagerFactory as SystemTagManagerFactory;
 use OC\Talk\Broker;
 use OC\Teams\TeamManager;
@@ -131,22 +158,32 @@ use OC\User\DisplayNameCache;
 use OC\User\Listeners\BeforeUserDeletedListener;
 use OC\User\Listeners\UserChangedListener;
 use OC\User\Session;
+use OC\User\User;
 use OCA\Theming\ImageManager;
 use OCA\Theming\Service\BackgroundService;
 use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
 use OCP\Accounts\IAccountManager;
+use OCP\Activity\IEventMerger;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\IControllerMethodReflector;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\AutoloadNotAllowedException;
 use OCP\BackgroundJob\IJobList;
+use OCP\Collaboration\Collaborators\ISearch;
+use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Reference\IReferenceManager;
+use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Command\IBus;
 use OCP\Comments\ICommentsManager;
+use OCP\Comments\ICommentsManagerFactory;
 use OCP\Config\IUserConfig;
 use OCP\Contacts\ContactsMenu\IActionFactory;
 use OCP\Contacts\ContactsMenu\IContactsStore;
+use OCP\ContextChat\IContentManager;
 use OCP\Defaults;
 use OCP\Diagnostics\IEventLogger;
 use OCP\Diagnostics\IQueryLogger;
@@ -161,9 +198,12 @@ use OCP\Files\Cache\IFileAccess;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Conversion\IConversionManager;
+use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\Lock\ILockManager;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorageFactory;
@@ -182,6 +222,7 @@ use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IDateTimeZone;
 use OCP\IDBConnection;
+use OCP\IEmojiHelper;
 use OCP\IEventSourceFactory;
 use OCP\IGroupManager;
 use OCP\IInitialStateService;
@@ -193,6 +234,7 @@ use OCP\IRequest;
 use OCP\IRequestId;
 use OCP\IServerContainer;
 use OCP\ISession;
+use OCP\ITagManager;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -205,7 +247,10 @@ use OCP\Lockdown\ILockdownManager;
 use OCP\Log\ILogFactory;
 use OCP\Mail\IEmailValidator;
 use OCP\Mail\IMailer;
+use OCP\OCM\ICapabilityAwareOCMProvider;
 use OCP\OCM\IOCMDiscoveryService;
+use OCP\OCM\IOCMProvider;
+use OCP\OCS\IDiscoveryService;
 use OCP\Preview\IMimeIconProvider;
 use OCP\Profile\IProfileManager;
 use OCP\Profiler\IProfiler;
@@ -215,10 +260,12 @@ use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Route\IRouter;
 use OCP\Security\Bruteforce\IThrottler;
+use OCP\Security\IContentSecurityPolicyManager;
 use OCP\Security\ICredentialsManager;
 use OCP\Security\ICrypto;
 use OCP\Security\IHasher;
 use OCP\Security\Ip\IRemoteAddress;
+use OCP\Security\IRemoteHostValidator;
 use OCP\Security\ISecureRandom;
 use OCP\Security\ITrustedDomainHelper;
 use OCP\Security\RateLimiting\ILimiter;
@@ -228,10 +275,12 @@ use OCP\ServerVersion;
 use OCP\Settings\IDeclarativeManager;
 use OCP\SetupCheck\ISetupCheckManager;
 use OCP\Share\IProviderFactory;
+use OCP\Share\IPublicShareTemplateFactory;
 use OCP\Share\IShareHelper;
 use OCP\Snowflake\ISnowflakeDecoder;
 use OCP\Snowflake\ISnowflakeGenerator;
 use OCP\SpeechToText\ISpeechToTextManager;
+use OCP\Support\Subscription\IAssertion;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\Talk\IBroker;
@@ -258,150 +307,38 @@ use Psr\Log\LoggerInterface;
  * TODO: hookup all manager classes
  */
 class Server extends ServerContainer implements IServerContainer {
-	/**
-	 * @param string $webRoot
-	 * @param \OC\Config $config
-	 */
-	public function __construct($webRoot, \OC\Config $config)
- {
- }
+	public function __construct(private string $webRoot, Config $config)
+    {
+    }
 
 	public function boot()
- {
- }
-
-	/**
-	 * @return \OCP\Contacts\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getContactsManager()
- {
- }
-
-	/**
-	 * @return \OC\Encryption\Manager
-	 * @deprecated 20.0.0
-	 */
-	public function getEncryptionManager()
- {
- }
-
-	/**
-	 * @return \OC\Encryption\File
-	 * @deprecated 20.0.0
-	 */
-	public function getEncryptionFilesHelper()
- {
- }
-
-	/**
-	 * The current request object holding all information about the request
-	 * currently being processed is returned from this method.
-	 * In case the current execution was not initiated by a web request null is returned
-	 *
-	 * @return \OCP\IRequest
-	 * @deprecated 20.0.0
-	 */
-	public function getRequest()
- {
- }
-
-	/**
-	 * Returns the root folder of ownCloud's data directory
-	 *
-	 * @return IRootFolder
-	 * @deprecated 20.0.0
-	 */
-	public function getRootFolder()
- {
- }
-
-	/**
-	 * Returns the root folder of ownCloud's data directory
-	 * This is the lazy variant so this gets only initialized once it
-	 * is actually used.
-	 *
-	 * @return IRootFolder
-	 * @deprecated 20.0.0
-	 */
-	public function getLazyRootFolder()
- {
- }
+    {
+    }
 
 	/**
 	 * Returns a view to ownCloud's files folder
 	 *
 	 * @param string $userId user ID
-	 * @return \OCP\Files\Folder|null
+	 * @return Folder|null
 	 * @deprecated 20.0.0
 	 */
-	public function getUserFolder($userId = null)
- {
- }
+	public function getUserFolder($userId = null): ?Folder
+    {
+    }
+
+	public function setSession(ISession $session): void
+    {
+    }
 
 	/**
-	 * @return \OC\User\Manager
+	 * Get the webroot
+	 *
+	 * @return string
 	 * @deprecated 20.0.0
 	 */
-	public function getUserManager()
- {
- }
-
-	/**
-	 * @return \OC\Group\Manager
-	 * @deprecated 20.0.0
-	 */
-	public function getGroupManager()
- {
- }
-
-	/**
-	 * @return \OC\User\Session
-	 * @deprecated 20.0.0
-	 */
-	public function getUserSession()
- {
- }
-
-	/**
-	 * @return \OCP\ISession
-	 * @deprecated 20.0.0
-	 */
-	public function getSession()
- {
- }
-
-	/**
-	 * @param \OCP\ISession $session
-	 * @return void
-	 */
-	public function setSession(\OCP\ISession $session)
- {
- }
-
-	/**
-	 * @return \OCP\IConfig
-	 * @deprecated 20.0.0
-	 */
-	public function getConfig()
- {
- }
-
-	/**
-	 * @return \OC\SystemConfig
-	 * @deprecated 20.0.0
-	 */
-	public function getSystemConfig()
- {
- }
-
-	/**
-	 * @return IFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getL10NFactory()
- {
- }
+	public function getWebRoot(): string
+    {
+    }
 
 	/**
 	 * get an L10N instance
@@ -412,242 +349,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @deprecated 20.0.0 use DI of {@see IL10N} or {@see IFactory} instead, or {@see \OCP\Util::getL10N()} as a last resort
 	 */
 	public function getL10N($app, $lang = null)
- {
- }
-
-	/**
-	 * @return IURLGenerator
-	 * @deprecated 20.0.0
-	 */
-	public function getURLGenerator()
- {
- }
-
-	/**
-	 * Returns an ICache instance. Since 8.1.0 it returns a fake cache. Use
-	 * getMemCacheFactory() instead.
-	 *
-	 * @return ICache
-	 * @deprecated 8.1.0 use getMemCacheFactory to obtain a proper cache
-	 */
-	public function getCache()
- {
- }
-
-	/**
-	 * Returns an \OCP\CacheFactory instance
-	 *
-	 * @return \OCP\ICacheFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getMemCacheFactory()
- {
- }
-
-	/**
-	 * Returns the current session
-	 *
-	 * @return \OCP\IDBConnection
-	 * @deprecated 20.0.0
-	 */
-	public function getDatabaseConnection()
- {
- }
-
-	/**
-	 * Returns the activity manager
-	 *
-	 * @return \OCP\Activity\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getActivityManager()
- {
- }
-
-	/**
-	 * Returns an job list for controlling background jobs
-	 *
-	 * @return IJobList
-	 * @deprecated 20.0.0
-	 */
-	public function getJobList()
- {
- }
-
-	/**
-	 * Returns a SecureRandom instance
-	 *
-	 * @return \OCP\Security\ISecureRandom
-	 * @deprecated 20.0.0
-	 */
-	public function getSecureRandom()
- {
- }
-
-	/**
-	 * Returns a Crypto instance
-	 *
-	 * @return ICrypto
-	 * @deprecated 20.0.0
-	 */
-	public function getCrypto()
- {
- }
-
-	/**
-	 * Returns a Hasher instance
-	 *
-	 * @return IHasher
-	 * @deprecated 20.0.0
-	 */
-	public function getHasher()
- {
- }
-
-	/**
-	 * Get the certificate manager
-	 *
-	 * @return \OCP\ICertificateManager
-	 */
-	public function getCertificateManager()
- {
- }
-
-	/**
-	 * Get the manager for temporary files and folders
-	 *
-	 * @return \OCP\ITempManager
-	 * @deprecated 20.0.0
-	 */
-	public function getTempManager()
- {
- }
-
-	/**
-	 * Get the app manager
-	 *
-	 * @return \OCP\App\IAppManager
-	 * @deprecated 20.0.0
-	 */
-	public function getAppManager()
- {
- }
-
-	/**
-	 * Creates a new mailer
-	 *
-	 * @return IMailer
-	 * @deprecated 20.0.0
-	 */
-	public function getMailer()
- {
- }
-
-	/**
-	 * Get the webroot
-	 *
-	 * @return string
-	 * @deprecated 20.0.0
-	 */
-	public function getWebRoot()
- {
- }
-
-	/**
-	 * Get the locking provider
-	 *
-	 * @return ILockingProvider
-	 * @since 8.1.0
-	 * @deprecated 20.0.0
-	 */
-	public function getLockingProvider()
- {
- }
-
-	/**
-	 * Get the MimeTypeDetector
-	 *
-	 * @return IMimeTypeDetector
-	 * @deprecated 20.0.0
-	 */
-	public function getMimeTypeDetector()
- {
- }
-
-	/**
-	 * Get the MimeTypeLoader
-	 *
-	 * @return IMimeTypeLoader
-	 * @deprecated 20.0.0
-	 */
-	public function getMimeTypeLoader()
- {
- }
-
-	/**
-	 * Get the Notification Manager
-	 *
-	 * @return \OCP\Notification\IManager
-	 * @since 8.2.0
-	 * @deprecated 20.0.0
-	 */
-	public function getNotificationManager()
- {
- }
-
-	/**
-	 * @return \OCA\Theming\ThemingDefaults
-	 * @deprecated 20.0.0
-	 */
-	public function getThemingDefaults()
- {
- }
-
-	/**
-	 * @return \OC\IntegrityCheck\Checker
-	 * @deprecated 20.0.0
-	 */
-	public function getIntegrityCodeChecker()
- {
- }
-
-	/**
-	 * @return CsrfTokenManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCsrfTokenManager()
- {
- }
-
-	/**
-	 * @return ContentSecurityPolicyNonceManager
-	 * @deprecated 20.0.0
-	 */
-	public function getContentSecurityPolicyNonceManager()
- {
- }
-
-	/**
-	 * @return \OCP\Settings\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getSettingsManager()
- {
- }
-
-	/**
-	 * @return \OCP\Files\IAppData
-	 * @deprecated 20.0.0 Use get(\OCP\Files\AppData\IAppDataFactory::class)->get($app) instead
-	 */
-	public function getAppDataDir($app)
- {
- }
-
-	/**
-	 * @return \OCP\Federation\ICloudIdManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCloudIdManager()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_servercontainer.php
+++ b/tests/stubs/oc_servercontainer.php
@@ -34,24 +34,24 @@ class ServerContainer extends SimpleContainer {
 	 * ServerContainer constructor.
 	 */
 	public function __construct()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appName
 	 * @param string $appNamespace
 	 */
 	public function registerNamespace(string $appName, string $appNamespace): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appName
 	 * @param DIContainer $container
 	 */
 	public function registerAppContainer(string $appName, DIContainer $container): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appName
@@ -59,8 +59,8 @@ class ServerContainer extends SimpleContainer {
 	 * @throws QueryException
 	 */
 	public function getRegisteredAppContainer(string $appName): DIContainer
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $namespace
@@ -69,12 +69,12 @@ class ServerContainer extends SimpleContainer {
 	 * @throws QueryException
 	 */
 	protected function getAppContainer(string $namespace, string $sensitiveNamespace): DIContainer
- {
- }
+    {
+    }
 
 	public function has($id, bool $noRecursion = false): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @template T
@@ -87,9 +87,9 @@ class ServerContainer extends SimpleContainer {
 	 * @throws QueryException
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 */
-	public function query(string $name, bool $autoload = true, array $chain = [])
- {
- }
+	public function query(string $name, bool $autoload = true, array $chain = []): mixed
+    {
+    }
 
 	/**
 	 * @internal
@@ -97,6 +97,10 @@ class ServerContainer extends SimpleContainer {
 	 * @return DIContainer|null
 	 */
 	public function getAppContainerForService(string $id): ?DIContainer
- {
- }
+    {
+    }
+
+	public function getWebRoot()
+    {
+    }
 }

--- a/tests/stubs/oc_share20_share.php
+++ b/tests/stubs/oc_share20_share.php
@@ -7,6 +7,7 @@
  */
 namespace OC\Share20;
 
+use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
@@ -19,6 +20,7 @@ use OCP\Share\Exceptions\IllegalIDChangeException;
 use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use Override;
 
 class Share implements IShare {
 	public function __construct(
@@ -27,409 +29,401 @@ class Share implements IShare {
 	) {
 	}
 
-	/**
-	 * @inheritdoc
-	 */
-	public function setId($id)
- {
- }
+	#[Override]
+    public function setId(string $id): self
+    {
+    }
 
-	/**
-	 * @inheritdoc
-	 */
-	public function getId()
- {
- }
+	#[Override]
+    public function getId(): string
+    {
+    }
 
-	/**
-	 * @inheritdoc
-	 */
-	public function getFullId()
- {
- }
+	#[Override]
+    public function getFullId(): string
+    {
+    }
 
-	/**
-	 * @inheritdoc
-	 */
-	public function setProviderId($id)
- {
- }
+	#[Override]
+    public function setProviderId(string $id): self
+    {
+    }
 
-	/**
-	 * @inheritdoc
-	 */
-	public function setNode(Node $node)
- {
- }
+	#[Override]
+    public function setNode(Node $node): self
+    {
+    }
 
-	/**
-	 * @inheritdoc
-	 */
-	public function getNode()
- {
- }
+	#[Override]
+    public function getNode(): Node
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setNodeId($fileId)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getNodeId(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setNodeType($type)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getNodeType()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setShareType($shareType)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getShareType()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setSharedWith($sharedWith)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getSharedWith()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setSharedWithDisplayName($displayName)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getSharedWithDisplayName()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setSharedWithAvatar($src)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getSharedWithAvatar()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setPermissions($permissions)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getPermissions()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function newAttributes(): IAttributes
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setAttributes(?IAttributes $attributes)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getAttributes(): ?IAttributes
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setStatus(int $status): IShare
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getStatus(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setNote($note)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getNote()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setLabel($label)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getLabel()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setExpirationDate($expireDate)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getExpirationDate()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setNoExpirationDate(bool $noExpirationDate)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getNoExpirationDate(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function isExpired()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setSharedBy($sharedBy)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getSharedBy()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setShareOwner($shareOwner)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getShareOwner()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setPassword($password)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getPassword()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setPasswordExpirationTime(?\DateTimeInterface $passwordExpirationTime = null): IShare
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getPasswordExpirationTime(): ?\DateTimeInterface
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setSendPasswordByTalk(bool $sendPasswordByTalk)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getSendPasswordByTalk(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setToken($token)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getToken()
- {
- }
+    {
+    }
 
 	public function setParent(int $parent): self
- {
- }
+    {
+    }
 
 	public function getParent(): ?int
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setTarget($target)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getTarget()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setShareTime(\DateTime $shareTime)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getShareTime()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setMailSend($mailSend)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getMailSend()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setNodeCacheEntry(ICacheEntry $entry)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getNodeCacheEntry()
- {
- }
+    {
+    }
 
 	public function setHideDownload(bool $hide): IShare
- {
- }
+    {
+    }
 
 	public function getHideDownload(): bool
- {
- }
+    {
+    }
 
 	public function setReminderSent(bool $reminderSent): IShare
- {
- }
+    {
+    }
 
 	public function getReminderSent(): bool
- {
- }
+    {
+    }
+
+	public function canDownload(): bool
+    {
+    }
 
 	public function canSeeContent(): bool
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_share20_shareattributes.php
+++ b/tests/stubs/oc_share20_shareattributes.php
@@ -11,27 +11,27 @@ use OCP\Share\IAttributes;
 
 class ShareAttributes implements IAttributes {
 	public function __construct()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function setAttribute(string $scope, string $key, mixed $value): IAttributes
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function getAttribute(string $scope, string $key): mixed
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
 	public function toArray(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_systemconfig.php
+++ b/tests/stubs/oc_systemconfig.php
@@ -44,6 +44,7 @@ class SystemConfig {
 		'proxyuserpwd' => true,
 		'sentry.dsn' => true,
 		'sentry.public-dsn' => true,
+		'sentry.csp-report-url' => true,
 		'zammad.download.secret' => true,
 		'zammad.portal.secret' => true,
 		'zammad.secret' => true,
@@ -113,16 +114,16 @@ class SystemConfig {
 	];
 
 	public function __construct(private Config $config)
- {
- }
+    {
+    }
 
 	/**
 	 * Lists all available config keys
 	 * @return array an array of key names
 	 */
 	public function getKeys()
- {
- }
+    {
+    }
 
 	/**
 	 * Sets a new system wide value
@@ -131,8 +132,8 @@ class SystemConfig {
 	 * @param mixed $value the value that should be stored
 	 */
 	public function setValue($key, $value)
- {
- }
+    {
+    }
 
 	/**
 	 * Sets and deletes values and writes the config.php
@@ -141,8 +142,8 @@ class SystemConfig {
 	 *                       If value is null, the config key will be deleted
 	 */
 	public function setValues(array $configs)
- {
- }
+    {
+    }
 
 	/**
 	 * Looks up a system wide defined value
@@ -152,8 +153,8 @@ class SystemConfig {
 	 * @return mixed the value or $default
 	 */
 	public function getValue($key, $default = '')
- {
- }
+    {
+    }
 
 	/**
 	 * Looks up a system wide defined value and filters out sensitive data
@@ -163,8 +164,8 @@ class SystemConfig {
 	 * @return mixed the value or $default
 	 */
 	public function getFilteredValue($key, $default = '')
- {
- }
+    {
+    }
 
 	/**
 	 * Delete a system wide defined value
@@ -172,8 +173,8 @@ class SystemConfig {
 	 * @param string $key the key of the value, under which it was saved
 	 */
 	public function deleteValue($key)
- {
- }
+    {
+    }
 
 	/**
 	 * @param bool|array $keysToRemove
@@ -181,6 +182,6 @@ class SystemConfig {
 	 * @return mixed
 	 */
 	protected function removeSensitiveValue($keysToRemove, $value)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_user_manager.php
+++ b/tests/stubs/oc_user_manager.php
@@ -18,6 +18,7 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
+use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\IUserManager;
@@ -34,6 +35,7 @@ use OCP\User\Backend\ISearchKnownUsersBackend;
 use OCP\User\Events\BeforeUserCreatedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\UserInterface;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -56,54 +58,54 @@ use Psr\Log\LoggerInterface;
 class Manager extends PublicEmitter implements IUserManager {
 	// This constructor can't autoload any class requiring a DB connection.
 	public function __construct(private IConfig $config, ICacheFactory $cacheFactory, private IEventDispatcher $eventDispatcher, private LoggerInterface $logger)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the active backends
 	 * @return UserInterface[]
 	 */
 	public function getBackends(): array
- {
- }
+    {
+    }
 
 	public function registerBackend(UserInterface $backend): void
- {
- }
+    {
+    }
 
 	public function removeBackend(UserInterface $backend): void
- {
- }
+    {
+    }
 
 	public function clearBackends(): void
- {
- }
+    {
+    }
 
 	/**
 	 * get a user by user id
 	 *
 	 * @param string $uid
-	 * @return \OC\User\User|null Either the user or null if the specified user does not exist
+	 * @return User|null Either the user or null if the specified user does not exist
 	 */
 	public function get($uid)
- {
- }
+    {
+    }
 
 	public function getDisplayName(string $uid): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * get or construct the user object
 	 *
 	 * @param string $uid
-	 * @param \OCP\UserInterface $backend
+	 * @param UserInterface $backend
 	 * @param bool $cacheUser If false the newly created user object will not be cached
-	 * @return \OC\User\User
+	 * @return User
 	 */
 	public function getUserObject($uid, $backend, $cacheUser = true)
- {
- }
+    {
+    }
 
 	/**
 	 * check if a user exists
@@ -112,8 +114,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return bool
 	 */
 	public function userExists($uid)
- {
- }
+    {
+    }
 
 	/**
 	 * Check if the password is valid for the user
@@ -123,8 +125,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return IUser|false the User object on success, false otherwise
 	 */
 	public function checkPassword($loginName, $password)
- {
- }
+    {
+    }
 
 	/**
 	 * Check if the password is valid for the user
@@ -135,23 +137,23 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return IUser|false the User object on success, false otherwise
 	 */
 	public function checkPasswordNoLogging($loginName, $password)
- {
- }
+    {
+    }
 
 	public function search($pattern, $limit = null, $offset = null)
- {
- }
+    {
+    }
 
 	public function searchDisplayName($pattern, $limit = null, $offset = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @return IUser[]
 	 */
 	public function getDisabledUsers(?int $limit = null, int $offset = 0, string $search = ''): array
- {
- }
+    {
+    }
 
 	/**
 	 * Search known users (from phonebook sync) by displayName
@@ -163,8 +165,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return IUser[]
 	 */
 	public function searchKnownUsersByDisplayName(string $searcher, string $pattern, ?int $limit = null, ?int $offset = null): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $uid
@@ -173,20 +175,18 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @throws \InvalidArgumentException
 	 * @throws HintException
 	 */
-	public function createUser($uid, $password)
- {
- }
+	public function createUser($uid, $password): IUser|false
+    {
+    }
 
 	/**
 	 * @param string $uid
 	 * @param string $password
-	 * @param UserInterface $backend
-	 * @return IUser|false
 	 * @throws \InvalidArgumentException
 	 */
-	public function createUserFromBackend($uid, $password, UserInterface $backend)
- {
- }
+	public function createUserFromBackend($uid, $password, UserInterface $backend): IUser|false
+    {
+    }
 
 	/**
 	 * returns how many users per backend exist (if supported by backend)
@@ -194,12 +194,12 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return array<string, int> an array of backend class as key and count number as value
 	 */
 	public function countUsers(bool $onlyMappedUsers = false)
- {
- }
+    {
+    }
 
 	public function countUsersTotal(int $limit = 0, bool $onlyMappedUsers = false): int|false
- {
- }
+    {
+    }
 
 	/**
 	 * returns how many users per backend exist in the requested groups (if supported by backend)
@@ -209,22 +209,22 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return array{int,int} total number of users, and number of disabled users in the given groups, below $limit. If limit is reached, -1 is returned for number of disabled users
 	 */
 	public function countUsersAndDisabledUsersOfGroups(array $groups, int $limit): array
- {
- }
+    {
+    }
 
 	/**
 	 * The callback is executed for each user on each backend.
 	 * If the callback returns false no further users will be retrieved.
 	 *
-	 * @psalm-param \Closure(\OCP\IUser):?bool $callback
+	 * @psalm-param \Closure(IUser):?bool $callback
 	 * @param string $search
 	 * @param boolean $onlySeen when true only users that have a lastLogin entry
 	 *                          in the preferences table will be affected
 	 * @since 9.0.0
 	 */
 	public function callForAllUsers(\Closure $callback, $search = '', $onlySeen = false)
- {
- }
+    {
+    }
 
 	/**
 	 * returns how many users are disabled
@@ -233,8 +233,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 12.0.0
 	 */
 	public function countDisabledUsers(): int
- {
- }
+    {
+    }
 
 	/**
 	 * returns how many users have logged in once
@@ -243,19 +243,19 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 11.0.0
 	 */
 	public function countSeenUsers()
- {
- }
+    {
+    }
 
 	public function callForSeenUsers(\Closure $callback)
- {
- }
+    {
+    }
 
 	/**
 	 * @internal Only for mocks it in unit tests.
 	 */
 	public function getUserConfig(): IUserConfig
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $email
@@ -263,8 +263,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 9.1.0
 	 */
 	public function getByEmail($email): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $uid
@@ -273,8 +273,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 26.0.0
 	 */
 	public function validateUserId(string $uid, bool $checkDataDirectory = false): void
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the list of user ids sorted by lastLogin, from most recent to least recent
@@ -285,18 +285,18 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return list<string> list of user IDs
 	 */
 	public function getLastLoggedInUsers(?int $limit = null, int $offset = 0, string $search = ''): array
- {
- }
+    {
+    }
 
 	public function getDisplayNameCache(): DisplayNameCache
- {
- }
+    {
+    }
 
 	public function getSeenUsers(int $offset = 0, ?int $limit = null): \Iterator
- {
- }
+    {
+    }
 
 	public function getExistingUser(string $userId, ?string $displayName = null): IUser
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_user_nouserexception.php
+++ b/tests/stubs/oc_user_nouserexception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/tests/stubs/oc_user_user.php
+++ b/tests/stubs/oc_user_user.php
@@ -14,6 +14,7 @@ use OC\Hooks\Emitter;
 use OCP\Accounts\IAccountManager;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\FileInfo;
 use OCP\Group\Events\BeforeUserRemovedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\IAvatarManager;
@@ -25,8 +26,10 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Server;
 use OCP\User\Backend\IGetHomeBackend;
 use OCP\User\Backend\IPasswordHashBackend;
+use OCP\User\Backend\IPropertyPermissionBackend;
 use OCP\User\Backend\IProvideAvatarBackend;
 use OCP\User\Backend\IProvideEnabledStateBackend;
 use OCP\User\Backend\ISetDisplayNameBackend;
@@ -38,6 +41,7 @@ use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\User\GetQuotaEvent;
 use OCP\UserInterface;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 use function json_decode;
@@ -45,178 +49,151 @@ use function json_encode;
 
 class User implements IUser {
 	private const CONFIG_KEY_MANAGERS = 'manager';
+	protected ?IAccountManager $accountManager = null;
 
-	/** @var IAccountManager */
-	protected $accountManager;
+	public function __construct(private string $uid, private ?UserInterface $backend, private IEventDispatcher $dispatcher, private Emitter|Manager|null $emitter = null, ?IConfig $config = null, $urlGenerator = null)
+    {
+    }
 
-	public function __construct(private string $uid, private ?UserInterface $backend, private IEventDispatcher $dispatcher, $emitter = null, ?IConfig $config = null, $urlGenerator = null)
- {
- }
+	public function getUID(): string
+    {
+    }
 
 	/**
-	 * get the user id
-	 *
-	 * @return string
+	 * Get the display name for the user, if no specific display name is set it will fallback to the user id
 	 */
-	public function getUID()
- {
- }
+	public function getDisplayName(): string
+    {
+    }
 
 	/**
-	 * get the display name for the user, if no specific display name is set it will fallback to the user id
-	 *
-	 * @return string
-	 */
-	public function getDisplayName()
- {
- }
-
-	/**
-	 * set the displayname for the user
+	 * Set the displayname for the user
 	 *
 	 * @param string $displayName
-	 * @return bool
 	 *
 	 * @since 25.0.0 Throw InvalidArgumentException
 	 * @throws \InvalidArgumentException
 	 */
-	public function setDisplayName($displayName)
- {
- }
+	public function setDisplayName($displayName): bool
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function setEMailAddress($mailAddress)
- {
- }
+	public function setEMailAddress($mailAddress): void
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function setSystemEMailAddress(string $mailAddress): void
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function setPrimaryEMailAddress(string $mailAddress): void
- {
- }
+    {
+    }
 
 	/**
 	 * returns the timestamp of the user's last login or 0 if the user did never
 	 * login
 	 */
 	public function getLastLogin(): int
- {
- }
+    {
+    }
 
 	/**
 	 * returns the timestamp of the user's last login or 0 if the user did never
 	 * login
 	 */
 	public function getFirstLogin(): int
- {
- }
+    {
+    }
 
 	/**
 	 * updates the timestamp of the most recent login of this user
 	 */
 	public function updateLastLoginTimestamp(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Delete the user
-	 *
-	 * @return bool
 	 */
-	public function delete()
- {
- }
+	public function delete(): bool
+    {
+    }
 
 	/**
 	 * Set the password of the user
 	 *
 	 * @param string $password
 	 * @param string $recoveryPassword for the encryption app to reset encryption keys
-	 * @return bool
 	 */
-	public function setPassword($password, $recoveryPassword = null)
- {
- }
+	public function setPassword($password, $recoveryPassword = null): bool
+    {
+    }
 
 	public function getPasswordHash(): ?string
- {
- }
+    {
+    }
 
 	public function setPasswordHash(string $passwordHash): bool
- {
- }
+    {
+    }
 
 	/**
-	 * get the users home folder to mount
-	 *
-	 * @return string
+	 * Get the users home folder to mount
 	 */
-	public function getHome()
- {
- }
+	public function getHome(): string
+    {
+    }
 
 	/**
 	 * Get the name of the backend class the user is connected with
-	 *
-	 * @return string
 	 */
-	public function getBackendClassName()
- {
- }
+	public function getBackendClassName(): string
+    {
+    }
 
 	public function getBackend(): ?UserInterface
- {
- }
+    {
+    }
 
-	/**
-	 * Check if the backend allows the user to change their avatar on Personal page
-	 *
-	 * @return bool
-	 */
-	public function canChangeAvatar()
- {
- }
+	public function canChangeAvatar(): bool
+    {
+    }
 
-	/**
-	 * check if the backend supports changing passwords
-	 *
-	 * @return bool
-	 */
-	public function canChangePassword()
- {
- }
+	public function canChangePassword(): bool
+    {
+    }
 
-	/**
-	 * check if the backend supports changing display names
-	 *
-	 * @return bool
-	 */
-	public function canChangeDisplayName()
- {
- }
+	public function canChangeDisplayName(): bool
+    {
+    }
 
 	public function canChangeEmail(): bool
- {
- }
+    {
+    }
 
 	/**
-	 * check if the user is enabled
-	 *
-	 * @return bool
+	 * @param IAccountManager::PROPERTY_*|IAccountManager::COLLECTION_* $property
 	 */
-	public function isEnabled()
- {
- }
+	public function canEditProperty(string $property): bool
+    {
+    }
+
+	/**
+	 * Check if the user is enabled
+	 */
+	public function isEnabled(): bool
+    {
+    }
 
 	/**
 	 * set the enabled status for the user
@@ -224,89 +201,84 @@ class User implements IUser {
 	 * @return void
 	 */
 	public function setEnabled(bool $enabled = true)
- {
- }
+    {
+    }
 
 	/**
-	 * get the users email address
+	 * Get the users email address
 	 *
-	 * @return string|null
 	 * @since 9.0.0
 	 */
-	public function getEMailAddress()
- {
- }
+	public function getEMailAddress(): ?string
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getSystemEMailAddress(): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getPrimaryEMailAddress(): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * get the users' quota
 	 *
-	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getQuota()
- {
- }
+	public function getQuota(): string
+    {
+    }
 
 	public function getQuotaBytes(): int|float
- {
- }
+    {
+    }
 
 	/**
-	 * set the users' quota
+	 * Set the users' quota
 	 *
 	 * @param string $quota
-	 * @return void
 	 * @throws InvalidArgumentException
 	 * @since 9.0.0
 	 */
-	public function setQuota($quota)
- {
- }
+	public function setQuota($quota): void
+    {
+    }
 
 	public function getManagerUids(): array
- {
- }
+    {
+    }
 
 	public function setManagerUids(array $uids): void
- {
- }
+    {
+    }
 
 	/**
 	 * get the avatar image if it exists
 	 *
 	 * @param int $size
-	 * @return IImage|null
 	 * @since 9.0.0
 	 */
-	public function getAvatarImage($size)
- {
- }
+	public function getAvatarImage($size): ?IImage
+    {
+    }
 
 	/**
 	 * get the federation cloud id
 	 *
-	 * @return string
 	 * @since 9.0.0
 	 */
-	public function getCloudId()
- {
- }
+	public function getCloudId(): string
+    {
+    }
 
-	public function triggerChange($feature, $value = null, $oldValue = null)
- {
- }
+	public function triggerChange($feature, $value = null, $oldValue = null): void
+    {
+    }
 }

--- a/tests/stubs/oca_dav_carddav_contactsmanager.php
+++ b/tests/stubs/oca_dav_carddav_contactsmanager.php
@@ -36,8 +36,8 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupContactsProvider(IManager $cm, $userId, IURLGenerator $urlGenerator)
- {
- }
+    {
+    }
 
 	/**
 	 * @param IManager $cm
@@ -45,6 +45,6 @@ class ContactsManager {
 	 * @param IURLGenerator $urlGenerator
 	 */
 	public function setupSystemContactsProvider(IManager $cm, ?string $userId, IURLGenerator $urlGenerator)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_federatedfilesharing_notifications.php
+++ b/tests/stubs/oca_federatedfilesharing_notifications.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\FederatedFileSharing;
 
+use OC\ServerNotAvailableException;
 use OCA\FederatedFileSharing\Events\FederatedShareAddedEvent;
 use OCP\AppFramework\Http;
 use OCP\BackgroundJob\IJobList;
@@ -47,11 +48,11 @@ class Notifications {
 	 * @param int $shareType (can be a remote user or group share)
 	 * @return bool
 	 * @throws HintException
-	 * @throws \OC\ServerNotAvailableException
+	 * @throws ServerNotAvailableException
 	 */
 	public function sendRemoteShare($token, $shareWith, $name, $remoteId, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId, $shareType)
- {
- }
+    {
+    }
 
 	/**
 	 * ask owner to re-share the file with the given user
@@ -65,11 +66,11 @@ class Notifications {
 	 * @param string $filename
 	 * @return array|false
 	 * @throws HintException
-	 * @throws \OC\ServerNotAvailableException
+	 * @throws ServerNotAvailableException
 	 */
 	public function requestReShare($token, $id, $shareId, $remote, $shareWith, $permission, $filename, $shareType)
- {
- }
+    {
+    }
 
 	/**
 	 * send server-to-server unshare to remote server
@@ -80,8 +81,8 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendRemoteUnShare($remote, $id, $token)
- {
- }
+    {
+    }
 
 	/**
 	 * send server-to-server unshare to remote server
@@ -92,8 +93,8 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendRevokeShare($remote, $id, $token)
- {
- }
+    {
+    }
 
 	/**
 	 * send notification to remote server if the permissions was changed
@@ -105,8 +106,8 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendPermissionChange($remote, $remoteId, $token, $permissions)
- {
- }
+    {
+    }
 
 	/**
 	 * forward accept reShare to remote server
@@ -116,8 +117,8 @@ class Notifications {
 	 * @param string $token
 	 */
 	public function sendAcceptShare($remote, $remoteId, $token)
- {
- }
+    {
+    }
 
 	/**
 	 * forward decline reShare to remote server
@@ -127,8 +128,8 @@ class Notifications {
 	 * @param string $token
 	 */
 	public function sendDeclineShare($remote, $remoteId, $token)
- {
- }
+    {
+    }
 
 	/**
 	 * inform remote server whether server-to-server share was accepted/declined
@@ -142,8 +143,8 @@ class Notifications {
 	 * @return boolean
 	 */
 	public function sendUpdateToRemote($remote, $remoteId, $token, $action, $data = [], $try = 0)
- {
- }
+    {
+    }
 
 
 	/**
@@ -152,8 +153,8 @@ class Notifications {
 	 * @return int
 	 */
 	protected function getTimestamp()
- {
- }
+    {
+    }
 
 	/**
 	 * try http post with the given protocol, if no protocol is given we pick
@@ -167,8 +168,8 @@ class Notifications {
 	 * @throws \Exception
 	 */
 	protected function tryHttpPostToShareEndpoint($remoteDomain, $urlSuffix, array $fields, $action = 'share')
- {
- }
+    {
+    }
 
 	/**
 	 * try old federated sharing API if the OCM api doesn't work
@@ -180,8 +181,8 @@ class Notifications {
 	 * @throws \Exception
 	 */
 	protected function tryLegacyEndPoint($remoteDomain, $urlSuffix, array $fields)
- {
- }
+    {
+    }
 
 	/**
 	 * send action regarding federated sharing to the remote server using the OCM API
@@ -193,6 +194,6 @@ class Notifications {
 	 * @return array|false
 	 */
 	protected function tryOCMEndPoint($remoteDomain, $fields, $action)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_sharing_event_usershareaccessupdatedevent.php
+++ b/tests/stubs/oca_files_sharing_event_usershareaccessupdatedevent.php
@@ -26,13 +26,13 @@ class UserShareAccessUpdatedEvent extends Event {
 	 * @param IUser|list<IUser> $users
 	 */
 	public function __construct(IUser|array $users)
- {
- }
+    {
+    }
 
 	/**
 	 * @return list<IUser>
 	 */
 	public function getUsers(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_sharing_external_manager.php
+++ b/tests/stubs/oca_files_sharing_external_manager.php
@@ -9,7 +9,6 @@
 namespace OCA\Files_Sharing\External;
 
 use OC\Files\Filesystem;
-use OC\Files\SetupManager;
 use OC\User\NoUserException;
 use OCA\FederatedFileSharing\Events\FederatedShareAddedEvent;
 use OCA\Files_Sharing\Helper;
@@ -21,11 +20,13 @@ use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -37,9 +38,9 @@ use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
 class Manager {
-	public function __construct(private IDBConnection $connection, private \OC\Files\Mount\Manager $mountManager, private IStorageFactory $storageLoader, private IClientService $clientService, private IManager $notificationManager, private IDiscoveryService $discoveryService, private ICloudFederationProviderManager $cloudFederationProviderManager, private ICloudFederationFactory $cloudFederationFactory, private IGroupManager $groupManager, IUserSession $userSession, private IEventDispatcher $eventDispatcher, private LoggerInterface $logger, private IRootFolder $rootFolder, private SetupManager $setupManager, private ICertificateManager $certificateManager, private ExternalShareMapper $externalShareMapper)
- {
- }
+	public function __construct(private IDBConnection $connection, private \OC\Files\Mount\Manager $mountManager, private IStorageFactory $storageLoader, private IClientService $clientService, private IManager $notificationManager, private IDiscoveryService $discoveryService, private ICloudFederationProviderManager $cloudFederationProviderManager, private ICloudFederationFactory $cloudFederationFactory, private IGroupManager $groupManager, IUserSession $userSession, private IEventDispatcher $eventDispatcher, private LoggerInterface $logger, private IRootFolder $rootFolder, private ISetupManager $setupManager, private ICertificateManager $certificateManager, private ExternalShareMapper $externalShareMapper, private IConfig $config)
+    {
+    }
 
 	/**
 	 * Add new server-to-server share.
@@ -49,16 +50,16 @@ class Manager {
 	 * @throws NoUserException
 	 */
 	public function addShare(ExternalShare $externalShare, IUser|IGroup|null $shareWith = null): ?Mount
- {
- }
+    {
+    }
 
 	public function getShare(string $id, ?IUser $user = null): ExternalShare|false
- {
- }
+    {
+    }
 
 	public function getShareByToken(string $token): ExternalShare|false
- {
- }
+    {
+    }
 
 	/**
 	 * Accept server-to-server share.
@@ -66,8 +67,8 @@ class Manager {
 	 * @return bool True if the share could be accepted, false otherwise
 	 */
 	public function acceptShare(ExternalShare $externalShare, ?IUser $user = null): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Decline server-to-server share
@@ -75,12 +76,12 @@ class Manager {
 	 * @return bool True if the share could be declined, false otherwise
 	 */
 	public function declineShare(ExternalShare $externalShare, ?Iuser $user = null): bool
- {
- }
+    {
+    }
 
 	public function processNotification(ExternalShare $remoteShare, ?IUser $user = null): void
- {
- }
+    {
+    }
 
 	/**
 	 * Try to send accept message to ocm end-point
@@ -89,53 +90,53 @@ class Manager {
 	 * @return array|false
 	 */
 	protected function tryOCMEndPoint(ExternalShare $externalShare, string $feedback)
- {
- }
+    {
+    }
 
 	/**
 	 * remove '/user/files' from the path and trailing slashes
 	 */
 	protected function stripPath(string $path): string
- {
- }
+    {
+    }
 
 	public function getMount(array $data, ?IUser $user = null): Mount
- {
- }
+    {
+    }
 
 	protected function mountShare(array $data, ?IUser $user = null): Mount
- {
- }
+    {
+    }
 
 	public function getMountManager(): \OC\Files\Mount\Manager
- {
- }
+    {
+    }
 
 	public function setMountPoint(string $source, string $target): bool
- {
- }
+    {
+    }
 
 	public function removeShare(string $mountPoint): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Remove re-shares from share table and mapping in the federated_reshares table
 	 */
 	protected function removeReShares(string $mountPointId): void
- {
- }
+    {
+    }
 
 	/**
 	 * Remove all shares for user $uid if the user was deleted.
 	 */
 	public function removeUserShares(IUser $user): bool
- {
- }
+    {
+    }
 
 	public function removeGroupShares(IGroup $group): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Return a list of shares which are not yet accepted by the user.
@@ -143,8 +144,8 @@ class Manager {
 	 * @return list<ExternalShare> list of open server-to-server shares
 	 */
 	public function getOpenShares(): array
- {
- }
+    {
+    }
 
 	/**
 	 * Return a list of shares which are accepted by the user.
@@ -152,6 +153,6 @@ class Manager {
 	 * @return list<ExternalShare> list of accepted server-to-server shares
 	 */
 	public function getAcceptedShares(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_user_ldap_mapping_abstractmapping.php
+++ b/tests/stubs/oca_user_ldap_mapping_abstractmapping.php
@@ -29,8 +29,8 @@ abstract class AbstractMapping {
 	 * @return string
 	 */
 	abstract protected function getTableName(bool $includePrefix = true)
- {
- }
+    {
+    }
 
 	/**
 	 * A month worth of cache time for as good as never changing mapping data.
@@ -61,16 +61,16 @@ abstract class AbstractMapping {
 	 * @param IDBConnection $dbc
 	 */
 	public function __construct(protected IDBConnection $dbc, protected ICacheFactory $cacheFactory, protected IAppConfig $config, protected bool $isCLI)
- {
- }
+    {
+    }
 
 	protected function initLocalCache(): void
- {
- }
+    {
+    }
 
 	protected function useCacheByUserCount(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * checks whether a provided string represents an existing table col
@@ -79,8 +79,8 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function isColNameValid($col)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the value of one column based on a provided value of another column
@@ -92,8 +92,8 @@ abstract class AbstractMapping {
 	 * @throws \Exception
 	 */
 	protected function getXbyY($fetchCol, $compareCol, $search)
- {
- }
+    {
+    }
 
 	/**
 	 * Performs a DELETE or UPDATE query to the database.
@@ -103,15 +103,15 @@ abstract class AbstractMapping {
 	 * @return bool true if at least one row was modified, false otherwise
 	 */
 	protected function modify(IPreparedStatement $statement, $parameters)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the LDAP DN based on the provided name.
 	 */
 	public function getDNByName(string $name): string|false
- {
- }
+    {
+    }
 
 	/**
 	 * Updates the DN based on the given UUID
@@ -121,8 +121,8 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function setDNbyUUID($fdn, $uuid)
- {
- }
+    {
+    }
 
 	/**
 	 * Updates the UUID based on the given DN
@@ -134,15 +134,15 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function setUUIDbyDN($uuid, $fdn): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Get the hash to store in database column ldap_dn_hash for a given dn
 	 */
 	protected function getDNHash(string $fdn): string
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the name based on the provided LDAP DN.
@@ -151,27 +151,27 @@ abstract class AbstractMapping {
 	 * @return string|false
 	 */
 	public function getNameByDN($fdn)
- {
- }
+    {
+    }
 
 	/**
 	 * @param array<string> $hashList
 	 */
 	protected function prepareListOfIdsQuery(array $hashList): IQueryBuilder
- {
- }
+    {
+    }
 
 	protected function collectResultsFromListOfIdsQuery(IQueryBuilder $qb, array &$results): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param array<string> $fdns
 	 * @return array<string,string>
 	 */
 	public function getListOfIdsByDn(array $fdns): array
- {
- }
+    {
+    }
 
 	/**
 	 * Searches mapped names by the giving string in the name column
@@ -179,8 +179,8 @@ abstract class AbstractMapping {
 	 * @return string[]
 	 */
 	public function getNamesBySearch(string $search, string $prefixMatch = '', string $postfixMatch = ''): array
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the name based on the provided LDAP UUID.
@@ -189,12 +189,12 @@ abstract class AbstractMapping {
 	 * @return string|false
 	 */
 	public function getNameByUUID($uuid)
- {
- }
+    {
+    }
 
 	public function getDnByUUID($uuid)
- {
- }
+    {
+    }
 
 	/**
 	 * Gets the UUID based on the provided LDAP DN
@@ -204,12 +204,12 @@ abstract class AbstractMapping {
 	 * @throws \Exception
 	 */
 	public function getUUIDByDN($dn)
- {
- }
+    {
+    }
 
 	public function getList(int $offset = 0, ?int $limit = null, bool $invalidatedOnly = false): array
- {
- }
+    {
+    }
 
 	/**
 	 * attempts to map the given entry
@@ -220,8 +220,8 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function map($fdn, $name, $uuid)
- {
- }
+    {
+    }
 
 	/**
 	 * removes a mapping based on the owncloud_name of the entry
@@ -230,8 +230,8 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function unmap($name)
- {
- }
+    {
+    }
 
 	/**
 	 * Truncates the mapping table
@@ -239,8 +239,8 @@ abstract class AbstractMapping {
 	 * @return bool
 	 */
 	public function clear()
- {
- }
+    {
+    }
 
 	/**
 	 * clears the mapping table one by one and executing a callback with
@@ -252,8 +252,8 @@ abstract class AbstractMapping {
 	 *              deleted
 	 */
 	public function clearCb(callable $preCallback, callable $postCallback): bool
- {
- }
+    {
+    }
 
 	/**
 	 * returns the number of entries in the mappings table
@@ -261,10 +261,10 @@ abstract class AbstractMapping {
 	 * @return int
 	 */
 	public function count(): int
- {
- }
+    {
+    }
 
 	public function countInvalidated(): int
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_user_ldap_mapping_usermapping.php
+++ b/tests/stubs/oca_user_ldap_mapping_usermapping.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\User_LDAP\Mapping;
 
 use OCP\HintException;
@@ -12,7 +15,6 @@ use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\IRequest;
-use OCP\Server;
 use OCP\Support\Subscription\IAssertion;
 
 /**
@@ -24,22 +26,22 @@ class UserMapping extends AbstractMapping {
 
 	protected const PROV_API_REGEX = '/\/ocs\/v[1-9].php\/cloud\/(groups|users)/';
 
-	public function __construct(IDBConnection $dbc, ICacheFactory $cacheFactory, IAppConfig $config, bool $isCLI, private IAssertion $assertion)
- {
- }
+	public function __construct(IDBConnection $dbc, ICacheFactory $cacheFactory, IAppConfig $config, bool $isCLI, private IAssertion $assertion, private IRequest $request)
+    {
+    }
 
 	/**
 	 * @throws HintException
 	 */
 	public function map($fdn, $name, $uuid): bool
- {
- }
+    {
+    }
 
 	/**
 	 * returns the DB table name which holds the mappings
 	 * @return string
 	 */
 	protected function getTableName(bool $includePrefix = true)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/symfony_component_console_command_command.php
+++ b/tests/stubs/symfony_component_console_command_command.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Command
+class Command implements SignalableCommandInterface
 {
     // see https://tldp.org/LDP/abs/html/exitcodes.html
     public const SUCCESS = 0;
@@ -40,23 +40,15 @@ class Command
     public const INVALID = 2;
 
     /**
-     * @var string|null The default command name
-     *
-     * @deprecated since Symfony 6.1, use the AsCommand attribute instead
+     * @deprecated since Symfony 7.3, use the #[AsCommand] attribute instead
      */
-    protected static $defaultName;
-
-    /**
-     * @var string|null The default command description
-     *
-     * @deprecated since Symfony 6.1, use the AsCommand attribute instead
-     */
-    protected static $defaultDescription;
-
     public static function getDefaultName(): ?string
     {
     }
 
+    /**
+     * @deprecated since Symfony 7.3, use the #[AsCommand] attribute instead
+     */
     public static function getDefaultDescription(): ?string
     {
     }
@@ -66,7 +58,7 @@ class Command
      *
      * @throws LogicException When the command name is empty
      */
-    public function __construct(?string $name = null)
+    public function __construct(?string $name = null, ?callable $code = null)
     {
     }
 
@@ -74,24 +66,16 @@ class Command
      * Ignores validation errors.
      *
      * This is mainly useful for the help command.
-     *
-     * @return void
      */
-    public function ignoreValidationErrors()
+    public function ignoreValidationErrors(): void
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setApplication(?Application $application = null)
+    public function setApplication(?Application $application): void
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setHelperSet(HelperSet $helperSet)
+    public function setHelperSet(HelperSet $helperSet): void
     {
     }
 
@@ -114,10 +98,8 @@ class Command
      *
      * Override this to check for x or y and return false if the command cannot
      * run properly under the current conditions.
-     *
-     * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
     }
 
@@ -144,7 +126,7 @@ class Command
      *
      * @see setCode()
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
     }
 
@@ -196,9 +178,18 @@ class Command
     }
 
     /**
-     * Adds suggestions to $suggestions for the current completion input (e.g. option or argument).
+     * Supplies suggestions when resolving possible completion options for input (e.g. option or argument).
      */
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+    }
+
+    /**
+     * Gets the code that is executed by the command.
+     *
+     * @return ?callable null if the code has not been set with setCode()
+     */
+    public function getCode(): ?callable
     {
     }
 
@@ -264,31 +255,31 @@ class Command
     /**
      * Adds an argument.
      *
-     * @param $mode    The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
-     * @param $default The default value (for InputArgument::OPTIONAL mode only)
+     * @param                                                                               $mode            The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param                                                                               $default         The default value (for InputArgument::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @return $this
      *
      * @throws InvalidArgumentException When argument mode is not valid
      */
-    public function addArgument(string $name, ?int $mode = null, string $description = '', mixed $default = null): static
+    public function addArgument(string $name, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
     }
 
     /**
      * Adds an option.
      *
-     * @param $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param $mode     The option mode: One of the InputOption::VALUE_* constants
-     * @param $default  The default value (must be null for InputOption::VALUE_NONE)
+     * @param                                                                               $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param                                                                               $mode            The option mode: One of the InputOption::VALUE_* constants
+     * @param                                                                               $default         The default value (must be null for InputOption::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @return $this
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */
-    public function addOption(string $name, string|array|null $shortcut = null, ?int $mode = null, string $description = '', mixed $default = null): static
+    public function addOption(string $name, string|array|null $shortcut = null, ?int $mode = null, string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
     }
 
@@ -431,12 +422,18 @@ class Command
     /**
      * Gets a helper instance by name.
      *
-     * @return HelperInterface
-     *
      * @throws LogicException           if no HelperSet is defined
      * @throws InvalidArgumentException if the helper is not defined
      */
-    public function getHelper(string $name): mixed
+    public function getHelper(string $name): HelperInterface
+    {
+    }
+
+    public function getSubscribedSignals(): array
+    {
+    }
+
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
     }
 }

--- a/tests/stubs/symfony_component_console_helper_helper.php
+++ b/tests/stubs/symfony_component_console_helper_helper.php
@@ -21,12 +21,9 @@ use Symfony\Component\String\UnicodeString;
  */
 abstract class Helper implements HelperInterface
 {
-    protected $helperSet;
+    protected ?HelperSet $helperSet = null;
 
-    /**
-     * @return void
-     */
-    public function setHelperSet(?HelperSet $helperSet = null)
+    public function setHelperSet(?HelperSet $helperSet): void
     {
     }
 
@@ -57,24 +54,15 @@ abstract class Helper implements HelperInterface
     {
     }
 
-    /**
-     * @return string
-     */
-    public static function formatTime(int|float $secs, int $precision = 1)
+    public static function formatTime(int|float $secs, int $precision = 1): string
     {
     }
 
-    /**
-     * @return string
-     */
-    public static function formatMemory(int $memory)
+    public static function formatMemory(int $memory): string
     {
     }
 
-    /**
-     * @return string
-     */
-    public static function removeDecoration(OutputFormatterInterface $formatter, ?string $string)
+    public static function removeDecoration(OutputFormatterInterface $formatter, ?string $string): string
     {
     }
 }

--- a/tests/stubs/symfony_component_console_helper_helperinterface.php
+++ b/tests/stubs/symfony_component_console_helper_helperinterface.php
@@ -20,10 +20,8 @@ interface HelperInterface
 {
     /**
      * Sets the helper set associated with this helper.
-     *
-     * @return void
      */
-    public function setHelperSet(?HelperSet $helperSet)
+    public function setHelperSet(?HelperSet $helperSet): void
     {
     }
 
@@ -36,10 +34,8 @@ interface HelperInterface
 
     /**
      * Returns the canonical name of this helper.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
     }
 }

--- a/tests/stubs/symfony_component_console_helper_questionhelper.php
+++ b/tests/stubs/symfony_component_console_helper_questionhelper.php
@@ -51,19 +51,15 @@ class QuestionHelper extends Helper
 
     /**
      * Prevents usage of stty.
-     *
-     * @return void
      */
-    public static function disableStty()
+    public static function disableStty(): void
     {
     }
 
     /**
      * Outputs the question prompt.
-     *
-     * @return void
      */
-    protected function writePrompt(OutputInterface $output, Question $question)
+    protected function writePrompt(OutputInterface $output, Question $question): void
     {
     }
 
@@ -76,10 +72,8 @@ class QuestionHelper extends Helper
 
     /**
      * Outputs an error message.
-     *
-     * @return void
      */
-    protected function writeError(OutputInterface $output, \Exception $error)
+    protected function writeError(OutputInterface $output, \Exception $error): void
     {
     }
 }

--- a/tests/stubs/symfony_component_console_helper_table.php
+++ b/tests/stubs/symfony_component_console_helper_table.php
@@ -39,16 +39,14 @@ class Table
     private const DISPLAY_ORIENTATION_HORIZONTAL = 'horizontal';
     private const DISPLAY_ORIENTATION_VERTICAL = 'vertical';
 
-    public function __construct(OutputInterface $output)
+    public function __construct(private OutputInterface $output)
     {
     }
 
     /**
      * Sets a style definition.
-     *
-     * @return void
      */
-    public static function setStyleDefinition(string $name, TableStyle $style)
+    public static function setStyleDefinition(string $name, TableStyle $style): void
     {
     }
 
@@ -135,7 +133,7 @@ class Table
     /**
      * @return $this
      */
-    public function setRows(array $rows)
+    public function setRows(array $rows): static
     {
     }
 
@@ -209,10 +207,8 @@ class Table
      *     | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
      *     | 960-425-059-0 | The Lord of the Rings | J. R. R. Tolkien |
      *     +---------------+-----------------------+------------------+
-     *
-     * @return void
      */
-    public function render()
+    public function render(): void
     {
     }
 }

--- a/tests/stubs/symfony_component_console_input_inputargument.php
+++ b/tests/stubs/symfony_component_console_input_inputargument.php
@@ -25,20 +25,31 @@ use Symfony\Component\Console\Exception\LogicException;
  */
 class InputArgument
 {
+    /**
+     * Providing an argument is required (e.g. just 'app:foo' is not allowed).
+     */
     public const REQUIRED = 1;
+
+    /**
+     * Providing an argument is optional (e.g. 'app:foo' and 'app:foo bar' are both allowed). This is the default behavior of arguments.
+     */
     public const OPTIONAL = 2;
+
+    /**
+     * The argument accepts multiple values and turn them into an array (e.g. 'app:foo bar baz' will result in value ['bar', 'baz']).
+     */
     public const IS_ARRAY = 4;
 
     /**
      * @param string                                                                        $name            The argument name
-     * @param int|null                                                                      $mode            The argument mode: a bit mask of self::REQUIRED, self::OPTIONAL and self::IS_ARRAY
+     * @param int-mask-of<InputArgument::*>|null                                            $mode            The argument mode: a bit mask of self::REQUIRED, self::OPTIONAL and self::IS_ARRAY
      * @param string                                                                        $description     A description text
      * @param string|bool|int|float|array|null                                              $default         The default value (for self::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @throws InvalidArgumentException When argument mode is not valid
      */
-    public function __construct(string $name, ?int $mode = null, string $description = '', string|bool|int|float|array|null $default = null, \Closure|array $suggestedValues = [])
+    public function __construct(private string $name, ?int $mode = null, private string $description = '', string|bool|int|float|array|null $default = null, private \Closure|array $suggestedValues = [])
     {
     }
 
@@ -69,12 +80,8 @@ class InputArgument
 
     /**
      * Sets the default value.
-     *
-     * @return void
-     *
-     * @throws LogicException When incorrect default value is given
      */
-    public function setDefault(string|bool|int|float|array|null $default = null)
+    public function setDefault(string|bool|int|float|array|null $default): void
     {
     }
 
@@ -85,12 +92,15 @@ class InputArgument
     {
     }
 
+    /**
+     * Returns true if the argument has values for input completion.
+     */
     public function hasCompletion(): bool
     {
     }
 
     /**
-     * Adds suggestions to $suggestions for the current completion input.
+     * Supplies suggestions when command resolves possible completion options for input.
      *
      * @see Command::complete()
      */

--- a/tests/stubs/symfony_component_console_input_inputinterface.php
+++ b/tests/stubs/symfony_component_console_input_inputinterface.php
@@ -18,9 +18,6 @@ use Symfony\Component\Console\Exception\RuntimeException;
  * InputInterface is the interface implemented by all input classes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @method string __toString() Returns a stringified representation of the args passed to the command.
- *                             InputArguments MUST be escaped as well as the InputOption values passed to the command.
  */
 interface InputInterface
 {
@@ -57,32 +54,26 @@ interface InputInterface
      * @param string|array                     $values     The value(s) to look for in the raw parameters (can be an array)
      * @param string|bool|int|float|array|null $default    The default value to return if no result is found
      * @param bool                             $onlyParams Only check real parameters, skip those following an end of options (--) signal
-     *
-     * @return mixed
      */
-    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false)
+    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false): mixed
     {
     }
 
     /**
      * Binds the current Input instance with the given arguments and options.
      *
-     * @return void
-     *
      * @throws RuntimeException
      */
-    public function bind(InputDefinition $definition)
+    public function bind(InputDefinition $definition): void
     {
     }
 
     /**
      * Validates the input.
      *
-     * @return void
-     *
      * @throws RuntimeException When not enough arguments are given
      */
-    public function validate()
+    public function validate(): void
     {
     }
 
@@ -98,22 +89,18 @@ interface InputInterface
     /**
      * Returns the argument value for a given argument name.
      *
-     * @return mixed
-     *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
-    public function getArgument(string $name)
+    public function getArgument(string $name): mixed
     {
     }
 
     /**
      * Sets an argument value by name.
      *
-     * @return void
-     *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
-    public function setArgument(string $name, mixed $value)
+    public function setArgument(string $name, mixed $value): void
     {
     }
 
@@ -136,22 +123,18 @@ interface InputInterface
     /**
      * Returns the option value for a given option name.
      *
-     * @return mixed
-     *
      * @throws InvalidArgumentException When option given doesn't exist
      */
-    public function getOption(string $name)
+    public function getOption(string $name): mixed
     {
     }
 
     /**
      * Sets an option value by name.
      *
-     * @return void
-     *
      * @throws InvalidArgumentException When option given doesn't exist
      */
-    public function setOption(string $name, mixed $value)
+    public function setOption(string $name, mixed $value): void
     {
     }
 
@@ -171,10 +154,17 @@ interface InputInterface
 
     /**
      * Sets the input interactivity.
-     *
-     * @return void
      */
-    public function setInteractive(bool $interactive)
+    public function setInteractive(bool $interactive): void
+    {
+    }
+
+    /**
+     * Returns a stringified representation of the args passed to the command.
+     *
+     * InputArguments MUST be escaped as well as the InputOption values passed to the command.
+     */
+    public function __toString(): string
     {
     }
 }

--- a/tests/stubs/symfony_component_console_input_inputoption.php
+++ b/tests/stubs/symfony_component_console_input_inputoption.php
@@ -46,19 +46,19 @@ class InputOption
     public const VALUE_IS_ARRAY = 8;
 
     /**
-     * The option may have either positive or negative value (e.g. --ansi or --no-ansi).
+     * The option allows passing a negated variant (e.g. --ansi or --no-ansi).
      */
     public const VALUE_NEGATABLE = 16;
 
     /**
      * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                                                                      $mode            The option mode: One of the VALUE_* constants
+     * @param int-mask-of<InputOption::*>|null                                              $mode            The option mode: One of the VALUE_* constants
      * @param string|bool|int|float|array|null                                              $default         The default value (must be null for self::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */
-    public function __construct(string $name, string|array|null $shortcut = null, ?int $mode = null, string $description = '', string|bool|int|float|array|null $default = null, array|\Closure $suggestedValues = [])
+    public function __construct(string $name, string|array|null $shortcut = null, ?int $mode = null, private string $description = '', string|bool|int|float|array|null $default = null, private array|\Closure $suggestedValues = [])
     {
     }
 
@@ -112,14 +112,19 @@ class InputOption
     {
     }
 
+    /**
+     * Returns true if the option allows passing a negated variant.
+     *
+     * @return bool true if mode is self::VALUE_NEGATABLE, false otherwise
+     */
     public function isNegatable(): bool
     {
     }
 
     /**
-     * @return void
+     * Sets the default value.
      */
-    public function setDefault(string|bool|int|float|array|null $default = null)
+    public function setDefault(string|bool|int|float|array|null $default): void
     {
     }
 
@@ -137,12 +142,15 @@ class InputOption
     {
     }
 
+    /**
+     * Returns true if the option has values for input completion.
+     */
     public function hasCompletion(): bool
     {
     }
 
     /**
-     * Adds suggestions to $suggestions for the current completion input.
+     * Supplies suggestions when command resolves possible completion options for input.
      *
      * @see Command::complete()
      */

--- a/tests/stubs/symfony_component_console_output_consoleoutput.php
+++ b/tests/stubs/symfony_component_console_output_consoleoutput.php
@@ -45,24 +45,15 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setDecorated(bool $decorated)
+    public function setDecorated(bool $decorated): void
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setFormatter(OutputFormatterInterface $formatter)
+    public function setFormatter(OutputFormatterInterface $formatter): void
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setVerbosity(int $level)
+    public function setVerbosity(int $level): void
     {
     }
 
@@ -70,10 +61,7 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setErrorOutput(OutputInterface $error)
+    public function setErrorOutput(OutputInterface $error): void
     {
     }
 

--- a/tests/stubs/symfony_component_console_output_consoleoutputinterface.php
+++ b/tests/stubs/symfony_component_console_output_consoleoutputinterface.php
@@ -26,10 +26,7 @@ interface ConsoleOutputInterface extends OutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setErrorOutput(OutputInterface $error)
+    public function setErrorOutput(OutputInterface $error): void
     {
     }
 

--- a/tests/stubs/symfony_component_console_output_consolesectionoutput.php
+++ b/tests/stubs/symfony_component_console_output_consolesectionoutput.php
@@ -43,19 +43,15 @@ class ConsoleSectionOutput extends StreamOutput
      * Clears previous output for this section.
      *
      * @param int $lines Number of lines to clear. If null, then the entire output of this section is cleared
-     *
-     * @return void
      */
-    public function clear(?int $lines = null)
+    public function clear(?int $lines = null): void
     {
     }
 
     /**
      * Overwrites the previous output with a new message.
-     *
-     * @return void
      */
-    public function overwrite(string|iterable $message)
+    public function overwrite(string|iterable $message): void
     {
     }
 
@@ -81,10 +77,7 @@ class ConsoleSectionOutput extends StreamOutput
     {
     }
 
-    /**
-     * @return void
-     */
-    protected function doWrite(string $message, bool $newline)
+    protected function doWrite(string $message, bool $newline): void
     {
     }
 }

--- a/tests/stubs/symfony_component_console_output_output.php
+++ b/tests/stubs/symfony_component_console_output_output.php
@@ -17,13 +17,14 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 /**
  * Base class for output classes.
  *
- * There are five levels of verbosity:
+ * There are six levels of verbosity:
  *
  *  * normal: no option passed (normal output)
  *  * verbose: -v (more output)
  *  * very verbose: -vv (highly extended output)
  *  * debug: -vvv (all debug output)
- *  * quiet: -q (no output)
+ *  * quiet: -q (only output errors)
+ *  * silent: --silent (no output)
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -38,10 +39,7 @@ abstract class Output implements OutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setFormatter(OutputFormatterInterface $formatter)
+    public function setFormatter(OutputFormatterInterface $formatter): void
     {
     }
 
@@ -49,10 +47,7 @@ abstract class Output implements OutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setDecorated(bool $decorated)
+    public function setDecorated(bool $decorated): void
     {
     }
 
@@ -60,14 +55,15 @@ abstract class Output implements OutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setVerbosity(int $level)
+    public function setVerbosity(int $level): void
     {
     }
 
     public function getVerbosity(): int
+    {
+    }
+
+    public function isSilent(): bool
     {
     }
 
@@ -87,26 +83,18 @@ abstract class Output implements OutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function writeln(string|iterable $messages, int $options = self::OUTPUT_NORMAL)
+    public function writeln(string|iterable $messages, int $options = self::OUTPUT_NORMAL): void
     {
     }
 
-    /**
-     * @return void
-     */
-    public function write(string|iterable $messages, bool $newline = false, int $options = self::OUTPUT_NORMAL)
+    public function write(string|iterable $messages, bool $newline = false, int $options = self::OUTPUT_NORMAL): void
     {
     }
 
     /**
      * Writes a message to the output.
-     *
-     * @return void
      */
-    abstract protected function doWrite(string $message, bool $newline)
+    abstract protected function doWrite(string $message, bool $newline): void
     {
     }
 }

--- a/tests/stubs/symfony_component_console_output_outputinterface.php
+++ b/tests/stubs/symfony_component_console_output_outputinterface.php
@@ -17,9 +17,12 @@ use Symfony\Component\Console\Formatter\OutputFormatterInterface;
  * OutputInterface is the interface implemented by all Output classes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method bool isSilent()
  */
 interface OutputInterface
 {
+    public const VERBOSITY_SILENT = 8;
     public const VERBOSITY_QUIET = 16;
     public const VERBOSITY_NORMAL = 32;
     public const VERBOSITY_VERBOSE = 64;
@@ -36,10 +39,8 @@ interface OutputInterface
      * @param bool $newline Whether to add a newline
      * @param int  $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
      *                      0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
-     *
-     * @return void
      */
-    public function write(string|iterable $messages, bool $newline = false, int $options = 0)
+    public function write(string|iterable $messages, bool $newline = false, int $options = 0): void
     {
     }
 
@@ -48,10 +49,8 @@ interface OutputInterface
      *
      * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants),
      *                     0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
-     *
-     * @return void
      */
-    public function writeln(string|iterable $messages, int $options = 0)
+    public function writeln(string|iterable $messages, int $options = 0): void
     {
     }
 
@@ -59,10 +58,8 @@ interface OutputInterface
      * Sets the verbosity of the output.
      *
      * @param self::VERBOSITY_* $level
-     *
-     * @return void
      */
-    public function setVerbosity(int $level)
+    public function setVerbosity(int $level): void
     {
     }
 
@@ -105,10 +102,8 @@ interface OutputInterface
 
     /**
      * Sets the decorated flag.
-     *
-     * @return void
      */
-    public function setDecorated(bool $decorated)
+    public function setDecorated(bool $decorated): void
     {
     }
 
@@ -119,10 +114,7 @@ interface OutputInterface
     {
     }
 
-    /**
-     * @return void
-     */
-    public function setFormatter(OutputFormatterInterface $formatter)
+    public function setFormatter(OutputFormatterInterface $formatter): void
     {
     }
 

--- a/tests/stubs/symfony_component_console_output_streamoutput.php
+++ b/tests/stubs/symfony_component_console_output_streamoutput.php
@@ -50,10 +50,7 @@ class StreamOutput extends Output
     {
     }
 
-    /**
-     * @return void
-     */
-    protected function doWrite(string $message, bool $newline)
+    protected function doWrite(string $message, bool $newline): void
     {
     }
 

--- a/tests/stubs/symfony_component_console_question_confirmationquestion.php
+++ b/tests/stubs/symfony_component_console_question_confirmationquestion.php
@@ -23,7 +23,7 @@ class ConfirmationQuestion extends Question
      * @param bool   $default         The default answer to return, true or false
      * @param string $trueAnswerRegex A regex to match the "yes" answer
      */
-    public function __construct(string $question, bool $default = true, string $trueAnswerRegex = '/^y/i')
+    public function __construct(string $question, bool $default = true, private string $trueAnswerRegex = '/^y/i')
     {
     }
 }

--- a/tests/stubs/symfony_component_console_question_question.php
+++ b/tests/stubs/symfony_component_console_question_question.php
@@ -25,8 +25,10 @@ class Question
      * @param string                     $question The question to ask to the user
      * @param string|bool|int|float|null $default  The default answer to return if the user enters nothing
      */
-    public function __construct(string $question, string|bool|int|float|null $default = null)
-    {
+    public function __construct(
+        private string $question,
+        private string|bool|int|float|null $default = null,
+    ) {
     }
 
     /**
@@ -56,6 +58,23 @@ class Question
      * @return $this
      */
     public function setMultiline(bool $multiline): static
+    {
+    }
+
+    /**
+     * Returns the timeout in seconds.
+     */
+    public function getTimeout(): ?int
+    {
+    }
+
+    /**
+     * Sets the maximum time the user has to answer the question.
+     * If the user does not answer within this time, an exception will be thrown.
+     *
+     * @return $this
+     */
+    public function setTimeout(?int $seconds): static
     {
     }
 
@@ -113,6 +132,8 @@ class Question
 
     /**
      * Gets the callback function used for the autocompleter.
+     *
+     * @return (callable(string):string[])|null
      */
     public function getAutocompleterCallback(): ?callable
     {
@@ -123,23 +144,29 @@ class Question
      *
      * The callback is passed the user input as argument and should return an iterable of corresponding suggestions.
      *
+     * @param (callable(string):string[])|null $callback
+     *
      * @return $this
      */
-    public function setAutocompleterCallback(?callable $callback = null): static
+    public function setAutocompleterCallback(?callable $callback): static
     {
     }
 
     /**
      * Sets a validator for the question.
      *
+     * @param (callable(mixed):mixed)|null $validator
+     *
      * @return $this
      */
-    public function setValidator(?callable $validator = null): static
+    public function setValidator(?callable $validator): static
     {
     }
 
     /**
      * Gets the validator for the question.
+     *
+     * @return (callable(mixed):mixed)|null
      */
     public function getValidator(): ?callable
     {
@@ -170,7 +197,7 @@ class Question
     /**
      * Sets a normalizer for the response.
      *
-     * The normalizer can be a callable (a string), a closure or a class implementing __invoke.
+     * @param callable(mixed):mixed $normalizer
      *
      * @return $this
      */
@@ -181,16 +208,13 @@ class Question
     /**
      * Gets the normalizer for the response.
      *
-     * The normalizer can ba a callable (a string), a closure or a class implementing __invoke.
+     * @return (callable(mixed):mixed)|null
      */
     public function getNormalizer(): ?callable
     {
     }
 
-    /**
-     * @return bool
-     */
-    protected function isAssoc(array $array)
+    protected function isAssoc(array $array): bool
     {
     }
 

--- a/tests/stubs/symfony_component_process_process.php
+++ b/tests/stubs/symfony_component_process_process.php
@@ -187,7 +187,12 @@ class Process implements \IteratorAggregate
      *
      * @return $this
      *
-     * @throws ProcessFailedException if the process didn't terminate successfully
+     * @throws ProcessFailedException   When process didn't terminate successfully
+     * @throws RuntimeException         When process can't be launched
+     * @throws RuntimeException         When process is already running
+     * @throws ProcessTimedOutException When process timed out
+     * @throws ProcessSignaledException When process stopped after receiving signal
+     * @throws LogicException           In case a callback is provided and output has been disabled
      *
      * @final
      */


### PR DESCRIPTION
* Resolves: #

## Summary

- Updates stubs located inside `tests/stubs`

### How I updated the stubs
- checkout to `master` on `server` and `circles`
- `git pull origin master` on `server` and `circles`
- `composer install` on `server` and `circles`
- `git clone https://codeberg.org/provokateurin/php-stubs-updater` inside `circles` app folder
- composer install inside `php-stubs-updater/` folder
- from `circles` app folder:
```bash
php -d memory_limit=-1 php-stubs-updater/update-stubs.php tests/stubs ../../
```
> I'm aware that more specific folders could have been passed as param instead of just `../../`, but as I didn't knew exactly which folders are needed I used nextcloud's root and `memory_limit=-1`
- psalm reported a `class or interface oc\db\querybuilder\typedquerybuilder that does not exist` error, so I added `<file name="tests/stubs/oc_db_querybuilder_typedquerybuilder.php" />` to `psalm.xml` and ran `generate-empty-psalm-stubs.php` to create the missing empty stub file
- ran the `update-stubs.php` command once again

@provokateurin would appreciate some input here to know if I did it correctly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI