### PR TITLE
fix: ignore playwright dev files in release archive

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -18,6 +18,7 @@
 /package.json
 /package-lock.json
 /phpDocumentor.sh
+/playwright
 /psalm.xml
 /README.md
 /rector.php


### PR DESCRIPTION
Update of the nextcloudignore to avoid shipping dev files

I see this is a new file here.
In the long run, the release script won't clean anything for you. It will assume Dev's maintenance of the Nextcloudignore file accordingly.

If there are other files you think should be excluded, please adjust this pr.

Thanks 😊