### PR TITLE
fix(maintenance-service): remove redundant empty check on getDisplayName

### DIFF
--- a/lib/Service/MaintenanceService.php
+++ b/lib/Service/MaintenanceService.php
@@ -358,10 +358,8 @@ class MaintenanceService {
 		}
 
 		$displayName = $user->getDisplayName();
-		if ($displayName !== '') {
-			$this->memberRequest->updateDisplayName($federatedUser->getSingleId(), $displayName);
-			$this->circleRequest->updateDisplayName($federatedUser->getSingleId(), $displayName);
-		}
+		$this->memberRequest->updateDisplayName($federatedUser->getSingleId(), $displayName);
+		$this->circleRequest->updateDisplayName($federatedUser->getSingleId(), $displayName);
 
 		return $displayName;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fixes error pointed by psalm:
```bash
Error: lib/Service/MaintenanceService.php:361:7: RedundantCondition: '' can never contain non-empty-string (see https://psalm.dev/122)
```
As can be seen [here](https://github.com/nextcloud/server/blob/e88740d0f6005e6c0417b769beac4dc0aedb294b/lib/private/User/User.php#L92), `$user->getDisplayName()` never returns empty string.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
