### PR TITLE
feat: show activities for teams

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -112,6 +112,7 @@ class Provider implements IProvider {
 
 		$this->parserCircle->parseSubjectCircleCreate($event, $params);
 		$this->parserCircle->parseSubjectCircleDelete($event, $params);
+		$this->parserCircle->parseSubjectCircleEdit($event, $params);
 		$this->parseMemberAsMember($event, $params);
 		$this->parseCircleMemberAsMember($event, $params);
 	}

--- a/lib/Activity/ProviderParser.php
+++ b/lib/Activity/ProviderParser.php
@@ -225,11 +225,13 @@ class ProviderParser {
 	 * @return array<string,string|integer>
 	 */
 	protected function generateCircleParameter(array $circle): array {
+		$quotedName = '"' . $circle['name'] . '"';
+
 		return [
 			'type' => 'circle',
 			'id' => $circle['singleId'],
-			'name' => $circle['name'],
-			'_parsed' => $circle['name'],
+			'name' => $quotedName,
+			'_parsed' => $quotedName,
 			'link' => $this->url->getAbsoluteURL($circle['url']),
 		];
 	}

--- a/lib/Activity/ProviderSubjectCircle.php
+++ b/lib/Activity/ProviderSubjectCircle.php
@@ -46,4 +46,24 @@ class ProviderSubjectCircle extends ProviderParser {
 
 		throw new FakeException();
 	}
+
+	/**
+	 * @param IEvent $event
+	 * @param array $params
+	 *
+	 * @throws FakeException
+	 */
+	public function parseSubjectCircleEdit(IEvent $event, array $params): void {
+		if ($event->getSubject() !== 'circle_edit') {
+			return;
+		}
+
+		$this->parseCircleEvent(
+			$event, $params,
+			$this->l10n->t('You edited the team {circle}'),
+			$this->l10n->t('{author} edited the team {circle}')
+		);
+
+		throw new FakeException();
+	}
 }

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -51,6 +51,7 @@ class CoreRequestBuilder {
 	/** @var array */
 	public static $tables = [
 		self::TABLE_CIRCLE => [
+			'id',
 			'unique_id',
 			'name',
 			'display_name',

--- a/lib/Model/Circle.php
+++ b/lib/Model/Circle.php
@@ -156,6 +156,9 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	private $singleId = '';
 
 	/** @var int */
+	private $circleId = 0;
+
+	/** @var int */
 	private $config = 0;
 
 	/** @var string */
@@ -243,6 +246,24 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 */
 	public function getSingleId(): string {
 		return $this->singleId;
+	}
+
+	/**
+	 * @param int $circleId
+	 *
+	 * @return self
+	 */
+	public function setCircleId(int $circleId): self {
+		$this->circleId = $circleId;
+
+		return $this;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getCircleId(): int {
+		return $this->circleId;
 	}
 
 	/**
@@ -820,6 +841,7 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 */
 	public function jsonSerialize(): array {
 		$arr = [
+			'circleId' => $this->getCircleId(),
 			'id' => $this->getSingleId(),
 			'name' => $this->getName(),
 			'displayName' => $this->getDisplayName(),
@@ -876,7 +898,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 			throw new CircleNotFoundException();
 		}
 
-		$this->setSingleId($this->get($prefix . 'unique_id', $data))
+		$this->setCircleId($this->getInt($prefix . 'id', $data))
+			->setSingleId($this->get($prefix . 'unique_id', $data))
 			->setName($this->get($prefix . 'name', $data))
 			->setDisplayName($this->get($prefix . 'display_name', $data))
 			->setSanitizedName($this->get($prefix . 'sanitized_name', $data))

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Circles\Service;
 
 use OCA\Circles\AppInfo\Application;
+use OCA\Circles\Db\CircleRequest;
 use OCA\Circles\Db\MemberRequest;
 use OCA\Circles\Events\CircleGenericEvent;
 use OCA\Circles\IFederatedUser;
@@ -27,6 +28,7 @@ class ActivityService {
 		private readonly IActivityManager $activityManager,
 		private readonly IUserManager $userManager,
 		private readonly MemberRequest $memberRequest,
+		private readonly CircleRequest $circleRequest,
 		private readonly ConfigService $configService,
 	) {
 	}
@@ -40,13 +42,14 @@ class ActivityService {
 			return;
 		}
 
-		$event = $this->generateEvent('circles_as_non_member');
+		$event = $this->generateEvent('circles_as_non_member', $circle);
+		$this->setActivityAuthor($event, $circle);
 		$event->setSubject(
 			'circle_create',
 			[
 				'ver' => 2,
 				'circle' => $this->shortenCircleData($circle),
-				'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+				'initiator' => $this->getActivityInitiatorData($circle),
 			]
 		);
 
@@ -66,19 +69,48 @@ class ActivityService {
 			return;
 		}
 
-		$event = $this->generateEvent('circles_as_member');
+		$event = $this->generateEvent('circles_as_member', $circle);
+		$this->setActivityAuthor($event, $circle);
 		$event->setSubject(
 			'circle_delete',
 			[
 				'ver' => 2,
 				'circle' => $this->shortenCircleData($circle),
-				'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+				'initiator' => $this->getActivityInitiatorData($circle),
 			]
 		);
 		$this->publishEvent(
 			$event,
 			$this->memberRequest->getInheritedMembers($circle->getSingleId(), false, Member::LEVEL_MEMBER)
 		);
+	}
+
+	/**
+	 * @param Circle $circle
+	 */
+	public function onCircleEdited(Circle $circle): void {
+		if ($circle->isConfig(Circle::CFG_PERSONAL)) {
+			return;
+		}
+
+		$event = $this->generateEvent('circles_as_member', $circle);
+		$this->setActivityAuthor($event, $circle);
+		$event->setSubject(
+			'circle_edit',
+			[
+				'ver' => 2,
+				'circle' => $this->shortenCircleData($circle),
+				'initiator' => $this->getActivityInitiatorData($circle),
+			]
+		);
+		$users = $this->memberRequest->getInheritedMembers($circle->getSingleId(), false, Member::LEVEL_MEMBER);
+		if (empty($users)
+			&& $circle->hasInitiator()
+			&& $circle->getInitiator()->getUserType() === Member::TYPE_USER) {
+			$users[] = $circle->getInitiator();
+		}
+
+		$this->publishEvent($event, $users);
 	}
 
 	/**
@@ -127,7 +159,9 @@ class ActivityService {
 		Member $member,
 		int $eventType,
 	): void {
-		$event = $this->generateEvent('circles_as_member');
+		$event = $this->generateEvent('circles_as_member', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		$this->setActivityAuthor($event, $circle);
 
 		try {
 			$event->setSubject(
@@ -138,7 +172,7 @@ class ActivityService {
 				[
 					'ver' => 2,
 					'circle' => $this->shortenCircleData($circle),
-					'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+					'initiator' => $this->getActivityInitiatorData($circle),
 					'member' => $this->shortenMemberData($member),
 				]
 			);
@@ -168,7 +202,9 @@ class ActivityService {
 		Member $member,
 		int $eventType = CircleGenericEvent::JOINED,
 	): void {
-		$event = $this->generateEvent('circles_as_member');
+		$event = $this->generateEvent('circles_as_member', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		$this->setActivityAuthor($event, $circle);
 
 		try {
 			$event->setSubject(
@@ -179,7 +215,7 @@ class ActivityService {
 				[
 					'ver' => 2,
 					'circle' => $this->shortenCircleData($circle),
-					'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+					'initiator' => $this->getActivityInitiatorData($circle),
 					'member' => $this->shortenMemberData($member),
 				]
 			);
@@ -209,7 +245,8 @@ class ActivityService {
 			return; // only if almost-member is a local account
 		}
 
-		$event = $this->generateEvent('circles_as_moderator');
+		$event = $this->generateEvent('circles_as_moderator', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
 
 		try {
 			$event->setSubject(
@@ -220,7 +257,7 @@ class ActivityService {
 				[
 					'ver' => 2,
 					'circle' => $this->shortenCircleData($circle),
-					'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+					'initiator' => $this->getActivityInitiatorData($circle),
 					'member' => $this->shortenMemberData($member),
 				]
 			);
@@ -269,7 +306,9 @@ class ActivityService {
 		Member $member,
 		int $eventType,
 	): void {
-		$event = $this->generateEvent('circles_as_member');
+		$event = $this->generateEvent('circles_as_member', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		$this->setActivityAuthor($event, $circle);
 
 		try {
 			$event->setSubject(
@@ -280,7 +319,7 @@ class ActivityService {
 				[
 					'ver' => 2,
 					'circle' => $this->shortenCircleData($circle),
-					'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+					'initiator' => $this->getActivityInitiatorData($circle),
 					'member' => $this->shortenMemberData($member),
 				]
 			);
@@ -305,7 +344,9 @@ class ActivityService {
 		Member $member,
 		int $eventType = CircleGenericEvent::JOINED,
 	): void {
-		$event = $this->generateEvent('circles_as_member');
+		$event = $this->generateEvent('circles_as_member', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		$this->setActivityAuthor($event, $circle);
 
 		try {
 			$event->setSubject(
@@ -316,7 +357,7 @@ class ActivityService {
 				[
 					'ver' => 2,
 					'circle' => $this->shortenCircleData($circle),
-					'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+					'initiator' => $this->getActivityInitiatorData($circle),
 					'member' => $this->shortenMemberData($member),
 				]
 			);
@@ -348,13 +389,15 @@ class ActivityService {
 			return;
 		}
 
-		$event = $this->generateEvent('circles_as_moderator');
+		$event = $this->generateEvent('circles_as_moderator', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		$this->setActivityAuthor($event, $circle);
 		$event->setSubject(
 			'member_level',
 			[
 				'ver' => 2,
 				'circle' => $this->shortenCircleData($circle),
-				'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+				'initiator' => $this->getActivityInitiatorData($circle),
 				'member' => $this->shortenMemberData($member),
 				'level' => $level
 			]
@@ -373,13 +416,15 @@ class ActivityService {
 	 * @param Member $member
 	 */
 	public function onMemberOwner(Circle $circle, Member $member): void {
-		$event = $this->generateEvent('circles_as_moderator');
+		$event = $this->generateEvent('circles_as_moderator', $circle);
+		$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		$this->setActivityAuthor($event, $circle);
 		$event->setSubject(
 			'member_owner',
 			[
 				'ver' => 2,
 				'circle' => $this->shortenCircleData($circle),
-				'initiator' => ($circle->hasInitiator() ? $this->shortenMemberData($circle->getInitiator()) : null),
+				'initiator' => $this->getActivityInitiatorData($circle),
 				'member' => $this->shortenMemberData($member),
 			]
 		);
@@ -398,15 +443,76 @@ class ActivityService {
 	 * Create an Activity Event with the basic settings for the app.
 	 *
 	 * @param string $type
+	 * @param ?Circle $circle
 	 *
 	 * @return IEvent
 	 */
-	private function generateEvent(string $type): IEvent {
+	private function generateEvent(string $type, ?Circle $circle = null): IEvent {
 		$event = $this->activityManager->generateEvent();
 		$event->setApp(Application::APP_ID)
 			->setType($type);
 
+		if ($circle !== null) {
+			$event->setObject('circles', $this->getActivityObjectId($circle), $circle->getName());
+		}
+
 		return $event;
+	}
+
+	/**
+	 * Populate activity author/user when available so oc_activity.user is not empty.
+	 */
+	private function setActivityAuthor(IEvent $event, Circle $circle): void {
+		$authorUserId = null;
+
+		if ($circle->hasInitiator()) {
+			$initiator = $circle->getInitiator();
+			if ($initiator->getUserType() === Member::TYPE_USER
+				&& $initiator->getUserId() !== '') {
+				$authorUserId = $initiator->getUserId();
+			}
+		}
+
+		if ($authorUserId === null) {
+			return;
+		}
+
+		if (method_exists($event, 'setAuthor')) {
+			call_user_func([$event, 'setAuthor'], $authorUserId);
+			return;
+		}
+
+		if (method_exists($event, 'setUser')) {
+			call_user_func([$event, 'setUser'], $authorUserId);
+		}
+	}
+
+	/**
+	 * Subject metadata should also use the acting user rather than persistent circle initiator.
+	 */
+	private function getActivityInitiatorData(Circle $circle): ?array {
+		if ($circle->hasInitiator()) {
+			return $this->shortenMemberData($circle->getInitiator());
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve the numeric DB id used as activity object_id.
+	 * Some event payloads only carry the circle singleId.
+	 */
+	private function getActivityObjectId(Circle $circle): int {
+		if ($circle->getCircleId() > 0) {
+			return $circle->getCircleId();
+		}
+
+		try {
+			$dbCircle = $this->circleRequest->getCircle($circle->getSingleId());
+			return $dbCircle->getCircleId();
+		} catch (\Throwable) {
+			return 0;
+		}
 	}
 
 	/**

--- a/lib/Service/EventService.php
+++ b/lib/Service/EventService.php
@@ -77,6 +77,7 @@ class EventService {
 	public function circleEdited(FederatedEvent $federatedEvent, array $results): void {
 		$event = new CircleEditedEvent($federatedEvent, $results);
 		$this->eventDispatcher->dispatchTyped($event);
+		$this->activityService->onCircleEdited($event->getCircle());
 	}
 
 	/**
@@ -85,7 +86,6 @@ class EventService {
 	public function circleDestroying(FederatedEvent $federatedEvent): void {
 		$event = new DestroyingCircleEvent($federatedEvent);
 		$this->eventDispatcher->dispatchTyped($event);
-		$this->activityService->onCircleDestruction($event->getCircle());
 	}
 
 	/**
@@ -95,6 +95,7 @@ class EventService {
 	public function circleDestroyed(FederatedEvent $federatedEvent, array $results): void {
 		$event = new CircleDestroyedEvent($federatedEvent, $results);
 		$this->eventDispatcher->dispatchTyped($event);
+		$this->activityService->onCircleDestruction($event->getCircle());
 	}
 
 	/**
@@ -112,7 +113,6 @@ class EventService {
 		$event = new AddingCircleMemberEvent($federatedEvent);
 		$event->setType(CircleGenericEvent::ADDED);
 		$this->eventDispatcher->dispatchTyped($event);
-		$this->activityService->onMemberNew($event->getCircle(), $event->getMember(), CircleGenericEvent::ADDED);
 	}
 
 	/**
@@ -123,6 +123,7 @@ class EventService {
 		$event = new CircleMemberAddedEvent($federatedEvent, $results);
 		$event->setType(CircleGenericEvent::ADDED);
 		$this->eventDispatcher->dispatchTyped($event);
+		$this->activityService->onMemberNew($event->getCircle(), $event->getMember(), CircleGenericEvent::ADDED);
 	}
 
 	/**
@@ -172,7 +173,6 @@ class EventService {
 		$event = new AddingCircleMemberEvent($federatedEvent);
 		$event->setType(CircleGenericEvent::JOINED);
 		$this->eventDispatcher->dispatchTyped($event);
-		$this->activityService->onMemberNew($event->getCircle(), $event->getMember(), CircleGenericEvent::JOINED);
 	}
 
 	/**
@@ -183,6 +183,7 @@ class EventService {
 		$event = new CircleMemberAddedEvent($federatedEvent, $results);
 		$event->setType(CircleGenericEvent::JOINED);
 		$this->eventDispatcher->dispatchTyped($event);
+		$this->activityService->onMemberNew($event->getCircle(), $event->getMember(), CircleGenericEvent::JOINED);
 	}
 
 	/**
@@ -193,7 +194,6 @@ class EventService {
 		$event->setLevel($federatedEvent->getData()->gInt('level'));
 		$event->setType(CircleGenericEvent::LEVEL);
 		$this->eventDispatcher->dispatchTyped($event);
-		$this->activityService->onMemberLevel($event->getCircle(), $event->getMember(), $event->getLevel());
 	}
 
 	/**
@@ -205,6 +205,7 @@ class EventService {
 		$event->setNewLevel($federatedEvent->getData()->gInt('level'));
 		$event->setType(CircleGenericEvent::LEVEL);
 		$this->eventDispatcher->dispatchTyped($event);
+		$this->activityService->onMemberLevel($event->getCircle(), $event->getMember(), $event->getNewLevel());
 	}
 
 	/**

--- a/lib/Service/FederatedEventService.php
+++ b/lib/Service/FederatedEventService.php
@@ -27,6 +27,8 @@ use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\FederatedItems\CircleCreate;
+use OCA\Circles\FederatedItems\CircleEdit;
+use OCA\Circles\FederatedItems\MemberLevel;
 use OCA\Circles\IFederatedItem;
 use OCA\Circles\IFederatedItemAsyncProcess;
 use OCA\Circles\IFederatedItemCircleCheckNotRequired;
@@ -123,15 +125,24 @@ class FederatedEventService extends NCSignature {
 				$federatedItem->manage($event);
 			}
 
-			if (!$this->initBroadcast($event)
-				&& $event->getClass() === CircleCreate::class) {
-				// Circle Creation is done in a different way as there is no Circle nor Members yet to
-				// base the broadcast to other instances, unless in GlobalScale. And the fact that we do
-				// not want to async the process.
-				// The result is that in a single instance setup, the CircleCreatedEvent is not trigger
-				// the usual (async) way.
-				// In case of no instances yet available for that circle, we call the event manually.
-				$this->eventService->circleCreated($event, [$event->getResult()]);
+			if (!$this->initBroadcast($event)) {
+				if ($event->getClass() === CircleCreate::class) {
+					// Circle Creation is done in a different way as there is no Circle nor Members yet to
+					// base the broadcast to other instances, unless in GlobalScale. And the fact that we do
+					// not want to async the process.
+					// The result is that in a single instance setup, the CircleCreatedEvent is not trigger
+					// the usual (async) way.
+					// In case of no instances yet available for that circle, we call the event manually.
+					$this->eventService->circleCreated($event, [$event->getResult()]);
+				} elseif ($event->getClass() === CircleEdit::class) {
+					// Circle Edit is processed synchronously and has no async result callback when
+					// there is no downstream broadcast target. Trigger the final edited event manually.
+					$this->eventService->circleEdited($event, [$event->getResult()]);
+				} elseif ($event->getClass() === MemberLevel::class) {
+					// Member level edits are processed synchronously and have no async result callback
+					// when there is no downstream broadcast target. Trigger the final edited event manually.
+					$this->eventService->memberLevelEdited($event, [$event->getResult()]);
+				}
 			}
 		} else {
 			$this->remoteUpstreamService->confirmEvent($event);

--- a/src/teams/components/TeamHeader.vue
+++ b/src/teams/components/TeamHeader.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import type Circle from '../team-page/models/circle.ts'
 
-import { mdiCogOutline, mdiContentCopy, mdiExitToApp, mdiTrashCanOutline } from '@mdi/js'
+import { mdiCogOutline, mdiContentCopy, mdiExitToApp, mdiLightningBolt, mdiTrashCanOutline } from '@mdi/js'
 import { t } from '@nextcloud/l10n'
 import { computed } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
@@ -24,7 +24,7 @@ const props = defineProps<{
 const store = useTeamsStore()
 const team = computed(() => store.getTeam(props.circle.id))
 
-const { canManage, canLeave, canDelete, onManage, onCopyLink, onLeave, onDelete } = useTeamActions(() => team.value)
+const { canManage, canLeave, canDelete, activityAppEnabled, onManage, onActivity, onCopyLink, onLeave, onDelete } = useTeamActions(() => team.value)
 </script>
 
 <template>
@@ -52,6 +52,13 @@ const { canManage, canLeave, canDelete, onManage, onCopyLink, onLeave, onDelete 
 					<NcIconSvgWrapper :path="mdiCogOutline" :size="20" />
 				</template>
 				{{ t('circles', 'Manage team') }}
+			</NcActionButton>
+
+			<NcActionButton v-if="activityAppEnabled" closeAfterClick @click="onActivity">
+				<template #icon>
+					<NcIconSvgWrapper :path="mdiLightningBolt" :size="20" />
+				</template>
+				{{ t('circles', 'Team activity') }}
 			</NcActionButton>
 
 			<NcActionButton closeAfterClick @click="onCopyLink">

--- a/src/teams/components/TeamNavigationItem.vue
+++ b/src/teams/components/TeamNavigationItem.vue
@@ -6,7 +6,7 @@
 <script setup lang="ts">
 import type { Team } from '../types.ts'
 
-import { mdiCogOutline, mdiContentCopy, mdiExitToApp, mdiTrashCanOutline } from '@mdi/js'
+import { mdiCogOutline, mdiContentCopy, mdiExitToApp, mdiLightningBolt, mdiTrashCanOutline } from '@mdi/js'
 import { t } from '@nextcloud/l10n'
 import { computed } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
@@ -21,7 +21,7 @@ const props = defineProps<{
 
 const to = computed(() => ({ name: 'team', params: { teamId: props.team.id } }))
 
-const { canManage, canLeave, canDelete, onManage, onCopyLink, onLeave, onDelete } = useTeamActions(() => props.team)
+const { canManage, canLeave, canDelete, activityAppEnabled, onManage, onActivity, onCopyLink, onLeave, onDelete } = useTeamActions(() => props.team)
 </script>
 
 <template>
@@ -35,6 +35,13 @@ const { canManage, canLeave, canDelete, onManage, onCopyLink, onLeave, onDelete 
 					<NcIconSvgWrapper :path="mdiCogOutline" :size="20" />
 				</template>
 				{{ t('circles', 'Manage team') }}
+			</NcActionButton>
+
+			<NcActionButton v-if="activityAppEnabled" closeAfterClick @click="onActivity">
+				<template #icon>
+					<NcIconSvgWrapper :path="mdiLightningBolt" :size="20" />
+				</template>
+				{{ t('circles', 'Team activity') }}
 			</NcActionButton>
 
 			<NcActionButton closeAfterClick @click="onCopyLink">

--- a/src/teams/composables/useTeamActions.ts
+++ b/src/teams/composables/useTeamActions.ts
@@ -23,9 +23,12 @@ import { useTeamsStore } from '../store.ts'
 export function useTeamActions(getTeam: () => Team | undefined) {
 	const router = useRouter()
 	const store = useTeamsStore()
+	const appsWebroots = ((window as typeof window & { OC?: { appswebroots?: Record<string, string> } }).OC?.appswebroots) ?? {}
 
 	const to = computed(() => ({ name: 'team', params: { teamId: getTeam()?.id } }))
 	const settingsTo = computed(() => ({ name: 'team-settings', params: { teamId: getTeam()?.id } }))
+	const activityTo = computed(() => ({ name: 'team-activity', params: { teamId: getTeam()?.id } }))
+	const activityAppEnabled = computed(() => appsWebroots.activity !== undefined)
 	const isOwner = computed(() => getTeam()?.myRole === 'owner')
 	const canManage = computed(() => {
 		const team = getTeam()
@@ -37,6 +40,15 @@ export function useTeamActions(getTeam: () => Team | undefined) {
 	/** Open the team's Settings page. */
 	async function onManage(): Promise<void> {
 		await router.push(settingsTo.value)
+	}
+
+	/** Open the team's Activity page. */
+	async function onActivity(): Promise<void> {
+		if (!activityAppEnabled.value) {
+			return
+		}
+
+		await router.push(activityTo.value)
 	}
 
 	/** Copy a direct link to the team. */
@@ -110,11 +122,14 @@ export function useTeamActions(getTeam: () => Team | undefined) {
 	return {
 		to,
 		settingsTo,
+		activityTo,
+		activityAppEnabled,
 		isOwner,
 		canManage,
 		canLeave,
 		canDelete,
 		onManage,
+		onActivity,
 		onCopyLink,
 		onLeave,
 		onDelete,

--- a/src/teams/router.ts
+++ b/src/teams/router.ts
@@ -9,6 +9,7 @@ import { generateUrl } from '@nextcloud/router'
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from './views/HomeView.vue'
 import JoinInvitation from './views/JoinInvitation.vue'
+import TeamActivityView from './views/TeamActivityView.vue'
 import TeamDashboardView from './views/TeamDashboardView.vue'
 import TeamPage from './views/TeamPage.vue'
 import TeamSettingsView from './views/TeamSettingsView.vue'
@@ -40,6 +41,12 @@ const routes: RouteRecordRaw[] = [
 				name: 'team-settings',
 				path: 'settings',
 				component: TeamSettingsView,
+				props: true,
+			},
+			{
+				name: 'team-activity',
+				path: 'activity',
+				component: TeamActivityView,
 				props: true,
 			},
 		],

--- a/src/teams/team-page/components/CircleDetails.vue
+++ b/src/teams/team-page/components/CircleDetails.vue
@@ -1066,6 +1066,9 @@ export default {
 .circle-details-container {
 	padding-inline: 20px;
 	margin-top: 1rem;
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0;
 
 	.circle-details-grid {
 		display: grid;

--- a/src/teams/team-page/models/circle.ts
+++ b/src/teams/team-page/models/circle.ts
@@ -56,6 +56,13 @@ export default class Circle {
 	}
 
 	/**
+	 * Numeric database id for activity object filters.
+	 */
+	get circleId(): number {
+		return this._data.circleId
+	}
+
+	/**
 	 * Formatted display name
 	 */
 	get displayName(): string {

--- a/src/teams/views/TeamActivityView.spec.ts
+++ b/src/teams/views/TeamActivityView.spec.ts
@@ -1,0 +1,189 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type * as NextcloudL10n from '@nextcloud/l10n'
+
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import TeamActivityView from './TeamActivityView.vue'
+
+const {
+	axiosGetMock,
+	generateOcsUrlMock,
+	getCircleMock,
+	loggerErrorMock,
+} = vi.hoisted(() => ({
+	axiosGetMock: vi.fn(),
+	generateOcsUrlMock: vi.fn(),
+	getCircleMock: vi.fn(),
+	loggerErrorMock: vi.fn(),
+}))
+
+vi.mock('@nextcloud/axios', () => ({
+	default: {
+		get: axiosGetMock,
+	},
+}))
+
+vi.mock('@nextcloud/l10n', async (importOriginal) => {
+	const actual = await importOriginal<NextcloudL10n>()
+
+	return {
+		...actual,
+		t: (_app: string, message: string) => message,
+	}
+})
+
+vi.mock('@nextcloud/router', () => ({
+	generateOcsUrl: generateOcsUrlMock,
+}))
+
+vi.mock('vuex', () => ({
+	useStore: () => ({
+		getters: {
+			getCircle: getCircleMock,
+		},
+	}),
+}))
+
+vi.mock('../../logger.ts', () => ({
+	logger: {
+		error: loggerErrorMock,
+	},
+}))
+
+interface Activity {
+	activity_id: number
+	user: string
+	subject: string
+	datetime: string | number | null
+}
+
+function makeActivities(count: number, startAt = 1): Activity[] {
+	return Array.from({ length: count }, (_, index) => ({
+		activity_id: startAt + index,
+		user: `user-${startAt + index}`,
+		subject: `subject-${startAt + index}`,
+		datetime: '2026-01-01T12:00:00.000Z',
+	}))
+}
+
+function mockOcsResponse(activities: Activity[]) {
+	return {
+		data: {
+			ocs: {
+				data: activities,
+			},
+		},
+	}
+}
+
+describe('TeamActivityView', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		generateOcsUrlMock.mockReturnValue('/ocs/activity/filter')
+		getCircleMock.mockReturnValue({
+			circleId: '42',
+		})
+		;(window as typeof window & { OC?: { appswebroots?: Record<string, string> } }).OC = {
+			appswebroots: {
+				activity: '/apps/activity',
+			},
+		}
+	})
+
+	it('renders unavailable state when team cannot be loaded', async () => {
+		getCircleMock.mockReturnValue(null)
+
+		const wrapper = shallowMount(TeamActivityView, {
+			props: { teamId: 'team-1' },
+		})
+
+		await flushPromises()
+
+		const emptyContent = wrapper.get('nc-empty-content-stub')
+		expect(emptyContent.attributes('name')).toBe('Activity unavailable')
+		expect(axiosGetMock).not.toHaveBeenCalled()
+	})
+
+	it('renders empty state when API returns no activities', async () => {
+		axiosGetMock.mockResolvedValueOnce(mockOcsResponse([]))
+
+		const wrapper = shallowMount(TeamActivityView, {
+			props: { teamId: 'team-1' },
+		})
+
+		await flushPromises()
+
+		expect(generateOcsUrlMock).toHaveBeenCalledWith('/apps/activity/api/v2/activity/filter')
+		const emptyContent = wrapper.get('nc-empty-content-stub')
+		expect(emptyContent.attributes('name')).toBe('No activity yet')
+	})
+
+	it('renders activities and unknown time fallback', async () => {
+		axiosGetMock.mockResolvedValueOnce(mockOcsResponse([
+			{
+				activity_id: 1,
+				user: 'alice',
+				subject: 'Alice created the team',
+				datetime: '2026-01-01T12:00:00.000Z',
+			},
+			{
+				activity_id: 2,
+				user: 'bob',
+				subject: 'Bob joined the team',
+				datetime: null,
+			},
+		]))
+
+		const wrapper = shallowMount(TeamActivityView, {
+			props: { teamId: 'team-1' },
+		})
+
+		await flushPromises()
+
+		expect(axiosGetMock).toHaveBeenCalledWith('/ocs/activity/filter', {
+			params: {
+				object_type: 'circles',
+				object_id: '42',
+				limit: 50,
+			},
+		})
+		expect(wrapper.text()).toContain('Alice created the team')
+		expect(wrapper.text()).toContain('Bob joined the team')
+		expect(wrapper.text()).toContain('Unknown time')
+		expect(wrapper.findAll('nc-date-time-stub')).toHaveLength(1)
+	})
+
+	it('loads and appends more activities when clicking load more', async () => {
+		const initialActivities = makeActivities(50, 1)
+		const additionalActivities = makeActivities(2, 51)
+		axiosGetMock
+			.mockResolvedValueOnce(mockOcsResponse(initialActivities))
+			.mockResolvedValueOnce(mockOcsResponse(additionalActivities))
+
+		const wrapper = shallowMount(TeamActivityView, {
+			props: { teamId: 'team-1' },
+		})
+
+		await flushPromises()
+
+		const loadMoreButton = wrapper.find('.team-activity-view__load-more')
+		expect(loadMoreButton.exists()).toBe(true)
+
+		await loadMoreButton.trigger('click')
+		await flushPromises()
+
+		expect(axiosGetMock).toHaveBeenNthCalledWith(2, '/ocs/activity/filter', {
+			params: {
+				object_type: 'circles',
+				object_id: '42',
+				limit: 50,
+				since: 50,
+			},
+		})
+		expect(wrapper.findAll('.activity-item')).toHaveLength(52)
+	})
+})

--- a/src/teams/views/TeamActivityView.vue
+++ b/src/teams/views/TeamActivityView.vue
@@ -1,0 +1,279 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import axios from '@nextcloud/axios'
+import { t } from '@nextcloud/l10n'
+import { generateOcsUrl } from '@nextcloud/router'
+import { computed, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcDateTime from '@nextcloud/vue/components/NcDateTime'
+import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import LightningBoltIcon from 'vue-material-design-icons/LightningBolt.vue'
+import ContentHeading from '../team-page/components/CircleDetails/ContentHeading.vue'
+import { logger } from '../../logger.ts'
+
+interface Activity {
+	activity_id: number
+	user: string
+	subject: string
+	datetime: string | number | null
+}
+
+const props = defineProps<{
+	teamId: string
+}>()
+
+const store = useStore()
+const appsWebroots = ((window as typeof window & { OC?: { appswebroots?: Record<string, string> } }).OC?.appswebroots) ?? {}
+const circle = computed(() => store.getters.getCircle(props.teamId))
+const activityAppEnabled = computed(() => appsWebroots.activity !== undefined)
+
+const activities = ref<Activity[]>([])
+const loading = ref(false)
+const loadingMore = ref(false)
+const hasMore = ref(false)
+const lastActivityId = ref(0)
+
+function toTimestamp(datetime: Activity['datetime']): number | null {
+	if (datetime === null || datetime === '') {
+		return null
+	}
+
+	if (typeof datetime === 'number') {
+		return Number.isFinite(datetime) ? datetime : null
+	}
+
+	const parsed = Date.parse(datetime)
+	return Number.isNaN(parsed) ? null : parsed
+}
+
+function safeTimestamp(datetime: Activity['datetime']): number {
+	return toTimestamp(datetime) ?? Date.now()
+}
+
+async function loadActivities() {
+	if (loading.value || !circle.value) {
+		return
+	}
+
+	loading.value = true
+	try {
+		const url = generateOcsUrl('/apps/activity/api/v2/activity/filter')
+		const response = await axios.get(url, {
+			params: {
+				object_type: 'circles',
+				object_id: circle.value.circleId,
+				limit: 50,
+			},
+		})
+
+		activities.value = response.data.ocs?.data ?? []
+		hasMore.value = activities.value.length >= 50
+
+		if (activities.value.length > 0) {
+			lastActivityId.value = activities.value[activities.value.length - 1]?.activity_id ?? 0
+		}
+	} catch (error) {
+		logger.error('Failed to load activities:', { error })
+		activities.value = []
+	} finally {
+		loading.value = false
+	}
+}
+
+async function loadMoreActivities() {
+	if (loadingMore.value || lastActivityId.value === 0 || !circle.value) {
+		return
+	}
+
+	loadingMore.value = true
+	try {
+		const url = generateOcsUrl('/apps/activity/api/v2/activity/filter')
+		const response = await axios.get(url, {
+			params: {
+				object_type: 'circles',
+				object_id: circle.value.circleId,
+				limit: 50,
+				since: lastActivityId.value,
+			},
+		})
+
+		const newActivities = response.data.ocs?.data ?? []
+		activities.value.push(...newActivities)
+		hasMore.value = newActivities.length > 50
+
+		if (newActivities.length > 0) {
+			lastActivityId.value = newActivities[newActivities.length - 1]?.activity_id ?? lastActivityId.value
+		}
+	} catch (error) {
+		logger.error('Failed to load more activities:', { error })
+	} finally {
+		loadingMore.value = false
+	}
+}
+
+onMounted(() => {
+	loadActivities()
+})
+</script>
+
+<template>
+	<div class="team-activity-view">
+		<template v-if="circle && activityAppEnabled">
+			<div class="team-activity-view__header">
+				<ContentHeading>{{ t('circles', 'Team activity') }}</ContentHeading>
+			</div>
+			<div class="team-activity-view__panel">
+				<NcLoadingIcon v-if="loading" class="team-activity-view__loading" :size="32" />
+				<NcEmptyContent
+					v-else-if="activities.length === 0"
+					:name="t('circles', 'No activity yet')"
+					class="team-activity-view__empty">
+					<template #icon>
+						<LightningBoltIcon :size="32" />
+					</template>
+				</NcEmptyContent>
+				<div v-else class="team-activity-view__list">
+					<div v-for="activity in activities" :key="activity.activity_id" class="activity-item">
+						<NcAvatar
+							:user="activity.user"
+							:displayName="activity.user"
+							:size="32"
+							class="activity-item__avatar" />
+						<div class="activity-item__content">
+							<p class="activity-item__subject">
+								{{ activity.subject }}
+							</p>
+							<NcDateTime
+								v-if="toTimestamp(activity.datetime) !== null"
+								class="activity-item__time"
+								:timestamp="safeTimestamp(activity.datetime)"
+								:ignoreSeconds="true" />
+							<span v-else class="activity-item__time">
+								{{ t('circles', 'Unknown time') }}
+							</span>
+						</div>
+					</div>
+					<NcButton
+						v-if="hasMore"
+						:disabled="loadingMore"
+						variant="tertiary"
+						class="team-activity-view__load-more"
+						@click="loadMoreActivities">
+						<template #icon>
+							<NcLoadingIcon v-if="loadingMore" :size="16" />
+						</template>
+						{{ t('circles', 'Load more') }}
+					</NcButton>
+				</div>
+			</div>
+		</template>
+
+		<NcEmptyContent
+			v-else
+			:name="t('circles', 'Activity unavailable')"
+			:description="t('circles', 'The Activity app is disabled or this team could not be loaded.')" />
+	</div>
+</template>
+
+<style scoped lang="scss">
+.team-activity-view {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	padding: 20px;
+	gap: 12px;
+
+	&__header {
+		display: flex;
+		align-items: center;
+	}
+
+	&__panel {
+		flex: 1 1 auto;
+		min-height: 0;
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		background-color: var(--color-main-background);
+		display: flex;
+		flex-direction: column;
+		overflow-y: auto;
+	}
+
+	&__loading {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		height: 100%;
+	}
+
+	&__empty {
+		flex: 1;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 12px;
+	}
+
+	&__load-more {
+		align-self: center;
+		margin-top: 12px;
+	}
+
+	:deep(.empty-content) {
+		flex: 1 1 auto;
+	}
+}
+
+.activity-item {
+	display: flex;
+	gap: 8px;
+	padding: 8px;
+	border-radius: 4px;
+	transition: background-color 0.2s;
+
+	&:hover {
+		background-color: var(--color-background-hover);
+	}
+
+	&__avatar {
+		flex-shrink: 0;
+	}
+
+	&__content {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+
+	&__subject {
+		margin: 0;
+		padding: 0;
+		font-size: 14px;
+		color: var(--color-text);
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+	}
+
+	&__time {
+		margin: 2px 0 0 0;
+		padding: 0;
+		font-size: 12px;
+		color: var(--color-text-lighter);
+	}
+}
+</style>


### PR DESCRIPTION
Co-authored-by :GitHub Copilot (Claude Sonnet 4.6) <copilot@github.com>

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #2692 

## Summary
- Fixes the creation of team events: Adding, editing and deleting a team, adding or removing a member and editing the member level adds an activity entry.
- The activities for a team are shown inside the teams app

Before: 
<img width="1124" height="395" alt="image" src="https://github.com/user-attachments/assets/2b5e073c-d40a-43c0-96ef-e36c82258886" />

After:

New Action
<img width="1131" height="396" alt="image" src="https://github.com/user-attachments/assets/d4abf99b-19e5-4d7a-b5e4-5a8bef5ed984" />
New view opened after clicking on the new "Team activity" action
<img width="1117" height="564" alt="image" src="https://github.com/user-attachments/assets/6c6ce328-7f2d-4424-b236-bcab50c2368f" />


## TODO

- [ ] Show activities for team owned resources

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
