### PR TITLE
fix(permission): get permissions for user from inherited when not direct member

### DIFF
--- a/lib/Db/MembershipRequest.php
+++ b/lib/Db/MembershipRequest.php
@@ -82,6 +82,26 @@ class MembershipRequest extends MembershipRequestBuilder {
 
 
 	/**
+	 * @throws MembershipNotFoundException
+	 */
+	public function getMembershipByUserId(string $circleId, string $userId): Membership {
+		$qb = $this->getMembershipSelectSql();
+		$qb->limitToCircleId($circleId);
+
+		$expr = $qb->expr();
+		$qb->leftJoin(
+			CoreQueryBuilder::MEMBERSHIPS,
+			CoreRequestBuilder::TABLE_MEMBER,
+			CoreQueryBuilder::MEMBER,
+			$expr->eq(CoreQueryBuilder::MEMBER . '.single_id', CoreQueryBuilder::MEMBERSHIPS . '.single_id')
+		);
+		$qb->andWhere($expr->eq(CoreQueryBuilder::MEMBER . '.user_id', $qb->createNamedParameter($userId)));
+
+		return $this->getItemFromRequest($qb);
+	}
+
+
+	/**
 	 * @param string $singleId
 	 *
 	 * @return Membership[]

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace OCA\Circles\Service;
 
 use OCA\Circles\Db\MemberRequest;
+use OCA\Circles\Db\MembershipRequest;
 use OCA\Circles\Exceptions\InitiatorNotFoundException;
 use OCA\Circles\Exceptions\InsufficientPermissionException;
 use OCA\Circles\Exceptions\MemberHelperException;
@@ -31,6 +32,7 @@ class PermissionService {
 		private readonly FederatedUserService $federatedUserService,
 		private readonly ConfigService $configService,
 		private readonly MemberRequest $memberRequest,
+		private readonly MembershipRequest $membershipRequest,
 	) {
 	}
 
@@ -154,9 +156,16 @@ class PermissionService {
 		try {
 			return $this->memberRequest->getMemberByUserId($circleId, $userId);
 		} catch (MemberNotFoundException) {
-			throw new InsufficientPermissionException(
-				$this->l10n->t('Insufficient permissions to perform this action')
-			);
+			// not a direct member, check if user has inherited membership via group/circle
+			try {
+				$membership = $this->membershipRequest->getMembershipByUserId($circleId, $userId);
+				// return group/circle member through which access is inherited, to use its permission level
+				return $this->memberRequest->getMember($circleId, $membership->getInheritanceFirst());
+			} catch (MembershipNotFoundException) {
+				throw new InsufficientPermissionException(
+					$this->l10n->t('Insufficient permissions to perform this action')
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/contacts/issues/5418

## Summary

- as mentioned on issue linked above, PR #2522 introduced a regression
- main point brought up on the issue is that when a user is a member of a circle via a group, user has no longer access to it's member list and other resources
- what was causing this is that `lib/Service/PermissionService::userMustBeMember()` was not taking into account the permission level from the group/circle through which the user has access to this circle
- this PR adjusts `lib/Service/PermissionService::userMustBeMember()` to consider inherited permissions when user is no direct member

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
