### PR TITLE
fix(shares): expose share of TYPE_CIRCLE to the FilesList in groupfolders

### DIFF
--- a/lib/Db/ShareWrapperRequest.php
+++ b/lib/Db/ShareWrapperRequest.php
@@ -434,7 +434,11 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 	}
 
 	/**
-	 * @param FederatedUser $federatedUser
+	 * A null $federatedUser returns the shares of every owner and initiator. This
+	 * is needed for ownerless mounts (e.g. groupfolders), where no single user can
+	 * be used to filter the shares.
+	 *
+	 * @param FederatedUser|null $federatedUser
 	 * @param Folder $node
 	 * @param bool $reshares
 	 * @param bool $shallow Whether the method should stop at the first level, or look into sub-folders.
@@ -443,7 +447,7 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function getSharesInFolder(
-		FederatedUser $federatedUser,
+		?FederatedUser $federatedUser,
 		Folder $node,
 		bool $reshares,
 		bool $shallow = true,
@@ -451,7 +455,9 @@ class ShareWrapperRequest extends ShareWrapperRequestBuilder {
 		$qb = $this->getShareSelectSql();
 
 		$qb->leftJoinCircle(CoreQueryBuilder::SHARE, null, 'share_with');
-		$qb->limitToShareOwner(CoreQueryBuilder::SHARE, $federatedUser, $reshares);
+		if ($federatedUser !== null) {
+			$qb->limitToShareOwner(CoreQueryBuilder::SHARE, $federatedUser, $reshares);
+		}
 		$qb->leftJoinFileCache(CoreQueryBuilder::SHARE);
 
 		$aliasFileCache = $qb->generateAlias(CoreQueryBuilder::SHARE, CoreQueryBuilder::FILE_CACHE);

--- a/lib/Service/ShareWrapperService.php
+++ b/lib/Service/ShareWrapperService.php
@@ -237,7 +237,7 @@ class ShareWrapperService {
 	 * @throws RequestBuilderException
 	 */
 	public function getSharesInFolder(
-		FederatedUser $federatedUser,
+		?FederatedUser $federatedUser,
 		Folder $node,
 		bool $reshares,
 		bool $shallow = true,

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -32,6 +32,7 @@ use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\FederatedItems\Files\FileShare;
 use OCA\Circles\FederatedItems\Files\FileUnshare;
 use OCA\Circles\Model\Federated\FederatedEvent;
+use OCA\Circles\Model\FederatedUser;
 use OCA\Circles\Model\Member;
 use OCA\Circles\Model\Probes\CircleProbe;
 use OCA\Circles\Model\Probes\DataProbe;
@@ -60,6 +61,7 @@ use OCP\Share\IPartialShareProvider;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
 use OCP\Share\IShareProviderGetUsers;
+use OCP\Share\IShareProviderSupportsAllSharesInFolder;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -67,7 +69,7 @@ use Psr\Log\LoggerInterface;
  *
  * @package OCA\Circles
  */
-class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IShareProviderGetUsers {
+class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IShareProviderGetUsers, IShareProviderSupportsAllSharesInFolder {
 	use TArrayTools;
 	use TStringTools;
 	use TNCLogger;
@@ -321,7 +323,7 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 	 * @param bool $reshares
 	 * @param bool $shallow Whether the method should stop at the first level, or look into sub-folders.
 	 *
-	 * @return array
+	 * @return array<int, list<IShare>>
 	 * @throws ContactAddressBookNotFoundException
 	 * @throws ContactFormatException
 	 * @throws ContactNotFoundException
@@ -336,12 +338,47 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 	 */
 	public function getSharesInFolder($userId, Folder $node, $reshares, $shallow = true): array {
 		$federatedUser = $this->federatedUserService->getLocalFederatedUser($userId);
-		$wrappedShares = $this->shareWrapperService->getSharesInFolder(
-			$federatedUser,
-			$node,
-			$reshares,
-			$shallow
-		);
+
+		return $this->getSharesInFolderInternal($federatedUser, $node, $reshares, $shallow);
+	}
+
+	/**
+	 * Get all shares in a folder, regardless of the share owner or initiator.
+	 * Used for ownerless mounts (e.g. groupfolders) where there is no single
+	 * user to filter shares by.
+	 *
+	 * @return array<int, list<IShare>>
+	 * @throws ContactAddressBookNotFoundException
+	 * @throws ContactFormatException
+	 * @throws ContactNotFoundException
+	 * @throws InvalidIdException
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 * @throws RequestBuilderException
+	 * @throws SingleCircleNotFoundException
+	 */
+	public function getAllSharesInFolder(Folder $node): array {
+		return $this->getSharesInFolderInternal(null, $node, false);
+	}
+
+	/**
+	 * @return array<int, list<IShare>>
+	 * @throws ContactAddressBookNotFoundException
+	 * @throws ContactFormatException
+	 * @throws ContactNotFoundException
+	 * @throws InvalidIdException
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 * @throws RequestBuilderException
+	 * @throws SingleCircleNotFoundException
+	 */
+	private function getSharesInFolderInternal(
+		?FederatedUser $federatedUser,
+		Folder $node,
+		bool $reshares,
+		bool $shallow = true,
+	): array {
+		$wrappedShares = $this->shareWrapperService->getSharesInFolder($federatedUser, $node, $reshares, $shallow);
 
 		$result = [];
 		foreach ($wrappedShares as $wrappedShare) {

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -386,8 +386,10 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 				$result[$wrappedShare->getFileSource()] = [];
 			}
 			if ($wrappedShare->getFileCache()->isAccessible()) {
-				$result[$wrappedShare->getFileSource()][]
-					= $wrappedShare->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
+				$share = $wrappedShare->getShare($this->rootFolder, $this->userManager, $this->urlGenerator);
+				if ($share !== null) {
+					$result[$wrappedShare->getFileSource()][] = $share;
+				}
 			} else {
 				$this->logger->debug('shared document is not available anymore', ['wrappedShare' => $wrappedShare]);
 				if ($wrappedShare->getFileCache()->getPath() === '') {

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -338,7 +338,6 @@
       <code><![CDATA[IShare]]></code>
     </InvalidNullableReturnType>
     <LessSpecificImplementedReturnType>
-      <code><![CDATA[array]]></code>
       <code><![CDATA[iterable]]></code>
     </LessSpecificImplementedReturnType>
     <NullableReturnStatement>

--- a/tests/unit/lib/ShareByCircleProviderTest.php
+++ b/tests/unit/lib/ShareByCircleProviderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Circles\Tests\Unit;
+
+use OCA\Circles\Model\FederatedUser;
+use OCA\Circles\Model\FileCacheWrapper;
+use OCA\Circles\Model\ShareWrapper;
+use OCA\Circles\Service\CircleService;
+use OCA\Circles\Service\EventService;
+use OCA\Circles\Service\FederatedEventService;
+use OCA\Circles\Service\FederatedUserService;
+use OCA\Circles\Service\ShareTokenService;
+use OCA\Circles\Service\ShareWrapperService;
+use OCA\Circles\ShareByCircleProvider;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ShareByCircleProviderTest extends TestCase {
+	private ShareByCircleProvider $provider;
+	private ShareWrapperService&MockObject $shareWrapperService;
+	private FederatedUserService&MockObject $federatedUserService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->shareWrapperService = $this->createMock(ShareWrapperService::class);
+		$this->federatedUserService = $this->createMock(FederatedUserService::class);
+
+		$this->provider = new ShareByCircleProvider(
+			$this->createMock(IUserManager::class),
+			$this->createMock(IRootFolder::class),
+			$this->createMock(IL10N::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(IURLGenerator::class),
+			$this->shareWrapperService,
+			$this->createMock(ShareTokenService::class),
+			$this->federatedUserService,
+			$this->createMock(FederatedEventService::class),
+			$this->createMock(CircleService::class),
+			$this->createMock(EventService::class),
+		);
+	}
+
+	public function testGetAllSharesInFolderQueriesWithoutFederatedUser(): void {
+		$node = $this->createMock(Folder::class);
+
+		$this->federatedUserService->expects($this->never())
+			->method('getLocalFederatedUser');
+		$this->shareWrapperService->expects($this->once())
+			->method('getSharesInFolder')
+			->with(null, $node, false, true)
+			->willReturn([]);
+
+		$this->assertSame([], $this->provider->getAllSharesInFolder($node));
+	}
+
+	public function testGetAllSharesInFolderGroupsSharesByFileSource(): void {
+		$node = $this->createMock(Folder::class);
+		$firstShare = $this->createMock(IShare::class);
+		$secondShare = $this->createMock(IShare::class);
+		$thirdShare = $this->createMock(IShare::class);
+
+		$this->shareWrapperService->method('getSharesInFolder')
+			->willReturn([
+				$this->createWrappedShare(42, $firstShare),
+				$this->createWrappedShare(42, $secondShare),
+				$this->createWrappedShare(1337, $thirdShare),
+			]);
+
+		$this->assertSame([
+			42 => [$firstShare, $secondShare],
+			1337 => [$thirdShare],
+		], $this->provider->getAllSharesInFolder($node));
+	}
+
+	public function testGetAllSharesInFolderSkipsInaccessibleShares(): void {
+		$node = $this->createMock(Folder::class);
+
+		$this->shareWrapperService->method('getSharesInFolder')
+			->willReturn([
+				$this->createWrappedShare(42, $this->createMock(IShare::class), false),
+			]);
+
+		$this->assertSame([42 => []], $this->provider->getAllSharesInFolder($node));
+	}
+
+	public function testGetSharesInFolderQueriesWithFederatedUser(): void {
+		$node = $this->createMock(Folder::class);
+		$federatedUser = $this->createMock(FederatedUser::class);
+
+		$this->federatedUserService->expects($this->once())
+			->method('getLocalFederatedUser')
+			->with('test-user')
+			->willReturn($federatedUser);
+		$this->shareWrapperService->expects($this->once())
+			->method('getSharesInFolder')
+			->with($federatedUser, $node, true, true)
+			->willReturn([]);
+
+		$this->assertSame([], $this->provider->getSharesInFolder('test-user', $node, true));
+	}
+
+	public function testGetSharesInFolderForwardsNonShallow(): void {
+		$node = $this->createMock(Folder::class);
+		$federatedUser = $this->createMock(FederatedUser::class);
+
+		$this->federatedUserService->method('getLocalFederatedUser')
+			->willReturn($federatedUser);
+		$this->shareWrapperService->expects($this->once())
+			->method('getSharesInFolder')
+			->with($federatedUser, $node, true, false)
+			->willReturn([]);
+
+		$this->assertSame([], $this->provider->getSharesInFolder('test-user', $node, true, false));
+	}
+
+	private function createWrappedShare(
+		int $fileSource,
+		IShare $share,
+		bool $accessible = true,
+	): ShareWrapper&MockObject {
+		$fileCache = $this->createMock(FileCacheWrapper::class);
+		$fileCache->method('isAccessible')->willReturn($accessible);
+		$fileCache->method('getPath')->willReturn('__groupfolders/1/document.md');
+
+		$wrappedShare = $this->createMock(ShareWrapper::class);
+		$wrappedShare->method('getFileSource')->willReturn($fileSource);
+		$wrappedShare->method('getFileCache')->willReturn($fileCache);
+		$wrappedShare->method('getShare')->willReturn($share);
+
+		return $wrappedShare;
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref: #2428

## Summary

- groupfolders PROPFIND collect data differently than normal folder, as it's missing an owner
- different path only calls for providers that have an implementation
- adding this to circles to allow server collect the data
- align behaviour with DefaultShareProvider

## Screenshots

B | A
-- | --
<img width="842" height="336" alt="image" src="https://github.com/user-attachments/assets/9d61e2e5-85a2-46e7-9793-a9314075ef74" /> | <img width="842" height="347" alt="image" src="https://github.com/user-attachments/assets/0fa5fbfa-cba1-4a36-b373-5d0045712c0a" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
