### PR TITLE
fix: resolve share mount for remote circle members

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -188,7 +188,7 @@ class Application extends App implements IBootstrap {
 
 	public function registerMountProvider(ContainerInterface $container): void {
 		$configService = $container->get(ConfigService::class);
-		if (!$configService->isGSAvailable()) {
+		if (!$configService->isGSAvailable() && !$configService->isFederatedTeamsEnabled()) {
 			return;
 		}
 

--- a/lib/Db/MountPointRequest.php
+++ b/lib/Db/MountPointRequest.php
@@ -49,4 +49,11 @@ class MountPointRequest extends MountPointRequestBuilder {
 			throw new MountNotFoundException('Mount not found');
 		}
 	}
+
+	public function deleteByMountId(string $mountId): void {
+		$qb = $this->getMountPointDeleteSql();
+
+		$qb->limit('mount_id', $mountId);
+		$qb->executeStatement();
+	}
 }

--- a/lib/Db/MountRequest.php
+++ b/lib/Db/MountRequest.php
@@ -12,6 +12,8 @@ namespace OCA\Circles\Db;
 use OCA\Circles\Exceptions\RequestBuilderException;
 use OCA\Circles\IFederatedUser;
 use OCA\Circles\Model\Mount;
+use OCA\Circles\Service\ConfigService;
+use OCA\Circles\Service\TimezoneService;
 use OCA\Circles\Tools\Traits\TStringTools;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
@@ -22,6 +24,14 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
  */
 class MountRequest extends MountRequestBuilder {
 	use TStringTools;
+
+	public function __construct(
+		TimezoneService $timezoneService,
+		ConfigService $configService,
+		private MountPointRequest $mountPointRequest,
+	) {
+		parent::__construct($timezoneService, $configService);
+	}
 
 	/**
 	 * @param Mount $mount
@@ -41,14 +51,40 @@ class MountRequest extends MountRequestBuilder {
 		$qb->executeStatement();
 	}
 
-	/**
-	 * @param string $token
-	 */
 	public function delete(string $token): void {
+		$qb = $this->getMountSelectSql();
+		$qb->limitToToken($token);
+		$mounts = $this->getItemsFromRequest($qb);
+
 		$qb = $this->getMountDeleteSql();
 		$qb->limitToToken($token);
-
 		$qb->executeStatement();
+
+		foreach ($mounts as $mount) {
+			$this->mountPointRequest->deleteByMountId($mount->getMountId());
+		}
+	}
+
+	public function hasMountForCircleId(string $circleId): bool {
+		$qb = $this->getMountSelectSql();
+		$qb->limitToCircleId($circleId);
+		$qb->setMaxResults(1);
+
+		return count($this->getItemsFromRequest($qb)) > 0;
+	}
+
+	public function deleteByCircleId(string $circleId): void {
+		$qb = $this->getMountSelectSql();
+		$qb->limitToCircleId($circleId);
+		$mounts = $this->getItemsFromRequest($qb);
+
+		$qb = $this->getMountDeleteSql();
+		$qb->limitToCircleId($circleId);
+		$qb->executeStatement();
+
+		foreach ($mounts as $mount) {
+			$this->mountPointRequest->deleteByMountId($mount->getMountId());
+		}
 	}
 
 	/**

--- a/lib/Listeners/Files/RemovingMember.php
+++ b/lib/Listeners/Files/RemovingMember.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\Circles\Listeners\Files;
 
+use OCA\Circles\Db\MemberRequest;
+use OCA\Circles\Db\MountRequest;
 use OCA\Circles\Events\RemovingCircleMemberEvent;
 use OCA\Circles\Exceptions\MembershipNotFoundException;
 use OCA\Circles\Model\Member;
@@ -30,6 +32,8 @@ class RemovingMember implements IEventListener {
 		private MemberService $memberService,
 		private ShareTokenService $shareTokenService,
 		private ShareWrapperService $shareWrapperService,
+		private MemberRequest $memberRequest,
+		private MountRequest $mountRequest,
 	) {
 	}
 
@@ -67,7 +71,46 @@ class RemovingMember implements IEventListener {
 
 			if ($member->getUserType() === Member::TYPE_USER) {
 				$this->removingSharesInternalMember($member, $singleIds);
+				$this->removingMountsIfLastLocalMember($member, $singleIds);
 			}
+		}
+	}
+
+	/**
+	 * A circle mount is created on the local instance when a file or folder is
+	 * shared on the remote instance with a circle that lives there but also has
+	 * members on the local instance. This mount is used by every member of the
+	 * local instance who belongs to that remote circle.
+	 *
+	 * Removing a share on a remote circle only propagates to instances that still
+	 * have a member in that circle. Once the last local member leaves, the local
+	 * instance stops receiving that propagation, so we have to remove the mount
+	 * at this point.
+	 *
+	 * We have to iterate through every parent circle this member's circle belongs
+	 * to, checking for circles where this member leaving would be the last local
+	 * member leaving that circle, and thus where the mount must be removed.
+	 *
+	 * @param Member $member the member being removed
+	 * @param string[] $singleIds parent circles this member's circle belongs to
+	 */
+	private function removingMountsIfLastLocalMember(Member $member, array $singleIds): void {
+		if (!$member->isLocal()) {
+			return;
+		}
+
+		foreach ($singleIds as $singleId) {
+			if (!$this->mountRequest->hasMountForCircleId($singleId)) {
+				continue;
+			}
+
+			foreach ($this->memberRequest->getInheritedMembers($singleId) as $remainingMember) {
+				if ($remainingMember->getUserType() === Member::TYPE_USER && $remainingMember->isLocal()) {
+					continue 2;
+				}
+			}
+
+			$this->mountRequest->deleteByCircleId($singleId);
 		}
 	}
 

--- a/lib/Model/Mount.php
+++ b/lib/Model/Mount.php
@@ -14,6 +14,7 @@ use OCA\Circles\Exceptions\CircleNotFoundException;
 use OCA\Circles\Tools\Db\IQueryRow;
 use OCA\Circles\Tools\IDeserializable;
 use OCA\Circles\Tools\Traits\TArrayTools;
+use OCA\Files_Sharing\External\Manager as ExternalShareManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 
@@ -39,6 +40,7 @@ class Mount extends ManagedModel implements IDeserializable, IQueryRow, JsonSeri
 	private string $storage;
 	private ICloudIdManager $cloudIdManager;
 	private IClientService $httpClientService;
+	private ExternalShareManager $externalShareManager;
 	private string $remote = '';
 	private int $remoteShareId = 0;
 
@@ -292,6 +294,16 @@ class Mount extends ManagedModel implements IDeserializable, IQueryRow, JsonSeri
 		return $this->httpClientService;
 	}
 
+	public function setExternalShareManager(ExternalShareManager $externalShareManager): self {
+		$this->externalShareManager = $externalShareManager;
+
+		return $this;
+	}
+
+	public function getExternalShareManager(): ExternalShareManager {
+		return $this->externalShareManager;
+	}
+
 	public function setRemote(string $remote): void {
 		$this->remote = $remote;
 	}
@@ -321,6 +333,7 @@ class Mount extends ManagedModel implements IDeserializable, IQueryRow, JsonSeri
 			'password' => $this->getPassword(),
 			'mountpoint' => $this->getMountPoint(false),
 			'HttpClientService' => $this->getHttpClientService(),
+			'manager' => $this->getExternalShareManager(),
 			'cloudId' => $this->getCloudIdManager()->getCloudId(
 				$member->getUserId(),
 				$member->getRemoteInstance()->getRoot()

--- a/lib/MountManager/CircleMountProvider.php
+++ b/lib/MountManager/CircleMountProvider.php
@@ -25,6 +25,7 @@ use OCA\Circles\Model\Mountpoint;
 use OCA\Circles\Service\ConfigService;
 use OCA\Circles\Service\FederatedUserService;
 use OCA\Circles\Tools\Traits\TArrayTools;
+use OCA\Files_Sharing\External\Manager as ExternalShareManager;
 use OCA\Files_Sharing\External\Storage as ExternalStorage;
 use OCP\DB\Exception;
 use OCP\Federation\ICloudIdManager;
@@ -56,6 +57,7 @@ class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 		private FederatedUserService $federatedUserService,
 		private ConfigService $configService,
 		private LoggerInterface $logger,
+		private ExternalShareManager $externalShareManager,
 	) {
 	}
 
@@ -98,7 +100,8 @@ class CircleMountProvider implements IMountProvider, IPartialMountProvider {
 		}
 
 		$mount->setCloudIdManager($this->cloudIdManager)
-			->setHttpClientService($this->clientService);
+			->setHttpClientService($this->clientService)
+			->setExternalShareManager($this->externalShareManager);
 
 		return new CircleMount(
 			$mount,

--- a/lib/ShareByCircleProvider.php
+++ b/lib/ShareByCircleProvider.php
@@ -870,7 +870,7 @@ class ShareByCircleProvider implements IShareProvider, IPartialShareProvider, IS
 	public function getUsersForShare(IShare $share): iterable {
 		$members = $this->shareWrapperService->getShareById((int)$share->getId())->getCircle()->getInheritedMembers();
 		foreach ($members as $member) {
-			if ($member->getUserType() === Member::TYPE_USER) {
+			if ($member->getUserType() === Member::TYPE_USER && $member->isLocal()) {
 				yield $this->userManager->getExistingUser($member->getUserId());
 			}
 		}

--- a/psalm.xml
+++ b/psalm.xml
@@ -58,6 +58,7 @@
 		<file name="tests/stubs/oca_federatedfilesharing_notifications.php" />
 		<file name="tests/stubs/oca_files_sharing_event_usershareaccessupdatedevent.php" />
 		<file name="tests/stubs/oca_files_sharing_external_storage.php" />
+		<file name="tests/stubs/oca_files_sharing_external_manager.php" />
 		<file name="tests/stubs/oca_user_ldap_mapping_abstractmapping.php" />
 		<file name="tests/stubs/oca_user_ldap_mapping_usermapping.php" />
 		<file name="tests/stubs/stecman_component_symfony_console_bashcompletion_completion_completionawareinterface.php" />

--- a/tests/stubs/oca_files_sharing_external_manager.php
+++ b/tests/stubs/oca_files_sharing_external_manager.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Files_Sharing\External;
+
+use OC\Files\Filesystem;
+use OCA\FederatedFileSharing\Events\FederatedShareAddedEvent;
+use OCA\Files_Sharing\Helper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\Exception;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudFederationFactory;
+use OCP\Federation\ICloudFederationProviderManager;
+use OCP\Files\Events\InvalidateMountCacheEvent;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\ISetupManager;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IStorageFactory;
+use OCP\Http\Client\IClientService;
+use OCP\ICertificateManager;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Notification\IManager;
+use OCP\OCS\IDiscoveryService;
+use OCP\Share\IShare;
+use OCP\User\Exceptions\UserNotFoundException;
+use Psr\Log\LoggerInterface;
+
+class Manager {
+	public function __construct(private IDBConnection $connection, private \OC\Files\Mount\Manager $mountManager, private IStorageFactory $storageLoader, private IClientService $clientService, private IManager $notificationManager, private IDiscoveryService $discoveryService, private ICloudFederationProviderManager $cloudFederationProviderManager, private ICloudFederationFactory $cloudFederationFactory, private IGroupManager $groupManager, IUserSession $userSession, private IEventDispatcher $eventDispatcher, private LoggerInterface $logger, private IRootFolder $rootFolder, private ISetupManager $setupManager, private ICertificateManager $certificateManager, private ExternalShareMapper $externalShareMapper, private IConfig $config)
+    {
+    }
+
+	/**
+	 * Add new server-to-server share.
+	 *
+	 * @throws Exception
+	 * @throws NotPermittedException
+	 * @throws UserNotFoundException
+	 */
+	public function addShare(ExternalShare $externalShare, IUser|IGroup|null $shareWith = null): ?Mount
+    {
+    }
+
+	public function getShare(string $id, ?IUser $user = null): ExternalShare|false
+    {
+    }
+
+	public function getShareByToken(string $token): ExternalShare|false
+    {
+    }
+
+	/**
+	 * Accept server-to-server share.
+	 *
+	 * @return bool True if the share could be accepted, false otherwise
+	 */
+	public function acceptShare(ExternalShare $externalShare, ?IUser $user = null): bool
+    {
+    }
+
+	/**
+	 * Decline server-to-server share
+	 *
+	 * @return bool True if the share could be declined, false otherwise
+	 */
+	public function declineShare(ExternalShare $externalShare, ?Iuser $user = null): bool
+    {
+    }
+
+	public function processNotification(ExternalShare $remoteShare, ?IUser $user = null): void
+    {
+    }
+
+	/**
+	 * Try to send accept message to ocm end-point
+	 *
+	 * @param 'accept'|'decline' $feedback
+	 * @return array|false
+	 */
+	protected function tryOCMEndPoint(ExternalShare $externalShare, string $feedback)
+    {
+    }
+
+	/**
+	 * remove '/user/files' from the path and trailing slashes
+	 */
+	protected function stripPath(string $path): string
+    {
+    }
+
+	public function getMount(array $data, ?IUser $user = null): Mount
+    {
+    }
+
+	protected function mountShare(array $data, ?IUser $user = null): Mount
+    {
+    }
+
+	public function getMountManager(): \OC\Files\Mount\Manager
+    {
+    }
+
+	public function setMountPoint(string $source, string $target): bool
+    {
+    }
+
+	public function removeShare(string $mountPoint): bool
+    {
+    }
+
+	/**
+	 * Remove re-shares from share table and mapping in the federated_reshares table
+	 */
+	protected function removeReShares(string $mountPointId): void
+    {
+    }
+
+	/**
+	 * Remove all shares for user $uid if the user was deleted.
+	 */
+	public function removeUserShares(IUser $user): bool
+    {
+    }
+
+	public function removeGroupShares(IGroup $group): bool
+    {
+    }
+
+	/**
+	 * Return a list of shares which are not yet accepted by the user.
+	 *
+	 * @return list<ExternalShare> list of open server-to-server shares
+	 */
+	public function getOpenShares(): array
+    {
+    }
+
+	/**
+	 * Return a list of shares which are accepted by the user.
+	 *
+	 * @return list<ExternalShare> list of accepted server-to-server shares
+	 */
+	public function getAcceptedShares(): array
+    {
+    }
+
+	/**
+	 * Update the access token for a share.
+	 *
+	 * @param string $refreshToken The refresh token to identify the share
+	 * @param string $accessToken The new access token to store
+	 */
+	public function updateAccessToken(string $refreshToken, string $accessToken, int $expiresAt): void
+    {
+    }
+}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/circles/issues/2761

## Summary

- `lib/ShareByCircleProvider.php`: sharing a folder with a circle containing a remote member threw `OC\User\NoUserException`, because `getUsersForShare()` treated every `TYPE_USER` member as local and tried resolving a local user folder for someone who isn't local. Added an `isLocal()` check, matching the pattern already used on other methos of file
- `lib/AppInfo/Application.php`: `registerMountProvider()` only registered `CircleMountProvider` for global scale setup, so federated setup never got a mount. Now also registers it for federated setup
- `lib/Model/Mount.php` / `lib/MountManager/CircleMountProvider.php`: after the provider was registered, building the mount threw a TypeError exception:
```
Cannot assign null to property OCA\Files_Sharing\External\Storage::$manager of type OCA\Files_Sharing\External\Manager
```
  - added an `ExternalShareManager` property/getter/setter to `Mount`, included it in `toMount()`, and had `CircleMountProvider` set it
- `lib/Db/MountRequest.php` / `lib/Db/MountPointRequest.php`: re-sharing the same folder repeatedly produced incrementing names (`test`, `test (1)`, `test(2)`, etc). This happened because `MountRequest::delete()` only removed the `oc_circles_mount` entry and left the related `oc_circles_mountpoint` entries there (orpahned). Added mechanism to also remove related mountpoint entries when deleting a mount
- `lib/RemovingMember.php`: a circle mount is created on the local instance when a file or folder is shared on a remote circle that also has local members. Share removals only propagate to instances that still have a member in that circle, so once the last local member leaves, the local instance stops receiving that propagation, meaning the mount would never be removed when the share is later removed on the remote
Added a mechanism that removes a circle's mounts as soon as its last local member is removed.

## TODO
- new members don't get existing circle shares synced in the following scenario:
  - circle already has shares, and a new member from another instance is added
  - the new member is the first member from that instance in the circle
  - the member doesn't get a mount registered, meaning they have no access to the shared folder/file
  - if there's already another member from that remote instance, adding a new member does show the resource correctly for them
  * https://github.com/nextcloud/circles/issues/2829

- deleting a federated circle doesn't clean up `oc_circles_mount` and `oc_circles_mountpoint` entries on remote instances that had members there. Those members can no longer access the resource though, it's just the tables that never get cleaned up for that circle's shares
  * https://github.com/nextcloud/circles/issues/2830

- adding a remote circle as a member of a federated circle doesn't make the shared file/folder appear for members who inherit membership from remote circle. Entries are still generated in `oc_circles_mount` and `oc_circles_mountpoint`, but for now seems like only direct remote members can actually access the shared resource
  * https://github.com/nextcloud/circles/issues/2831

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
