### PR TITLE
fix(circles): preserve group display names when creating circles

### DIFF
--- a/lib/Service/FederatedUserService.php
+++ b/lib/Service/FederatedUserService.php
@@ -1185,7 +1185,7 @@ class FederatedUserService {
 		} catch (CircleNotFoundException) {
 		}
 
-		$circle->setDisplayName($groupId);
+		$circle->setDisplayName($group->getDisplayName());
 
 		$event = new FederatedEvent(CircleCreate::class);
 		$event->setCircle($circle);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Fixes the display name of group-backed circles being initialized with the internal group ID instead of the group’s display name.

Related to nextcloud/collectives#1510

Root cause:

When a local group circle is created, `FederatedUserService::getGroupCircle()` already loads the corresponding group but initializes the circle with:

```php
$circle->setDisplayName($groupId);
```

Notes:

- This fix corrects newly created group circles, but existing Circles records may still have the group ID in `cached_name`. Best as I can tell, existing records should (eventually) be repaired by Circles’ synchronization or a migration/maintenance tasks.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
