### PR TITLE
fix: refresh user mounts when removed from a group or circle that has associated team folders

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -13,6 +13,7 @@ use OCA\Circles\ConfigLexicon;
 use OCA\Circles\Dashboard\TeamDashboardWidget;
 use OCA\Circles\Events\AddingCircleMemberEvent;
 use OCA\Circles\Events\CircleMemberAddedEvent;
+use OCA\Circles\Events\CircleMemberRemovedEvent;
 use OCA\Circles\Events\DestroyingCircleEvent;
 use OCA\Circles\Events\Files\CreatingFileShareEvent;
 use OCA\Circles\Events\Files\FileShareCreatedEvent;
@@ -23,6 +24,7 @@ use OCA\Circles\Events\RequestingCircleMemberEvent;
 use OCA\Circles\FileSharingTeamResourceProvider;
 use OCA\Circles\Handlers\WebfingerHandler;
 use OCA\Circles\Listeners\AccountUpdated;
+use OCA\Circles\Listeners\CircleMemberRemoved;
 use OCA\Circles\Listeners\Files\AddingMemberSendMail as ListenerFilesAddingMemberSendMail;
 use OCA\Circles\Listeners\Files\CreatingShareSendMail as ListenerFilesCreatingShareSendMail;
 use OCA\Circles\Listeners\Files\DestroyingCircle as ListenerFilesDestroyingCircle;
@@ -101,6 +103,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserUpdatedEvent::class, AccountUpdated::class);
 		$context->registerEventListener(UserChangedEvent::class, AccountUpdated::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeleted::class);
+
+		// Circle Events
+		$context->registerEventListener(CircleMemberRemovedEvent::class, CircleMemberRemoved::class);
 
 		// Group Events
 		$context->registerEventListener(GroupCreatedEvent::class, GroupCreated::class);

--- a/lib/Listeners/CircleMemberRemoved.php
+++ b/lib/Listeners/CircleMemberRemoved.php
@@ -3,27 +3,27 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\Circles\Listeners;
 
 use Exception;
-use OCA\Circles\Service\SyncService;
+use OCA\Circles\Events\CircleMemberRemovedEvent;
 use OCP\App\IAppManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Config\IUserMountCache;
-use OCP\Group\Events\UserRemovedEvent;
+use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
-/** @template-implements IEventListener<UserRemovedEvent> */
-class GroupMemberRemoved implements IEventListener {
+/** @template-implements IEventListener<CircleMemberRemovedEvent> */
+class CircleMemberRemoved implements IEventListener {
 	public function __construct(
-		private readonly SyncService $syncService,
+		private readonly IUserManager $userManager,
 		private readonly IAppManager $appManager,
 		private readonly IUserMountCache $userMountCache,
 		private readonly IMountProviderCollection $mountProviderCollection,
@@ -33,19 +33,22 @@ class GroupMemberRemoved implements IEventListener {
 
 	#[\Override]
 	public function handle(Event $event): void {
-		if (!($event instanceof UserRemovedEvent)) {
+		if (!($event instanceof CircleMemberRemovedEvent)) {
 			return;
 		}
 
-		$user = $event->getUser();
-		$group = $event->getGroup();
-
-		try {
-			$this->syncService->groupMemberRemoved($group->getGID(), $user->getUID());
-		} catch (Exception) {
+		$member = $event->getMember();
+		if ($member === null) {
+			return;
 		}
 
-		if (!$this->groupHasAssociatedGroupFolder($group->getGID())) {
+		$user = $this->userManager->get($member->getUserId());
+		if ($user === null) {
+			return;
+		}
+
+		$circle = $event->getCircle();
+		if (!$this->circleHasAssociatedGroupFolder($circle->getSingleId())) {
 			return;
 		}
 
@@ -59,16 +62,16 @@ class GroupMemberRemoved implements IEventListener {
 		}
 	}
 
-	private function groupHasAssociatedGroupFolder(string $groupId): bool {
+	private function circleHasAssociatedGroupFolder(string $circleId): bool {
 		if (!$this->appManager->isEnabledForUser('groupfolders')) {
 			return false;
 		}
 
 		try {
 			$folderManager = Server::get(\OCA\GroupFolders\Folder\FolderManager::class);
-			return $folderManager->hasFolderForGroup($groupId);
+			return $folderManager->hasFolderForCircle($circleId);
 		} catch (Exception $e) {
-			$this->logger->debug('Failed to check if group ' . $groupId . ' has an associated team folder', ['exception' => $e]);
+			$this->logger->debug('Failed to check if circle ' . $circleId . ' has an associated team folder', ['exception' => $e]);
 			return false;
 		}
 	}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -447,4 +447,14 @@
       <code><![CDATA[getOpenSSLAlgo]]></code>
     </UndefinedMethod>
   </file>
+  <file src="lib/Listeners/GroupMemberRemoved.php">
+    <UndefinedClass>
+      <code><![CDATA[\OCA\GroupFolders\Folder\FolderManager]]></code>
+    </UndefinedClass>
+  </file>
+  <file src="lib/Listeners/CircleMemberRemoved.php">
+    <UndefinedClass>
+      <code><![CDATA[\OCA\GroupFolders\Folder\FolderManager]]></code>
+    </UndefinedClass>
+  </file>
 </files>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

When a team folder is shared with a group or circle, removing a member currently leaves a stale entry for that folder in `oc_mounts` until their next login.

This PR refreshes the user's mounts (removing the stale entry) upon detecting the following events:
- `OCP\Group\Events\UserRemovedEvent`
- `OCA\Circles\Events\CircleMemberRemovedEvent`

To avoid refreshing mounts unnecessarily, the refresh only runs if the group/circle actually has a team folder associated with it.

The refresh logic mirrors what the `files:mount:refresh` command already does:
https://github.com/nextcloud/server/blob/master/apps/files/lib/Command/Mount/Refresh.php#L45

This PR depends on the following PR being merged first, which introduces methods to check whether a given group or circle has a team folder shared with it:
* https://github.com/nextcloud/groupfolders/pull/4884

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
