### PR TITLE
fix(federated-event-service): broadcast CircleDestroy event before executing it's manage() method

### DIFF
--- a/lib/Service/FederatedEventService.php
+++ b/lib/Service/FederatedEventService.php
@@ -27,6 +27,7 @@ use OCA\Circles\Exceptions\RemoteResourceNotFoundException;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\Exceptions\UnknownRemoteException;
 use OCA\Circles\FederatedItems\CircleCreate;
+use OCA\Circles\FederatedItems\CircleDestroy;
 use OCA\Circles\IFederatedItem;
 use OCA\Circles\IFederatedItemAsyncProcess;
 use OCA\Circles\IFederatedItemCircleCheckNotRequired;
@@ -119,12 +120,23 @@ class FederatedEventService extends NCSignature {
 				return $event->getOutcome();
 			}
 
+			$broadcasted = false;
 			if (OC::$CLI || !$event->isAsync()) {
+				// CircleDestroy needs to be broadcast before manage() runs.
+				// initBroadcast() > getInstances() > RemoteRequest::getOutgoingRecipient()
+				// finds remote instances via the circle's members, and if manage() already
+				// deleted them, no instance is found, thus the event is not broadcast.
+				if ($event->getClass() === CircleDestroy::class) {
+					$broadcasted = $this->initBroadcast($event);
+				}
 				$federatedItem->manage($event);
 			}
 
-			if (!$this->initBroadcast($event)
-				&& $event->getClass() === CircleCreate::class) {
+			if (!$broadcasted) {
+				$broadcasted = $this->initBroadcast($event);
+			}
+
+			if (!$broadcasted && $event->getClass() === CircleCreate::class) {
 				// Circle Creation is done in a different way as there is no Circle nor Members yet to
 				// base the broadcast to other instances, unless in GlobalScale. And the fact that we do
 				// not want to async the process.


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/circles/issues/2752

## Summary

Running `occ circles:manage:destroy <circle-single-id>` in a federated environment only removed the circle locally, and never propagated the removal to remote instances that had members in that circle.

### Root cause

`CircleDestroy::manage()` deletes all of a circle's members at once. When the `CircleDestroy` event is triggered via CLI (`occ circles:manage:destroy <circle-single-id>`), `FederatedEventService::newEvent()` calls `manage()` before resolving the broadcast (`initBroadcast()`).

When attempting to broadcast:

```php
FederatedEventService::initBroadcast() > FederatedEventService::getInstances() > RemoteRequest::getOutgoingRecipient()
```

`getOutgoingRecipient()` finds remote instances by checking the circle's members. Since those members were already deleted, no instance is found, and the event is silently never broadcast.

`MemberRemove` is not affected: `getInstances()` falls back to `$event->getMember()`'s own instance, captured before `manage()` runs, so it does not depend on the member row still existing in the database.

### Fix

For the `CircleDestroy` event specifically, the broadcast is now resolved before `manage()` runs, so remote instances are resolved correctly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
