### PR TITLE
Feat: Get GSS Mockup Server from database

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -424,9 +424,21 @@ class ConfigService {
 
 
 	/**
-	 * @return array
-	 */
+	* Returns the list of GSS mockup instances.
+	* @return array
+	*/
 	public function getGSSMockup(): array {
+		// Try reading from the database (app config)
+		$dbValue = $this->config->getAppValue(Application::APP_ID, 'gss.mockup', '');
+
+		if ($dbValue !== '') {
+			$decoded = json_decode($dbValue, true);
+			if (is_array($decoded)) {
+				return $decoded;
+			}
+		}
+
+		// Fall back to system config (config.php) for backward compatibility
 		return $this->config->getSystemValue('gss.mockup', []);
 	}
 


### PR DESCRIPTION
## Summary


To set up federated groups in Nextcloud without using the Global Scale architecture, a configuration option must now be added to each Nextcloud backend, containing an array of all trusted environments.

This appears to be more or less the same as the list of trusted servers that can already be configured for Federated Document Editing, for example, via https://docs.nextcloud.com/server/32/admin_manual/configuration_files/federated_cloud_sharing_configuration.html

Where having a separate configuration file on every backend is very scalable, especially when it comes to adding or removing sites. This option make a database array also possible, with current array in the config as fallback option.

## How to use
 
 Prefers app config (database) over system config (config.php) for flexibility.
 To set via occ:
 ```
occ config:app:set circles gss.mockup --value='["nextcloud1.example.nl","nextcloud2.example.nl"]'
```

Current config option is still supported as fallback scenario;
```
$CONFIG = array (
   'allow_local_remove_servers' => true,
   'gss.mockup' => ['[nextcloud1.example.nl](http://nextcloud1.example.nl/)','[nextcloud2.example.nl](http://nextcloud2.example.nl/)'],
);
```
