### PR TITLE
feat: store SCIM group id on circle settings; use existing notes methods for OIDC's managed_by

### DIFF
--- a/lib/Model/Circle.php
+++ b/lib/Model/Circle.php
@@ -93,6 +93,9 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	public const CFG_SCIM = 262144;                   // Circle is managed by a SCIM server, not manually
 	public static $DEF_CFG_MAX = 524287;
 
+	// settings array keys
+	public const SETTING_EXTERNAL_ID = 'external_id';
+
 	/**
 	 * Note: When editing those values, update lib/Application/Capabilities.php
 	 *

--- a/lib/Model/Member.php
+++ b/lib/Model/Member.php
@@ -61,6 +61,9 @@ class Member extends ManagedModel implements
 	public const APP_OCC = 10002;
 	public const APP_DEFAULT = 11000;
 
+	// notes array keys
+	public const NOTE_MANAGED_BY = 'managed_by';
+
 	public static $TYPE = [
 		0 => 'single',
 		1 => 'user',
@@ -674,15 +677,6 @@ class Member extends ManagedModel implements
 		}
 
 		return $this->memberships;
-	}
-
-	public function setManagedBy(string $managedBy): self {
-		$this->setNote('managedBy', $managedBy);
-		return $this;
-	}
-
-	public function getManagedBy(): string {
-		return $this->getNote('managedBy');
 	}
 
 	/**

--- a/lib/Service/OidcService.php
+++ b/lib/Service/OidcService.php
@@ -84,7 +84,7 @@ class OidcService {
 
 		// remove user from circles they were added to via OIDC but no longer belong to
 		foreach ($this->memberRequest->getMembersByUserId($userId) as $member) {
-			if ($member->getManagedBy() !== self::MANAGED_BY_OIDC) {
+			if ($member->getNote(Member::NOTE_MANAGED_BY) !== self::MANAGED_BY_OIDC) {
 				continue;
 			}
 			if (in_array($member->getCircleId(), $desiredCircleIds, true)) {
@@ -117,7 +117,7 @@ class OidcService {
 
 			// mark this membership as managed by OIDC
 			$member = $this->memberRequest->getMemberByUserId($circleId, $userId);
-			$member->setManagedBy(self::MANAGED_BY_OIDC);
+			$member->setNote(Member::NOTE_MANAGED_BY, self::MANAGED_BY_OIDC);
 			$this->memberRequest->update($member);
 		} catch (Exception $e) {
 			$this->logger->error('could not add user to circle', ['userId' => $userId, 'circleId' => $circleId, 'exception' => $e]);

--- a/lib/Service/ScimService.php
+++ b/lib/Service/ScimService.php
@@ -61,7 +61,7 @@ class ScimService {
 			} catch (CircleNotFoundException) {
 			}
 			try {
-				$this->createCircle($circleId, $circle['displayName']);
+				$this->createCircle($circleId, $circle['displayName'], $circle['id']);
 				$this->logger->debug('circle created from SCIM group', ['scimGroupId' => $circle['id'], 'circleId' => $circleId, 'displayName' => $circle['displayName']]);
 			} catch (Exception $e) {
 				$this->logger->error('could not create circle from SCIM group', ['scimGroupId' => $circle['id'], 'exception' => $e]);
@@ -140,7 +140,7 @@ class ScimService {
 	/**
 	 * @throws Exception
 	 */
-	public function createCircle(string $singleId, string $name): void {
+	public function createCircle(string $singleId, string $name, string $externalId): void {
 		$owner = $this->federatedUserService->getCurrentApp();
 
 		$config = Circle::CFG_ROOT + Circle::CFG_FEDERATED + Circle::CFG_SCIM;
@@ -149,7 +149,8 @@ class ScimService {
 		$circle->setName($this->circleService->cleanCircleName($name))
 			->setSingleId($singleId)
 			->setSource(Member::APP_CIRCLES)
-			->setConfig($config);
+			->setConfig($config)
+			->setSettings([Circle::SETTING_EXTERNAL_ID => $externalId]);
 
 		$this->circleService->confirmName($circle);
 		$this->permissionService->confirmAllowedCircleTypes($circle);


### PR DESCRIPTION
* Related to: https://github.com/nextcloud/circles/pull/2674

## Summary

This PR is a follow-up of #2674 and addresses one of the items left in its TODO:

> Store the SCIM group ID on the circle, to know which SCIM group a given circle represents.

What this PR does:

- stores the SCIM group id on the circle's `settings`, so a circle can be traced back to the SCIM group it represents.

Note: also decided to revert the `Member::setManagedBy()`/`getManagedBy()` wrapper methods introduced in #2674. They only had a single caller and just forwarded to `setNote()`/`getNote()`, so seemed a bit unnecessary to me. Adjusted so `OidcService` now uses `setNote()`/`getNote()` directly, following the same pattern used for circle settings on this PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
