### PR TITLE
fix: add promoteToOwner method

### DIFF
--- a/lib/Db/MemberRequest.php
+++ b/lib/Db/MemberRequest.php
@@ -18,6 +18,9 @@ use OCA\Circles\Model\FederatedUser;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\CircleProbe;
 use OCA\Circles\Model\Probes\MemberProbe;
+use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\TimezoneService;
+use OCP\IDBConnection;
 
 /**
  * Class MemberRequest
@@ -25,6 +28,15 @@ use OCA\Circles\Model\Probes\MemberProbe;
  * @package OCA\Circles\Db
  */
 class MemberRequest extends MemberRequestBuilder {
+
+	public function __construct(
+		private IDBConnection $db,
+		TimezoneService $timezoneService,
+		ConfigService $configService,
+	) {
+		parent::__construct($timezoneService, $configService);
+	}
+
 	/**
 	 * @param Member $member
 	 *
@@ -173,6 +185,42 @@ class MemberRequest extends MemberRequestBuilder {
 		$qb->limitToSingleId($member->getSingleId());
 
 		$qb->executeStatement();
+	}
+
+	/**
+	 * @return ?Member old owner or null if old owner was not found
+	 */
+	public function promoteToOwner(Member $member): ?Member {
+		try {
+			$this->db->beginTransaction();
+
+			$qb = $this->getMemberSelectSql();
+			$qb->limitToCircleId($member->getCircleId());
+			$qb->limitInt('level', Member::LEVEL_OWNER);
+			// forUpdate locks the owner row until transaction is commited, forcing concurrent
+			// requests to wait and read the updated current owner, preventing multiple owners
+			$qb->forUpdate();
+
+			try {
+				$oldOwner = $this->getItemFromRequest($qb);
+			} catch (MemberNotFoundException) {
+				$oldOwner = null;
+			}
+
+			$this->updateLevel($member);
+
+			if ($oldOwner !== null && $oldOwner->getId() !== $member->getId()) {
+				$oldOwner->setLevel(Member::LEVEL_ADMIN);
+				$this->updateLevel($oldOwner);
+			}
+
+			$this->db->commit();
+
+			return $oldOwner;
+		} catch (\Throwable $e) {
+			$this->db->rollBack();
+			throw $e;
+		}
 	}
 
 	/**

--- a/lib/FederatedItems/MemberLevel.php
+++ b/lib/FederatedItems/MemberLevel.php
@@ -103,13 +103,14 @@ class MemberLevel implements
 	public function manage(FederatedEvent $event): void {
 		$member = clone $event->getMember();
 		$member->setLevel($event->getData()->gInt('level'));
-		$this->memberRequest->updateLevel($member);
 
 		if ($member->getLevel() === Member::LEVEL_OWNER) {
-			$oldOwner = clone $event->getCircle()->getOwner();
-			$oldOwner->setLevel(Member::LEVEL_ADMIN);
-			$this->memberRequest->updateLevel($oldOwner);
-			$this->membershipService->onUpdate($oldOwner->getSingleId());
+			$oldOwner = $this->memberRequest->promoteToOwner($member);
+			if ($oldOwner !== null) {
+				$this->membershipService->onUpdate($oldOwner->getSingleId());
+			}
+		} else {
+			$this->memberRequest->updateLevel($member);
 		}
 
 		$this->membershipService->onUpdate($member->getSingleId());


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- adds `promoteToOwner` method on `lib/Db/MemberRequest` and uses it on `lib/FederatedItems/MemberLevel`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
