### PR TITLE
feat(teams): declare ITeamFileResourceProvider on the files provider

### DIFF
--- a/lib/FileSharingTeamResourceProvider.php
+++ b/lib/FileSharingTeamResourceProvider.php
@@ -13,10 +13,10 @@ use OCA\Circles\Model\ShareWrapper;
 use OCA\Circles\Service\ShareWrapperService;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\Teams\ITeamResourceProvider;
+use OCP\Teams\ITeamFileResourceProvider;
 use OCP\Teams\TeamResource;
 
-class FileSharingTeamResourceProvider implements ITeamResourceProvider {
+class FileSharingTeamResourceProvider implements ITeamFileResourceProvider {
 	public function __construct(
 		private readonly IL10N $l10n,
 		private readonly ?CirclesManager $circlesManager,
@@ -93,11 +93,15 @@ class FileSharingTeamResourceProvider implements ITeamResourceProvider {
 	}
 
 	public function getTeamsForResource(string $resourceId): array {
+		return $this->getTeamsForFile((int)$resourceId);
+	}
+
+	public function getTeamsForFile(int $fileId): array {
 		if (!$this->circlesManager) {
 			return [];
 		}
 
-		$shares = $this->shareWrapperService->getSharesByFileId((int)$resourceId);
+		$shares = $this->shareWrapperService->getSharesByFileId($fileId);
 
 		return array_map(fn ($share) => $share->getSharedWith(), $shares);
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/61385

## Summary

`FileSharingTeamResourceProvider::getTeamsForResource()` already casts its argument to a file id, so it qualifies for the new `ITeamFileResourceProvider` from nextcloud/server#6344. Declaring it lets other apps contribute teams for the same file, which is what makes team folders show up in the sidebar.

`getTeamsForResource()` now delegates to `getTeamsForFile()`. No behaviour change on its own.

Depends on nextcloud/server#6344. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
