### PR TITLE
bugfix: enhance team folder management with group permissions and res…

### DIFF
--- a/lib/Controller/TeamFolderController.php
+++ b/lib/Controller/TeamFolderController.php
@@ -20,6 +20,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -35,6 +36,7 @@ class TeamFolderController extends OCSController {
 		private readonly TeamFolderPolicy $policy,
 		private readonly CircleRequest $circleRequest,
 		private readonly PermissionService $permissionService,
+		private readonly IGroupManager $groupManager,
 		private readonly IUserSession $userSession,
 	) {
 		parent::__construct($appName, $request);
@@ -53,12 +55,13 @@ class TeamFolderController extends OCSController {
 
 	#[NoAdminRequired]
 	public function upgradeTeamFolder(string $circleId, string $name = ''): DataResponse {
-		if (!$this->policy->isTeamFolderProvisioningEnabled()) {
+		$circle = $this->getCircle($circleId);
+		$user = $this->getAuthenticatedUser();
+		$this->assertAuthenticatedUserIsTeamOwnerOrServerAdmin($circleId, $user);
+
+		if (!$this->policy->isTeamFolderProvisioningEnabled() && !$this->groupManager->isAdmin($user->getUID())) {
 			throw new OCSException('Team space provisioning is disabled', Http::STATUS_FORBIDDEN);
 		}
-
-		$circle = $this->getCircle($circleId);
-		$this->assertAuthenticatedUserIsTeamOwnerOrServerAdmin($circleId);
 
 		if (!$this->policy->isEligibleCircle($circle)) {
 			throw new OCSException('This team cannot have a team space', Http::STATUS_FORBIDDEN);
@@ -81,20 +84,25 @@ class TeamFolderController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	public function getLinkableTeamFolders(string $circleId): array {
+	public function getLinkableTeamFolders(string $circleId): DataResponse {
 		$this->assertAuthenticatedUserIsTeamOwnerOrServerAdmin($circleId);
 
-		return array_map(
+		return new DataResponse(array_map(
 			static fn (\OCP\Teams\TeamFolder $folder): array => $folder->jsonSerialize(),
 			$this->getProvider()->getLinkableTeamFolders($circleId),
-		);
+		));
 	}
 
 	#[NoAdminRequired]
-	public function linkTeamFolder(string $circleId, int $folderId): TeamFolder {
+	public function linkTeamFolder(string $circleId, int $folderId): DataResponse {
 		$this->assertAuthenticatedUserIsTeamOwnerOrServerAdmin($circleId);
 		$folder = $this->getProvider()->linkTeamFolder($circleId, $folderId);
-		return $folder;
+
+		return new DataResponse([
+			'success' => true,
+			'folderId' => $folder->getId(),
+			'folder' => $folder->jsonSerialize(),
+		]);
 	}
 
 	#[NoAdminRequired]
@@ -154,9 +162,9 @@ class TeamFolderController extends OCSController {
 		}
 	}
 
-	private function assertAuthenticatedUserIsTeamOwnerOrServerAdmin(string $circleId): void {
+	private function assertAuthenticatedUserIsTeamOwnerOrServerAdmin(string $circleId, ?IUser $user = null): void {
 		try {
-			$this->permissionService->userMustBeTeamOwnerOrServerAdmin($this->getAuthenticatedUser()->getUID(), $circleId);
+			$this->permissionService->userMustBeTeamOwnerOrServerAdmin(($user ?? $this->getAuthenticatedUser())->getUID(), $circleId);
 		} catch (InsufficientPermissionException $e) {
 			throw new OCSException($e->getMessage(), Http::STATUS_FORBIDDEN);
 		}

--- a/tests/unit/lib/Controller/TeamFolderControllerTest.php
+++ b/tests/unit/lib/Controller/TeamFolderControllerTest.php
@@ -13,10 +13,13 @@ use OCA\Circles\Model\Circle;
 use OCA\Circles\Service\PermissionService;
 use OCA\Circles\Service\TeamFolderPolicy;
 use OCP\AppFramework\OCS\OCSException;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Teams\ITeamManager;
+use OCP\Teams\ITeamFolderProvider;
+use OCP\Teams\TeamFolder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -26,6 +29,7 @@ class TeamFolderControllerTest extends TestCase {
 	private ITeamManager&MockObject $teamManager;
 	private CircleRequest&MockObject $circleRequest;
 	private PermissionService&MockObject $permissionService;
+	private IGroupManager&MockObject $groupManager;
 	private IUserSession&MockObject $userSession;
 
 	protected function setUp(): void {
@@ -35,6 +39,7 @@ class TeamFolderControllerTest extends TestCase {
 		$this->teamManager = $this->createMock(ITeamManager::class);
 		$this->circleRequest = $this->createMock(CircleRequest::class);
 		$this->permissionService = $this->createMock(PermissionService::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 
 		$this->controller = new TeamFolderController(
@@ -44,17 +49,87 @@ class TeamFolderControllerTest extends TestCase {
 			$this->policy,
 			$this->circleRequest,
 			$this->permissionService,
+			$this->groupManager,
 			$this->userSession,
 		);
 	}
 
 	public function testUpgradeTeamFolderForbiddenWhenProvisioningDisabled(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('owner');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->circleRequest->method('getCircle')->with('team1')->willReturn($this->createMock(Circle::class));
 		$this->policy->method('isTeamFolderProvisioningEnabled')->willReturn(false);
+		$this->groupManager->method('isAdmin')->with('owner')->willReturn(false);
 
 		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Team space provisioning is disabled');
 
 		$this->controller->upgradeTeamFolder('team1');
+	}
+
+	public function testUpgradeTeamFolderAllowedForServerAdminWhenProvisioningDisabled(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$circle = $this->createMock(Circle::class);
+		$circle->method('getSingleId')->willReturn('team1');
+		$circle->method('getDisplayName')->willReturn('Team One');
+		$this->circleRequest->method('getCircle')->with('team1')->willReturn($circle);
+
+		$folder = $this->createMock(TeamFolder::class);
+		$folder->method('getId')->willReturn(42);
+		$folder->method('jsonSerialize')->willReturn(['id' => 42, 'mountPoint' => 'Team One']);
+		$provider = $this->createMock(ITeamFolderProvider::class);
+		$provider->expects($this->once())->method('createTeamFolder')->willReturn($folder);
+		$this->teamManager->method('getTeamFolderProvider')->willReturn($provider);
+
+		$this->policy->method('isTeamFolderProvisioningEnabled')->willReturn(false);
+		$this->policy->method('isEligibleCircle')->with($circle)->willReturn(true);
+		$this->policy->method('getDefaultQuota')->willReturn(0);
+		$this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
+
+		$response = $this->controller->upgradeTeamFolder('team1');
+
+		$this->assertSame(42, $response->getData()['folderId']);
+	}
+
+	public function testGetLinkableTeamFoldersReturnsDataResponse(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$provider = $this->createMock(ITeamFolderProvider::class);
+		$provider->method('getLinkableTeamFolders')->with('team1')->willReturn([
+			new TeamFolder(56, 'teamfolderda?'),
+		]);
+		$this->teamManager->method('getTeamFolderProvider')->willReturn($provider);
+
+		$response = $this->controller->getLinkableTeamFolders('team1');
+
+		$this->assertSame([
+			['id' => 56, 'quota' => null, 'mountPoint' => 'teamfolderda?'],
+		], $response->getData());
+	}
+
+	public function testLinkTeamFolderReturnsDataResponse(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('admin');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$folder = new TeamFolder(56, 'teamfolderda?');
+		$provider = $this->createMock(ITeamFolderProvider::class);
+		$provider->method('linkTeamFolder')->with('team1', 56)->willReturn($folder);
+		$this->teamManager->method('getTeamFolderProvider')->willReturn($provider);
+
+		$response = $this->controller->linkTeamFolder('team1', 56);
+
+		$this->assertSame([
+			'success' => true,
+			'folderId' => 56,
+			'folder' => ['id' => 56, 'quota' => null, 'mountPoint' => 'teamfolderda?'],
+		], $response->getData());
 	}
 
 	public function testUpgradeTeamFolderForbiddenForIneligibleCircle(): void {


### PR DESCRIPTION
…ponse handling



<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Fix adding team folders in the Teams settings view by returning linkable folders through a proper OCS response and allowing admins to manually create team folders when auto-provisioning is disabled.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
