### PR TITLE
build: add .nextcloudignore for release builds

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+.git
+.gitattributes
+.github
+.gitignore
+.nextcloudignore
+.php-cs-fixer.dist.php
+.tx
+
+/AUTHORS.md
+/CHANGELOG.md
+/composer.json
+/composer.lock
+/Makefile
+/node_modules
+/package.json
+/package-lock.json
+/phpDocumentor.sh
+/psalm.xml
+/README.md
+/rector.php
+/REUSE.toml
+/screenshots
+/src
+/testConfiguration.json
+/testConfiguration.json.license
+/tests
+/tsconfig.json
+/vendor-bin


### PR DESCRIPTION
## Summary

Add `.nextcloudignore` file to strip dev/build files from release archives.

This file was missing on stable branches, causing release builds to include unnecessary files like `phpDocumentor.sh`, `testConfiguration.json`, `vendor-bin/`, `src/`, `tests/`, build configs, etc.

Other bundled apps (suspicious_login, bruteforcesettings, twofactor_totp, etc.) already have this file.

## Entries

- Build tooling: `composer.*`, `package.*`, `Makefile`, `node_modules`
- Source/test dirs: `src/`, `tests/`, `screenshots/`, `vendor-bin/`
- Config files: `psalm.xml`, `rector.php`, `tsconfig.json`, `.php-cs-fixer.dist.php`
- Dev docs: `README.md`, `AUTHORS.md`, `CHANGELOG.md`, `REUSE.toml`
- Circles-specific: `phpDocumentor.sh`, `testConfiguration.json`
- Git artifacts: `.git`, `.github`, `.gitignore`, `.gitattributes`, `.tx`

## Test plan

- [ ] Verify release archive no longer contains dev files
- [ ] Backport to other stable branches