### PR TITLE
fix(event): new indexes based on status

### DIFF
--- a/lib/Migration/Version0034Date20260428110733.php
+++ b/lib/Migration/Version0034Date20260428110733.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+#[AddIndex('circles_event', IndexType::INDEX, 'lighten the cleaning of the table')]
+class Version0034Date20260428110733 extends SimpleMigrationStep {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+
+        try {
+            $table = $schema->getTable('circles_event');
+            if ($table->hasIndex('circles_event_sc_cr')) {
+                return null;
+            }
+
+            $table->addIndex(['status', 'creation'], 'circles_event_sc_cr');
+        } catch (SchemaException $e) {
+            $this->logger->warning('Could not add index to circles_event', ['exception' => $e]);
+            return null;
+        }
+
+        return $schema;
+    }
+}


### PR DESCRIPTION
adding an index on `status` and `creation` to lighten some request, mainly when cleaning the table:

https://github.com/nextcloud/circles/blob/5edae1f33d5106984284f9a427403a3fe7112cc1/lib/Db/EventWrapperRequest.php#L129-L140

In some edgy use case, the table might be too big for the purge to be fulfill, cascading with an ever growing database

_note: backport will require an upgrade of the version_