### PR TITLE
fix(shared-with-list): adjust resource filtering

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -183,18 +183,16 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 
 
 	/**
-	 * @param string $circleId
-	 * @param FederatedUser|null $shareRecipient
-	 * @param FederatedUser|null $shareInitiator
-	 * @param bool $completeDetails
-	 *
 	 * @return ShareWrapper[]
 	 * @throws RequestBuilderException
 	 */
-	public function getSharesToCircles(array $circleIds): array {
+	public function getSharesToCircles(array $circleIds, ?string $fileId = null): array {
 		$qb = $this->getShareSelectSql();
 		$qb->limitNull('parent', false);
-		$qb->expr()->in('share_with', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY));
+		$qb->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY)));
+		if ($fileId !== null) {
+			$qb->limitToFileSource((int)$fileId);
+		}
 		return $this->getItemsFromRequest($qb);
 	}
 

--- a/lib/FileSharingTeamResourceProvider.php
+++ b/lib/FileSharingTeamResourceProvider.php
@@ -20,7 +20,7 @@ class FileSharingTeamResourceProvider implements ITeamResourceProvider {
 	public function __construct(
 		private IL10N $l10n,
 		private ?CirclesManager $circlesManager,
-		private ShareWrapperService $shareByCircleProvider,
+		private ShareWrapperService $shareWrapperService,
 		private IURLGenerator $urlGenerator,
 	) {
 	}
@@ -42,24 +42,20 @@ class FileSharingTeamResourceProvider implements ITeamResourceProvider {
 			return [];
 		}
 
-		$shares = $this->shareByCircleProvider->getSharesToCircle($teamId);
+		$shares = $this->shareWrapperService->getSharesToCircle($teamId);
 		return $this->convertWrappedShareToResource($shares);
 	}
 
 	/**
 	 * @return array<string, TeamResource[]>
 	 */
-	public function getSharedWithList(array $teams): array {
-		$data = $shares = [];
-		foreach ($this->shareByCircleProvider->getSharesToCircles($teams) as $share) {
-			if (!array_key_exists($share->getId(), $shares)) {
-				$shares[$share->getSharedWith()] = [];
-			}
+	public function getSharedWithList(array $teams, string $resourceId): array {
+		$shares = $data = [];
+		foreach ($this->shareWrapperService->getSharesToCircles($teams, $resourceId) as $share) {
 			$shares[$share->getSharedWith()][] = $share;
 		}
-
 		foreach ($teams as $teamId) {
-			$data[$teamId] = $this->convertWrappedShareToResource($shares[$teamId]);
+			$data[$teamId] = $this->convertWrappedShareToResource($shares[$teamId] ?? []);
 		}
 
 		return $data;
@@ -105,7 +101,7 @@ class FileSharingTeamResourceProvider implements ITeamResourceProvider {
 			return [];
 		}
 
-		$shares = $this->shareByCircleProvider->getSharesByFileId((int)$resourceId);
+		$shares = $this->shareWrapperService->getSharesByFileId((int)$resourceId);
 
 		return array_map(function ($share) {
 			return $share->getSharedWith();

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -116,8 +116,8 @@ class ShareWrapperService {
 	/**
 	 * @return ShareWrapper[]
 	 */
-	public function getSharesToCircles(array $circleIds): array {
-		return $this->shareWrapperRequest->getSharesToCircles($circleIds);
+	public function getSharesToCircles(array $circleIds, ?string $fileId = null): array {
+		return $this->shareWrapperRequest->getSharesToCircles($circleIds, $fileId);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: #
* Related to: https://github.com/nextcloud/server/pull/59903

## Summary

Adjust resource filtering when getting shared with list.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI