### PR TITLE
fix(local-controller): include CFG_OPEN in config mask for visible circles

### DIFF
--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -355,10 +355,15 @@ class LocalController extends OCSController {
 				->setItemsLimit($limit)
 				->setItemsOffset($offset);
 
-			// hide configs of "visible to everyone" circles for non-members (return only CFG_VISIBLE)
+			// hide full config of "visible to everyone" circles for non-members
 			$circles = (array_map(function (Circle $circle) {
 				if ($circle->isConfig(Circle::CFG_VISIBLE) && !$circle->hasInitiator()) {
-					$circle->setConfig(Circle::CFG_VISIBLE);
+					// return only configs needed by frontend
+					$circleConfig = Circle::CFG_VISIBLE;
+					if ($circle->isConfig(Circle::CFG_OPEN)) {
+						$circleConfig += Circle::CFG_OPEN;
+					}
+					$circle->setConfig($circleConfig);
 				}
 				return $circle;
 			}, $this->circleService->getCircles($probe)));


### PR DESCRIPTION
* Related to: https://github.com/nextcloud/circles/pull/2523

### Summary

- the related PR linked above introduced a regression
  - for context, a circle's config is a bitwise integer, as seen [here](https://github.com/nextcloud/circles/blob/master/lib/Model/Circle.php#L79)
  - the idea was to not expose the full config of a circle to non-members on `GET ocs/v2.php/apps/circles/circles`
  - to achieve that, the returned config was stripped down to only `Circle::CFG_VISIBLE` for non-members
  - however, one oversight is that `Circle::CFG_OPEN` is also needed by the frontend to decide whether a user can request to join
- this PR fixes that, so when a non-member fetches a "visible to everyone" circle, instead of returning only `Circle::CFG_VISIBLE`, value of `Circle::CFG_OPEN` is also returned
- before this fix, if john creates `test_team` with `CFG_VISIBLE` and `CFG_OPEN` enabled, bob can see the circle but cannot request to join
- after this fix, bob can see and use the "request to join" option again, since `Circle::CFG_OPEN` is included
- all other configs returned on circle object remain hidden for non-members, preserving the intent of the original PR

### Screenshots

| john's circle | bob screen (before fix) | bob screen (after fix) |
|:---:|:---:|:---:|
| <img width="689" alt="John's circle config" src="https://github.com/user-attachments/assets/6c464e03-0927-486c-a773-63f39b03e2cb" /> | <img width="689" alt="Bob before fix" src="https://github.com/user-attachments/assets/7b78c34e-3772-4423-8514-16f5fc0d3c21" /> | <img width="689" alt="Bob after fix" src="https://github.com/user-attachments/assets/f1e749a4-3d5d-440e-ab63-5e2928529a6f" /> |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI