### PR TITLE
fix: correct typo post -> port in error messages

### DIFF
--- a/lib/Command/CirclesCheck.php
+++ b/lib/Command/CirclesCheck.php
@@ -199,7 +199,7 @@ class CirclesCheck extends Base {
 			try {
 				[$scheme, $cloudId, $path] = $this->parseAddress($loopback);
 			} catch (Exception) {
-				$output->writeln('<error>format must be http[s]://domain.name[:post][/path]</error>');
+				$output->writeln('<error>format must be http[s]://domain.name[:port][/path]</error>');
 				continue;
 			}
 
@@ -407,7 +407,7 @@ class CirclesCheck extends Base {
 			try {
 				[$scheme, $cloudId, $path] = $this->parseAddress($internal);
 			} catch (Exception) {
-				$output->writeln('<error>format must be http[s]://domain.name[:post][/path]</error>');
+				$output->writeln('<error>format must be http[s]://domain.name[:port][/path]</error>');
 				continue;
 			}
 
@@ -587,7 +587,7 @@ class CirclesCheck extends Base {
 			try {
 				[$scheme, $cloudId, $path] = $this->parseAddress($frontal);
 			} catch (Exception) {
-				$output->writeln('<error>format must be http[s]://domain.name[:post][/path]</error>');
+				$output->writeln('<error>format must be http[s]://domain.name[:port][/path]</error>');
 				continue;
 			}
 


### PR DESCRIPTION
Closes #1808

Fixed 3 occurrences of "post" -> "port" in error messages in `lib/Command/CirclesCheck.php`.

The placeholder in the URL format description should say "port" (as in `:8080`) not "post".

Assisted-by: DeepSeek:V4-Pro