### PR TITLE
feat(admin-controller): add route to fetch all circles

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -47,6 +47,7 @@ return [
 
 		// AdminController
 		['name' => 'Admin#circles', 'url' => '/admin/{emulated}/circles', 'verb' => 'GET'],
+		['name' => 'Admin#circlesAll', 'url' => '/admin/circlesall', 'verb' => 'GET'],
 		['name' => 'Admin#create', 'url' => '/admin/{emulated}/circles', 'verb' => 'POST'],
 		['name' => 'Admin#destroy', 'url' => '/admin/{emulated}/circles/{circleId}', 'verb' => 'DELETE'],
 		[

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -232,6 +232,38 @@ class AdminController extends OCSController {
 	}
 
 	/**
+	 * @throws OCSException
+	 */
+	public function circlesAll(
+		int $limit = 100,
+		int $offset = 0,
+		bool $filterPersonal = true,
+		bool $filterSingle = true,
+		bool $filterSystem = true,
+		bool $filterHidden = true,
+		bool $filterBackend = true,
+	): DataResponse {
+		try {
+			// no need for emulated user since results are not scoped to any specific user
+			$this->setLocalFederatedUser($this->userSession->getUser()->getUID());
+
+			$probe = new CircleProbe();
+			$probe->filterPersonalCircles($filterPersonal)
+				->filterSingleCircles($filterSingle)
+				->filterSystemCircles($filterSystem)
+				->filterHiddenCircles($filterHidden)
+				->filterBackendCircles($filterBackend)
+				->addDetail(BasicProbe::DETAILS_POPULATION)
+				->setItemsLimit($limit)
+				->setItemsOffset($offset);
+
+			return new DataResponse($this->serializeArray($this->circleService->getAllCircles($probe)));
+		} catch (Exception $e) {
+			throw new OCSException($e->getMessage(), (int)$e->getCode());
+		}
+	}
+
+	/**
 	 * @param string $emulated
 	 * @param string $circleId
 	 *

--- a/lib/Service/CircleService.php
+++ b/lib/Service/CircleService.php
@@ -506,6 +506,37 @@ class CircleService {
 	}
 
 	/**
+	 * @return Circle[]
+	 * @throws InitiatorNotFoundException
+	 * @throws RequestBuilderException
+	 */
+	public function getAllCircles(CircleProbe $probe, bool $caching = false): array {
+		$this->federatedUserService->mustHaveCurrentUser();
+
+		$key = '';
+		if ($caching) {
+			$key = '#' . $probe->getChecksum();
+			$cachedData = $this->cache->get($key);
+			try {
+				if (!is_string($cachedData)) {
+					throw new InvalidItemException();
+				}
+				return $this->deserializeList($cachedData, Circle::class);
+			} catch (InvalidItemException) {
+			}
+		}
+
+		// pass null as initiator to skip user filtering and get all circles
+		$circles = $this->circleRequest->getCircles(null, $probe);
+
+		if ($caching) {
+			$this->cache->set($key, json_encode($circles), self::CACHE_GET_CIRCLES_TTL);
+		}
+
+		return $circles;
+	}
+
+	/**
 	 * @param Circle $circle
 	 *
 	 * @throws RequestBuilderException

--- a/tests/unit/lib/Controller/AdminControllerTest.php
+++ b/tests/unit/lib/Controller/AdminControllerTest.php
@@ -201,6 +201,32 @@ class AdminControllerTest extends TestCase {
 		}
 	}
 
+	public function testCirclesAll(): void {
+		$circleService = $this->container->get(CircleService::class);
+
+		$countBeforeWithPersonal = count($this->adminController->circlesAll(filterPersonal: false)->getData());
+		$countBeforeWithoutPersonal = count($this->adminController->circlesAll(filterPersonal: true)->getData());
+
+		$circleData = $circleService->create('test-circle');
+		$circleDataPersonal = $circleService->create('test-circle-personal', personal: true);
+		$this->circlesToCleanup[] = $circleData['id'];
+		$this->circlesToCleanup[] = $circleDataPersonal['id'];
+
+		$result = $this->adminController->circlesAll(filterPersonal: false)->getData();
+
+		$resultIds = array_column($result, 'id');
+		$this->assertCount($countBeforeWithPersonal + 2, $result);
+		$this->assertContains($circleData['id'], $resultIds);
+		$this->assertContains($circleDataPersonal['id'], $resultIds);
+
+		$result = $this->adminController->circlesAll(filterPersonal: true)->getData();
+
+		$resultIds = array_column($result, 'id');
+		$this->assertCount($countBeforeWithoutPersonal + 1, $result);
+		$this->assertContains($circleData['id'], $resultIds);
+		$this->assertNotContains($circleDataPersonal['id'], $resultIds);
+	}
+
 	public function testCircleDetails(): void {
 		$circleService = $this->container->get(CircleService::class);
 


### PR DESCRIPTION

* Resolves: #

## Summary

The existing admin endpoint for fetching circles requires an emulated user:
- GET `ocs/v2.php/apps/circles/admin/{emulated}/circles`

Results are scoped to the emulated user, so only circles related to that specific user are returned.

This PR introduces a new admin endpoint that returns all circles from the instance without user scoping:
- GET `ocs/v2.php/apps/circles/admin/circlesall`
> "/circlesall" was used instead of "/circlesAll" or "/circles-all" to follow the standard from another multiword endpoint already present: "/probecircles"

The authenticated admin user is used for auth only, not to scope results:
```php
// lib/Controller/AdminController::circlesAll()

// no need for emulated user since results are not scoped to any specific user
$this->setLocalFederatedUser($this->userSession->getUser()->getUID());
```

Params available:
```
- limit
- offset
- filterPersonal
- filterSingle
- filterSystem
- filterHidden
- filterBackend
```
The filter params are related to those configs (defined on [lib/Model/Circle](https://github.com/nextcloud/circles/blob/master/lib/Model/Circle.php#L72)):
```
- CFG_PERSONAL - personal circle, only the owner can see it
- CFG_SINGLE - circle with only one single member
- CFG_SYSTEM - system Circle (not managed by the official front-end)
- CFG_HIDDEN - hidden from listing, but available as a share entity
- CFG_BACKEND - fully hidden, only backend Circles
```

All filter params default to `true` (1). So to include, for example, personal circles in the results, you must explicitly pass `?filterPersonal=0` to disable the filter.

Below are some request examples:
```bash
# get circles using default params
curl -X GET \
  -u "admin:admin" \
  -H "OCS-APIRequest: true" \
  "http://nextcloud.local/ocs/v2.php/apps/circles/admin/circlesall"

# include personal circles
curl -X GET \
  -u "admin:admin" \
  -H "OCS-APIRequest: true" \
  "http://nextcloud.local/ocs/v2.php/apps/circles/admin/circlesall?filterPersonal=0"

# limit results to 50 and set offset of 25
curl -X GET \
  -u "admin:admin" \
  -H "OCS-APIRequest: true" \
  "http://nextcloud.local/ocs/v2.php/apps/circles/admin/circlesall?limit=50&offset=25" 

# include system and hidden circles
curl -X GET \
  -u "admin:admin" \
  -H "OCS-APIRequest: true" \
  "http://nextcloud.local/ocs/v2.php/apps/circles/admin/circlesall?filterSystem=0&filterHidden=0"
```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
