### PR TITLE
fix(teams): hide dot entries and route team space link

### DIFF
--- a/src/teams/components/TeamFolderWidget.vue
+++ b/src/teams/components/TeamFolderWidget.vue
@@ -98,6 +98,16 @@ function encodeDir(dir: string): string {
 }
 
 /**
+ * Hidden entries in Nextcloud start with a dot and should not be shown in
+ * the Team space widget.
+ *
+ * @param node - The team folder node
+ */
+function isHiddenEntry(node: INode): boolean {
+	return node.basename.startsWith('.')
+}
+
+/**
  * Build the URL for a single node so the list items are real links.
  *
  * Both files and folders open in the Files app using the file id based URL
@@ -222,6 +232,7 @@ async function loadContents(): Promise<void> {
 		nodes.value = data
 			.slice(1)
 			.map((entry) => resultToNode(entry, rootPath))
+			.filter((node) => !isHiddenEntry(node))
 			.sort((a, b) => {
 				if (a.type === b.type) {
 					return a.basename.localeCompare(b.basename)


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Hiding .apps Folder in TeamFolder Issue #46309

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
