### PR TITLE
Avoid `occ circles:check` from failing because of outdated cache values

### DIFF
--- a/lib/Command/CirclesCheck.php
+++ b/lib/Command/CirclesCheck.php
@@ -10,6 +10,7 @@ namespace OCA\Circles\Command;
 
 use Exception;
 use OC\Core\Command\Base;
+use OC\Memcache\APCu;
 use OCA\Circles\AppInfo\Application;
 use OCA\Circles\AppInfo\Capabilities;
 use OCA\Circles\Exceptions\FederatedEventException;
@@ -39,6 +40,7 @@ use OCA\Circles\Tools\Traits\TArrayTools;
 use OCA\Circles\Tools\Traits\TNCRequest;
 use OCA\Circles\Tools\Traits\TStringTools;
 use OCP\IAppConfig;
+use OCP\IConfig;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -67,6 +69,7 @@ class CirclesCheck extends Base {
 	public function __construct(
 		private Capabilities $capabilities,
 		private IAppConfig $appConfig,
+		private IConfig $config,
 		private InterfaceService $interfaceService,
 		private FederatedEventService $federatedEventService,
 		private RemoteService $remoteService,
@@ -260,6 +263,17 @@ class CirclesCheck extends Base {
 
 		if (!$this->testRequest($output, 'GET', 'core.CSRFToken.index')) {
 			return false;
+		}
+
+		$localIsApcu = ltrim($this->config->getSystemValueString('memcache.local'), '\\') === '\OC\Memcache\APCu';
+		if ($localIsApcu) {
+			/*
+			 * APCu cache is not shared between the CLI process and web requests, so freshly
+			 * set values will either be missing or stale and make the check fail.
+			 * The amount of seconds slept here depends on the TTL set by the AppConfig.
+			 */
+			$output->writeln('- Waiting for APCu config cache to refresh (4s)');
+			sleep(4);
 		}
 
 		if (!$this->testRequest(


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The `occ circles:check` command sets and reads values from `IAppConfig`, and so does the service called by it, to perform checks.

During the loopback check, the code sets the value in the app config for a dummy token, before issuing a request that reads this value. Since the app config can use caches, when the local cache is set to APCu, the cache is not shared between CLI and HTTP workers. This results in random failures caused by the fact that a worker may receive the HTTP request and still hold the out-of-date config value.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
