### PR TITLE
fix(no_op): add missings param to ignore_user_abort calls

### DIFF
--- a/lib/Service/MiscService.php
+++ b/lib/Service/MiscService.php
@@ -316,7 +316,7 @@ class MiscService {
 		}
 
 		header('Connection: close');
-		ignore_user_abort();
+		ignore_user_abort(true);
 		ob_start();
 		echo(json_encode($result));
 		$size = ob_get_length();

--- a/lib/Tools/Traits/TAsync.php
+++ b/lib/Tools/Traits/TAsync.php
@@ -29,7 +29,7 @@ trait TAsync {
 
 		header('Connection: close');
 		header('Content-Encoding: none');
-		ignore_user_abort();
+		ignore_user_abort(true);
 		$timeLimit = $this->setupInt(self::$SETUP_TIME_LIMIT);
 		set_time_limit(($timeLimit > 0) ? $timeLimit : 0);
 		ob_start();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #2032

## Summary


## TODO

- [x] fix no_op ignore_user_abort() calls 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI