### PR TITLE
fix(local-controller): dont show full config int of circle for non-members

### DIFF
--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -19,6 +19,7 @@ use OCA\Circles\Exceptions\InvalidIdException;
 use OCA\Circles\Exceptions\MemberNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\Exceptions\SingleCircleNotFoundException;
+use OCA\Circles\Model\Circle;
 use OCA\Circles\Model\FederatedUser;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\BasicProbe;
@@ -386,7 +387,15 @@ class LocalController extends OCSController {
 				->setItemsLimit($limit)
 				->setItemsOffset($offset);
 
-			return new DataResponse($this->serializeArray($this->circleService->getCircles($probe)));
+			// hide configs of "visible to everyone" circles for non-members (return only CFG_VISIBLE)
+			$circles = (array_map(function (Circle $circle) {
+				if ($circle->isConfig(Circle::CFG_VISIBLE) && !$circle->hasInitiator()) {
+					$circle->setConfig(Circle::CFG_VISIBLE);
+				}
+				return $circle;
+			}, $this->circleService->getCircles($probe)));
+
+			return new DataResponse($this->serializeArray($circles));
 		} catch (Exception $e) {
 			$this->e($e);
 			throw new OCSException($e->getMessage(), (int)$e->getCode());


### PR DESCRIPTION
### Summary

- for non-members of "visible to everyone" circles, config is stripped down to `Circle::CFG_VISIBLE` only

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI