### PR TITLE
fix(types): declare vite/modulepreload-polyfill virtual module

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/// <reference types="vite/client" />
+
+// Vite virtual module with no shipped types; declare it so the import resolves.
+declare module 'vite/modulepreload-polyfill' {}


### PR DESCRIPTION
## Summary

Type checking fails on master because `settings-admin.ts` imports `vite/modulepreload-polyfill`, a Vite virtual module with no shipped types. This adds a declaration.

## AI

- [ ] The content of this PR was partly or fully generated using AI
